### PR TITLE
ImGui frame profiler overlay, and Vulkan per-draw descriptor set churn fix

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -77,6 +77,7 @@ TARGET_LINK_LIBRARIES(code PUBLIC jansson)
 target_link_libraries(code PUBLIC anl)
 
 target_link_libraries(code PUBLIC imgui)
+target_link_libraries(code PUBLIC implot)
 
 IF(FSO_BUILD_WITH_OPENXR)
 	target_link_libraries(code PUBLIC OpenXR::openxr_loader)

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -2339,10 +2339,9 @@ bool SetCmdlineParams()
 	if (gr_sync_validation_arg.found()) {
 		// Enables the Vulkan validation layer + debug messenger + synchronization
 		// validation feature (see VulkanRenderer::initializeInstance), but NOT the
-		// engine-level graphics debug output: -gr_debug additionally draws debug
-		// overlays (e.g. output_uniform_debug_data), which are unrelated to GPU
-		// sync validation and would otherwise appear as spurious on-screen
-		// artifacts. Keep this a pure GPU-validation switch.
+		// engine-level graphics debug output: -gr_debug additionally feeds extra
+		// stat groups into the ImGui frame profiler overlay (see gr_get_debug_stats),
+		// which are unrelated to GPU sync validation. Keep this a pure GPU-validation switch.
 		Cmdline_gr_sync_validation = true;
 	}
 

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -42,6 +42,7 @@
 #include "render/3d.h"
 #include "scripting/hook_api.h"
 #include "scripting/scripting.h"
+#include "tracing/ProfilerOverlay.h"
 #include "tracing/tracing.h"
 #include "utils/boost/hash_combine.h"
 #include "utils/string_utils.h"
@@ -3189,8 +3190,19 @@ gr_debug_stats gr_get_debug_stats()
 	return stats;
 }
 
+static bool Imgui_frame_active = false;
+
 void gr_imgui_begin_frame()
 {
+	if (Imgui_frame_active) {
+		return;
+	}
+
+	// The stub renderer (standalone server) never assigns the ImGui entry points.
+	if (!gr_screen.gf_imgui_new_frame || !ImGui::GetCurrentContext()) {
+		return;
+	}
+
 	gr_imgui_new_frame();      // renderer backend (OpenGL/Vulkan)
 	ImGui_ImplSDL3_NewFrame(); // platform backend, derives the display size from the SDL window
 
@@ -3208,6 +3220,23 @@ void gr_imgui_begin_frame()
 	}
 
 	ImGui::NewFrame();
+	Imgui_frame_active = true;
+}
+
+void gr_imgui_end_frame()
+{
+	if (!Imgui_frame_active) {
+		return;
+	}
+
+	ImGui::Render();
+	gr_imgui_render_draw_data();
+	Imgui_frame_active = false;
+}
+
+bool gr_imgui_frame_active()
+{
+	return Imgui_frame_active;
 }
 
 void gr_flip(bool execute_scripting)
@@ -3227,6 +3256,14 @@ void gr_flip(bool execute_scripting)
 	}
 
 	model_process_cached_ui_render_instances();
+
+	// Every presented frame drains the frame profiler and contributes the overlay window to
+	// this frame's ImGui pass. Doing it here rather than per game state is what keeps the
+	// profiler's event buffer bounded: collection is global, so the drain has to be too.
+	tracing::profiler_overlay_frame();
+
+	// Closes whatever ImGui frame the overlay (or the lab, or the options screen) opened.
+	gr_imgui_end_frame();
 
 	// IMPORTANT: No rendering may happen after this point until gf_flip()/gr_setup_frame().
 	// gr_reset_immediate_buffer() resets the write offset to 0, so any subsequent immediate

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -3170,20 +3170,23 @@ void gr_set_bitmap(int bitmap_num, int alphablend_mode, int bitblt_mode, float a
 	gr_screen.current_bitmap          = bitmap_num;
 }
 
-static void output_uniform_debug_data()
+gr_debug_stats gr_get_debug_stats()
 {
-	if (gr_screen.mode == GraphicsAPI::Stub) {
-		return;
+	gr_debug_stats stats;
+
+	if (!Cmdline_graphics_debug_output) {
+		return stats;
 	}
 
-	int line_height = gr_get_font_height() + 1;
+	if (UniformBufferManager) {
+		stats.uniform_buffer_valid = true;
+		stats.uniform_buffer_size = UniformBufferManager->getBufferSize();
+		stats.uniform_buffer_used = UniformBufferManager->getCurrentlyUsedSize();
+	}
 
-	gr_set_color_fast(&Color_bright_white);
+	gr_screen.gf_get_debug_stats(stats);
 
-	gr_printf_no_resize(gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 160,
-	                    "Uniform buffer size: " SIZE_T_ARG, UniformBufferManager->getBufferSize());
-	gr_printf_no_resize(gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 160 + line_height,
-	                    "Currently used data: " SIZE_T_ARG, UniformBufferManager->getCurrentlyUsedSize());
+	return stats;
 }
 
 void gr_imgui_begin_frame()
@@ -3224,10 +3227,6 @@ void gr_flip(bool execute_scripting)
 	}
 
 	model_process_cached_ui_render_instances();
-
-	if (Cmdline_graphics_debug_output) {
-		output_uniform_debug_data();
-	}
 
 	// IMPORTANT: No rendering may happen after this point until gf_flip()/gr_setup_frame().
 	// gr_reset_immediate_buffer() resets the write offset to 0, so any subsequent immediate

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -22,6 +22,7 @@
 #include "material.h"
 #include "matrix.h"
 
+#include "bmpman/bmpman.h"
 #include "cmdline/cmdline.h"
 #include "debugconsole/console.h"
 #include "executor/global_executors.h"
@@ -3530,6 +3531,30 @@ void gr_heap_deallocate(GpuHeap heap_type, size_t data_offset)
 	auto gpuHeap = get_gpu_heap(heap_type);
 
 	gpuHeap->freeGpuData(data_offset);
+}
+
+gr_memory_stats gr_get_memory_stats()
+{
+	gr_memory_stats stats;
+
+	// gpu_heaps[] entries stay null when gpu_heap_init() early-returned (GraphicsAPI::Stub, e.g.
+	// a build with both graphics backends disabled), so this must not assume a live heap.
+	auto vertex_heap = get_gpu_heap(GpuHeap::ModelVertex);
+	auto index_heap = get_gpu_heap(GpuHeap::ModelIndex);
+	if (vertex_heap != nullptr && index_heap != nullptr) {
+		stats.model_heap_valid = true;
+		stats.model_vertex_heap_used = vertex_heap->usedBytes();
+		stats.model_vertex_heap_size = vertex_heap->bufferSize();
+		stats.model_index_heap_used = index_heap->usedBytes();
+		stats.model_index_heap_size = index_heap->bufferSize();
+	}
+
+	stats.locked_bitmap_ram_valid = true;
+	stats.locked_bitmap_ram_bytes = bm_texture_ram;
+
+	gr_screen.gf_get_memory_stats(stats);
+
+	return stats;
 }
 
 void gr_set_gamma(float gamma)

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1348,6 +1348,16 @@ inline void gr_post_process_restore_zbuffer()
  */
 void gr_imgui_begin_frame();
 
+/**
+ * @brief Renders and submits the open ImGui frame, if any. Called by gr_flip().
+ */
+void gr_imgui_end_frame();
+
+/**
+ * @brief Whether an ImGui frame is currently open for contributions
+ */
+bool gr_imgui_frame_active();
+
 inline void gr_render_primitives(material* material_info,
 	primitive_type prim_type,
 	vertex_layout* layout,

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -716,6 +716,30 @@ struct gr_debug_stats {
 	int on_demand_texture_uploads = 0;
 };
 
+/**
+ * @brief Cross-backend memory usage snapshot for the profiler overlay's memory panel
+ *
+ * Unlike gr_debug_stats, this is always populated when queried (no -gr_debug gate) -- memory
+ * usage is meant to be visible to anyone with the profiler overlay open. Each group still carries
+ * its own "valid" flag since not every backend/build collects every group (e.g. both graphics
+ * backends disabled at build time). See gr_get_memory_stats().
+ */
+struct gr_memory_stats {
+	bool model_heap_valid = false;
+	size_t model_vertex_heap_used = 0;
+	size_t model_vertex_heap_size = 0;
+	size_t model_index_heap_used = 0;
+	size_t model_index_heap_size = 0;
+
+	bool locked_bitmap_ram_valid = false;
+	size_t locked_bitmap_ram_bytes = 0;
+
+	bool gpu_purpose_valid = false;
+	size_t gpu_texture_bytes = 0;
+	size_t gpu_geometry_bytes = 0;
+	size_t gpu_render_target_bytes = 0;
+};
+
 typedef struct screen {
 	int max_w = 0, max_h = 0; // Width and height
 	int max_w_unscaled = 0, max_h_unscaled = 0;
@@ -993,6 +1017,10 @@ typedef struct screen {
 	// so backends without per-draw-call counters (OpenGL, stub) don't have to assign it.
 	std::function<void(gr_debug_stats& stats)> gf_get_debug_stats = [](gr_debug_stats&) {};
 
+	// Fills in whichever memory_stats groups this backend collects (GPU-purpose byte totals).
+	// Defaults to a no-op so backends without per-purpose tagging don't have to assign it.
+	std::function<void(gr_memory_stats& stats)> gf_get_memory_stats = [](gr_memory_stats&) {};
+
 	std::function<int()> gf_create_query_object;
 	std::function<void(int obj, QueryType type)> gf_query_value;
 	std::function<bool(int obj)> gf_query_value_available;
@@ -1190,6 +1218,15 @@ void gr_flip(bool execute_scripting = true);
  * to call every frame regardless of backend or debug flag.
  */
 gr_debug_stats gr_get_debug_stats();
+
+/**
+ * @brief Collects whichever cross-backend memory usage stats are available
+ *
+ * Unlike gr_get_debug_stats(), this is always populated (no -gr_debug gate) -- memory usage is
+ * meant to be visible whenever the profiler overlay is open. Safe to call every frame regardless
+ * of backend or build configuration; groups a backend/build doesn't support stay invalid/zero.
+ */
+gr_memory_stats gr_get_memory_stats();
 
 inline void gr_setup_frame() {
 	gr_screen.gf_setup_frame();

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -690,6 +690,32 @@ enum class BufferUsageHint { Static, Dynamic, Streaming, PersistentMapping };
  */
 typedef void* gr_sync;
 
+/**
+ * @brief Per-backend diagnostic counters, populated only when -gr_debug is active
+ *
+ * Each stat group carries its own "valid" flag since not every backend collects every
+ * group (e.g. per-draw-call counters currently only exist in the Vulkan backend). See
+ * gr_get_debug_stats().
+ */
+struct gr_debug_stats {
+	bool uniform_buffer_valid = false;
+	size_t uniform_buffer_size = 0;
+	size_t uniform_buffer_used = 0;
+
+	bool draw_stats_valid = false;
+	int draw_calls = 0;
+	int draw_indexed_calls = 0;
+	int total_vertices = 0;
+	int total_indices = 0;
+	int apply_material_calls = 0;
+	int apply_material_failures = 0;
+	int no_pipeline_skips = 0;
+	int descriptor_sets_allocated = 0;
+	int descriptor_writes = 0;
+	size_t pipeline_count = 0;
+	int on_demand_texture_uploads = 0;
+};
+
 typedef struct screen {
 	int max_w = 0, max_h = 0; // Width and height
 	int max_w_unscaled = 0, max_h_unscaled = 0;
@@ -963,6 +989,10 @@ typedef struct screen {
 	std::function<void(const char* name)> gf_push_debug_group;
 	std::function<void()> gf_pop_debug_group;
 
+	// Fills in whichever debug_stats groups this backend collects. Defaults to a no-op
+	// so backends without per-draw-call counters (OpenGL, stub) don't have to assign it.
+	std::function<void(gr_debug_stats& stats)> gf_get_debug_stats = [](gr_debug_stats&) {};
+
 	std::function<int()> gf_create_query_object;
 	std::function<void(int obj, QueryType type)> gf_query_value;
 	std::function<bool(int obj)> gf_query_value_available;
@@ -1152,6 +1182,14 @@ bool gr_is_screenshot_requested();
 
 //#define gr_flip				GR_CALL(gr_screen.gf_flip)
 void gr_flip(bool execute_scripting = true);
+
+/**
+ * @brief Collects whichever graphics-API debug stats are available for the active backend
+ *
+ * Returns a default-constructed (all-invalid) gr_debug_stats unless -gr_debug is active. Safe
+ * to call every frame regardless of backend or debug flag.
+ */
+gr_debug_stats gr_get_debug_stats();
 
 inline void gr_setup_frame() {
 	gr_screen.gf_setup_frame();

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1164,6 +1164,7 @@ void gr_opengl_init_function_pointers()
 
 	gr_screen.gf_is_capable = gr_opengl_is_capable;
 	gr_screen.gf_get_property = gr_opengl_get_property;
+	gr_screen.gf_get_memory_stats = gr_opengl_get_memory_stats;
 
 	gr_screen.gf_push_debug_group = gr_opengl_push_debug_group;
 	gr_screen.gf_pop_debug_group = gr_opengl_pop_debug_group;

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -20,6 +20,7 @@
 #include "cmdline/cmdline.h"
 #include "ddsutils/ddsutils.h"
 #include "globalincs/systemvars.h"
+#include "graphics/2d.h"
 #include "graphics/grinternal.h"
 #include "math/vecmat.h"
 #include "options/Option.h"
@@ -1641,6 +1642,7 @@ struct fbo_t {
 	// these first vars should only be modified in opengl_make_render_target()
 	GLuint renderbuffer_id = 0;
 	GLuint framebuffer_id = 0;
+	size_t renderbuffer_bytes = 0; // for the profiler overlay's memory panel; see GL_renderbuffer_bytes_used
 	int width = 0;
 	int height = 0;
 	// these next 2 should only be modifed in opengl_set_render_target()
@@ -1652,6 +1654,12 @@ struct fbo_t {
 static SCP_vector<fbo_t> RenderTarget;
 static fbo_t *render_target = NULL;
 static int next_fbo_id = 0;
+
+// Running total of bytes used by depth/stencil renderbuffers across all live FBOs, for the
+// profiler overlay's memory panel. Kept in sync with each fbo_t's renderbuffer_bytes at every
+// create/delete site below rather than summed on demand, since RenderTarget entries are reused
+// (opengl_get_free_fbo) and reset in place.
+static size_t GL_renderbuffer_bytes_used = 0;
 
 static fbo_t* opengl_get_fbo(int id) {
 	if (id < 0) {
@@ -1768,9 +1776,20 @@ void opengl_kill_render_target(bitmap_slot* slot)
 	if (fbo->renderbuffer_id) {
 		glDeleteRenderbuffers(1, &fbo->renderbuffer_id);
 		fbo->renderbuffer_id = 0;
+		GL_renderbuffer_bytes_used -= fbo->renderbuffer_bytes;
+		fbo->renderbuffer_bytes = 0;
 	}
 
 	opengl_free_fbo_slot(fbo->fbo_id);
+}
+
+void gr_opengl_get_memory_stats(gr_memory_stats& stats)
+{
+	stats.gpu_purpose_valid = true;
+	stats.gpu_render_target_bytes = GL_renderbuffer_bytes_used;
+	// gpu_texture_bytes and gpu_geometry_bytes are left at 0 -- OpenGL has no per-purpose byte
+	// tracking for those yet (geometry bytes come from the backend-agnostic GpuHeap accounting in
+	// gr_get_memory_stats() instead; see model_vertex_heap_used/model_index_heap_used).
 }
 
 void opengl_kill_all_render_targets()
@@ -1786,6 +1805,8 @@ void opengl_kill_all_render_targets()
 		if (fbo->renderbuffer_id) {
 			glDeleteRenderbuffers(1, &fbo->renderbuffer_id);
 			fbo->renderbuffer_id = 0;
+			GL_renderbuffer_bytes_used -= fbo->renderbuffer_bytes;
+			fbo->renderbuffer_bytes = 0;
 		}
 	}
 
@@ -1954,6 +1975,10 @@ int opengl_make_render_target( int handle, int *w, int *h, int *bpp, int *mm_lvl
 		glBindRenderbuffer(GL_RENDERBUFFER, new_fbo->renderbuffer_id);
 		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, *w, *h);
 		glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+		// GL_DEPTH24_STENCIL8 is 4 bytes/pixel
+		new_fbo->renderbuffer_bytes = static_cast<size_t>(*w) * static_cast<size_t>(*h) * 4;
+		GL_renderbuffer_bytes_used += new_fbo->renderbuffer_bytes;
 	}
 
 	// frame buffer
@@ -1987,6 +2012,8 @@ int opengl_make_render_target( int handle, int *w, int *h, int *bpp, int *mm_lvl
 		if (new_fbo->renderbuffer_id) {
 			glDeleteRenderbuffers(1, &new_fbo->renderbuffer_id);
 			new_fbo->renderbuffer_id = 0;
+			GL_renderbuffer_bytes_used -= new_fbo->renderbuffer_bytes;
+			new_fbo->renderbuffer_bytes = 0;
 		}
 
 		opengl_set_texture_target();

--- a/code/graphics/opengl/gropengltexture.h
+++ b/code/graphics/opengl/gropengltexture.h
@@ -81,6 +81,8 @@ void opengl_set_additive_tex_env();
 void opengl_set_modulate_tex_env();
 void opengl_preload_init();
 void opengl_kill_render_target(bitmap_slot* slot);
+struct gr_memory_stats;
+void gr_opengl_get_memory_stats(gr_memory_stats& stats);
 int opengl_make_render_target(int handle, int *w, int *h, int *bpp, int *mm_lvl, int flags);
 int opengl_set_render_target(int slot, int face = -1, int is_static = 0);
 ubyte* gr_opengl_get_bitmap_from_texture(int bitmap_num, int* width_out, int* height_out);

--- a/code/graphics/util/GPUMemoryHeap.cpp
+++ b/code/graphics/util/GPUMemoryHeap.cpp
@@ -70,6 +70,12 @@ void GPUMemoryHeap::freeGpuData(size_t offset) {
 gr_buffer_handle GPUMemoryHeap::bufferHandle() {
 	return _bufferHandle;
 }
+size_t GPUMemoryHeap::usedBytes() const {
+	return _allocator->usedBytes();
+}
+size_t GPUMemoryHeap::bufferSize() const {
+	return _bufferSize;
+}
 
 }
 }

--- a/code/graphics/util/GPUMemoryHeap.h
+++ b/code/graphics/util/GPUMemoryHeap.h
@@ -54,6 +54,18 @@ class GPUMemoryHeap {
 	 * @return The graphics code buffer handle.
 	 */
 	gr_buffer_handle bufferHandle();
+
+	/**
+	 * @brief Gets the number of bytes currently allocated from this heap
+	 * @return The sum of the sizes of all active allocations.
+	 */
+	size_t usedBytes() const;
+
+	/**
+	 * @brief Gets the total size of the backing GPU buffer, including both allocated and free space
+	 * @return The current buffer size.
+	 */
+	size_t bufferSize() const;
 };
 
 }

--- a/code/graphics/vulkan/VulkanBuffer.cpp
+++ b/code/graphics/vulkan/VulkanBuffer.cpp
@@ -339,7 +339,22 @@ vk::BufferUsageFlags VulkanBufferManager::getVkUsageFlags(BufferType type, bool 
 	return flags;
 }
 
-MemoryUsage VulkanBufferManager::getMemoryUsage(BufferUsageHint hint) 
+namespace {
+MemoryPurpose bufferTypeToPurpose(BufferType type)
+{
+	switch (type) {
+	case BufferType::Vertex:
+	case BufferType::Index:
+		return MemoryPurpose::Geometry;
+	case BufferType::Uniform:
+	default:
+		// Uniform buffers are already tracked separately via UniformBufferManager/gr_debug_stats.
+		return MemoryPurpose::Unknown;
+	}
+}
+}
+
+MemoryUsage VulkanBufferManager::getMemoryUsage(BufferUsageHint hint)
 {
 	switch (hint) {
 	case BufferUsageHint::Static:
@@ -455,7 +470,8 @@ bool VulkanBufferManager::createOrResizeBuffer(VulkanBufferObject& bufferObj, si
 
 	// Allocate memory
 	MemoryUsage memUsage = getMemoryUsage(bufferObj.usage);
-	if (!m_memoryManager->allocateBufferMemory(bufferObj.buffer, memUsage, bufferObj.allocation)) {
+	if (!m_memoryManager->allocateBufferMemory(
+			bufferObj.buffer, memUsage, bufferObj.allocation, bufferTypeToPurpose(bufferObj.type))) {
 		m_device.destroyBuffer(bufferObj.buffer);
 		bufferObj.buffer = oldBuffer;
 		bufferObj.allocation = oldAllocation;

--- a/code/graphics/vulkan/VulkanConvert.cpp
+++ b/code/graphics/vulkan/VulkanConvert.cpp
@@ -132,6 +132,20 @@ vk::PrimitiveTopology convertPrimitiveType(primitive_type type)
 	}
 }
 
+bool topologySupportsPrimitiveRestart(vk::PrimitiveTopology topology)
+{
+	switch (topology) {
+	case vk::PrimitiveTopology::eLineStrip:
+	case vk::PrimitiveTopology::eTriangleStrip:
+	case vk::PrimitiveTopology::eTriangleFan:
+	case vk::PrimitiveTopology::eLineStripWithAdjacency:
+	case vk::PrimitiveTopology::eTriangleStripWithAdjacency:
+		return true;
+	default:
+		return false;
+	}
+}
+
 vk::CullModeFlags convertCullMode(bool cullEnabled)
 {
 	return cullEnabled ? vk::CullModeFlagBits::eBack : vk::CullModeFlagBits::eNone;

--- a/code/graphics/vulkan/VulkanConvert.h
+++ b/code/graphics/vulkan/VulkanConvert.h
@@ -47,6 +47,15 @@ vk::StencilOp convertStencilOp(StencilOperation op);
 vk::PrimitiveTopology convertPrimitiveType(primitive_type type);
 
 /**
+ * @brief Whether a topology may declare primitiveRestartEnable
+ *
+ * True for the strip/fan topologies. For list topologies the Vulkan spec requires
+ * primitiveRestartEnable to be VK_FALSE unless VK_EXT_primitive_topology_list_restart is
+ * enabled, which FSO does not request.
+ */
+bool topologySupportsPrimitiveRestart(vk::PrimitiveTopology topology);
+
+/**
  * @brief Convert FSO cull mode to Vulkan cull mode
  * @param cullEnabled Whether culling is enabled
  * @return Vulkan cull mode flags

--- a/code/graphics/vulkan/VulkanDeferred.cpp
+++ b/code/graphics/vulkan/VulkanDeferred.cpp
@@ -411,25 +411,8 @@ void vulkan_deferred_lighting_msaa()
 				ring.alloc(descriptorMgr->getCurrentFrame(), &resolveData, sizeof(resolveData));
 			writer.setBuffer(PerDrawBinding::GenericData, {ring.buffer(), slotOffset, ring.slotSize()});
 			writer.flush();
-			// Per-set accessors (not the concatenating overload) — those return views
-			// into one shared scratch buffer, so two live at once would alias.
-			cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-				pipelineMgr->getPipelineLayout(),
-				static_cast<uint32_t>(DescriptorSetIndex::Global), globalSet, {});
-			cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-				pipelineMgr->getPipelineLayout(),
-				static_cast<uint32_t>(DescriptorSetIndex::Material),
-				materialSet,
-				vk::ArrayProxy<const uint32_t>(
-					VulkanDescriptorManager::getDynamicOffsetCount(DescriptorSetIndex::Material),
-					writer.dynamicOffsets(DescriptorSetIndex::Material)));
-			cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-				pipelineMgr->getPipelineLayout(),
-				static_cast<uint32_t>(DescriptorSetIndex::PerDraw),
-				perDrawSet,
-				vk::ArrayProxy<const uint32_t>(
-					VulkanDescriptorManager::getDynamicOffsetCount(DescriptorSetIndex::PerDraw),
-					writer.dynamicOffsets(DescriptorSetIndex::PerDraw)));
+			const vk::DescriptorSet sets[] = {globalSet, materialSet, perDrawSet};
+			writer.bindSets(cmd, pipelineMgr->getPipelineLayout(), DescriptorSetIndex::Global, sets);
 
 			cmd.draw(3, 1, 0, 0);
 		}

--- a/code/graphics/vulkan/VulkanDeferred.cpp
+++ b/code/graphics/vulkan/VulkanDeferred.cpp
@@ -369,13 +369,13 @@ void vulkan_deferred_lighting_msaa()
 			// Global set (fallback — resolve shader doesn't use global bindings)
 			vk::DescriptorSet globalSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Global);
 			Assert(globalSet);
-			writer.writeSet(globalSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Global));
+			writer.writeSet(DescriptorSetIndex::Global, globalSet);
 
 			// Material set: All 6 MSAA textures in binding 1 array (elements 0-5)
 			// [0]=color, [1]=position, [2]=normal, [3]=specular, [4]=emissive, [5]=depth
 			vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 			Assert(materialSet);
-			writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+			writer.writeSet(DescriptorSetIndex::Material, materialSet);
 
 			// Build texture array: elements 0-5 are MSAA textures, 6-15 are fallback
 			vk::Sampler nearestSampler = texMgr->getSampler(
@@ -397,7 +397,7 @@ void vulkan_deferred_lighting_msaa()
 			// PerDraw set: GenericData UBO with {samples, fov} at binding 0
 			vk::DescriptorSet perDrawSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::PerDraw);
 			Assert(perDrawSet);
-			writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+			writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 
 			struct MsaaResolveData {
 				int samples;
@@ -411,15 +411,25 @@ void vulkan_deferred_lighting_msaa()
 				ring.alloc(descriptorMgr->getCurrentFrame(), &resolveData, sizeof(resolveData));
 			writer.setBuffer(PerDrawBinding::GenericData, {ring.buffer(), slotOffset, ring.slotSize()});
 			writer.flush();
+			// Per-set accessors (not the concatenating overload) — those return views
+			// into one shared scratch buffer, so two live at once would alias.
 			cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
 				pipelineMgr->getPipelineLayout(),
 				static_cast<uint32_t>(DescriptorSetIndex::Global), globalSet, {});
 			cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
 				pipelineMgr->getPipelineLayout(),
-				static_cast<uint32_t>(DescriptorSetIndex::Material), materialSet, {});
+				static_cast<uint32_t>(DescriptorSetIndex::Material),
+				materialSet,
+				vk::ArrayProxy<const uint32_t>(
+					VulkanDescriptorManager::getDynamicOffsetCount(DescriptorSetIndex::Material),
+					writer.dynamicOffsets(DescriptorSetIndex::Material)));
 			cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
 				pipelineMgr->getPipelineLayout(),
-				static_cast<uint32_t>(DescriptorSetIndex::PerDraw), perDrawSet, {});
+				static_cast<uint32_t>(DescriptorSetIndex::PerDraw),
+				perDrawSet,
+				vk::ArrayProxy<const uint32_t>(
+					VulkanDescriptorManager::getDynamicOffsetCount(DescriptorSetIndex::PerDraw),
+					writer.dynamicOffsets(DescriptorSetIndex::PerDraw)));
 
 			cmd.draw(3, 1, 0, 0);
 		}
@@ -1008,12 +1018,12 @@ void vulkan_render_decals(decal_material* material_info,
 	// Set 0: Global (all fallback)
 	vk::DescriptorSet globalSet = descManager->allocateFrameSet(DescriptorSetIndex::Global);
 	Assert(globalSet);
-	writer.writeSet(globalSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Global));
+	writer.writeSet(DescriptorSetIndex::Global, globalSet);
 
 	// Set 1: Material
 	vk::DescriptorSet materialSet = descManager->allocateFrameSet(DescriptorSetIndex::Material);
 	Assert(materialSet);
-	writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+	writer.writeSet(DescriptorSetIndex::Material, materialSet);
 
 	// Binding 2: DecalGlobals UBO
 	writer.setBuffer(MaterialBinding::DecalGlobals,
@@ -1047,15 +1057,19 @@ void vulkan_render_decals(decal_material* material_info,
 	// Set 2: PerDraw
 	vk::DescriptorSet perDrawSet = descManager->allocateFrameSet(DescriptorSetIndex::PerDraw);
 	Assert(perDrawSet);
-	writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+	writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 	writer.setBuffer(PerDrawBinding::Matrices,
 		getPendingBufInfo(static_cast<size_t>(uniform_block_type::Matrices)));
 	writer.setBuffer(PerDrawBinding::DecalInfo,
 		getPendingBufInfo(static_cast<size_t>(uniform_block_type::DecalInfo)));
 	writer.flush();
 	stateTracker->bindDescriptorSet(DescriptorSetIndex::Global, globalSet);
-	stateTracker->bindDescriptorSet(DescriptorSetIndex::Material, materialSet);
-	stateTracker->bindDescriptorSet(DescriptorSetIndex::PerDraw, perDrawSet);
+	stateTracker->bindDescriptorSet(DescriptorSetIndex::Material,
+		materialSet,
+		writer.dynamicOffsets(DescriptorSetIndex::Material));
+	stateTracker->bindDescriptorSet(DescriptorSetIndex::PerDraw,
+		perDrawSet,
+		writer.dynamicOffsets(DescriptorSetIndex::PerDraw));
 
 	// Bind vertex buffers: binding 0 = box VBO, binding 1 = instance buffer
 	vk::Buffer boxVBO = bufferManager->getVkBuffer(buffers.Vbuffer_handle);

--- a/code/graphics/vulkan/VulkanDescriptorManager.cpp
+++ b/code/graphics/vulkan/VulkanDescriptorManager.cpp
@@ -19,6 +19,12 @@ static constexpr DescriptorBindingTemplate s_globalBindings[] = {
 static constexpr DescriptorBindingTemplate s_globalTlasBinding{
 	GlobalBinding::Tlas, vk::DescriptorType::eAccelerationStructureKHR, 1, vk::ShaderStageFlagBits::eFragment};
 
+// GLOBAL_DYNAMIC_OFFSET_COUNT is stated rather than derived because this set's template is
+// assembled at runtime (see below); keep the two in agreement. The optional TLAS binding is not
+// a dynamic UBO, so it cannot change the count either.
+static_assert(dynamic_offset_count(s_globalBindings) == GLOBAL_DYNAMIC_OFFSET_COUNT,
+	"The Global set gained a dynamic binding; GLOBAL_DYNAMIC_OFFSET_COUNT must follow.");
+
 // The Global set's layout must omit the TLAS binding entirely on devices without
 // VK_KHR_acceleration_structure enabled -- a descriptor type the device didn't
 // enable the extension for is invalid in vkCreateDescriptorSetLayout. So, unlike
@@ -27,48 +33,10 @@ static constexpr DescriptorBindingTemplate s_globalTlasBinding{
 // the per-instance m_globalBindingsRuntime/m_globalTemplateRuntime members
 // (see VulkanDescriptorManager.h), rather than compiled in as a fixed constexpr array.
 
-static constexpr DescriptorBindingTemplate s_materialBindings[] = {
-	{MaterialBinding::ModelData,
-		vk::DescriptorType::eUniformBufferDynamic,
-		1,
-		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::TextureArray,
-		vk::DescriptorType::eCombinedImageSampler,
-		16,
-		vk::ShaderStageFlagBits::eFragment,
-		vk::ImageViewType::e2DArray},
-	{MaterialBinding::DecalGlobals,
-		vk::DescriptorType::eUniformBuffer,
-		1,
-		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::TransformSSBO, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eVertex},
-	{MaterialBinding::DepthMap, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::SceneColor, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::DistortionMap, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::ShadowMapData, vk::DescriptorType::eUniformBufferDynamic, 1, vk::ShaderStageFlagBits::eVertex},
-};
-static constexpr DescriptorSetTemplate s_materialTemplate(s_materialBindings);
-
-static constexpr DescriptorBindingTemplate s_perDrawBindings[] = {
-	{PerDrawBinding::GenericData,
-		vk::DescriptorType::eUniformBufferDynamic,
-		1,
-		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{PerDrawBinding::Matrices,
-		vk::DescriptorType::eUniformBufferDynamic,
-		1,
-		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{PerDrawBinding::NanoVGData,
-		vk::DescriptorType::eUniformBuffer,
-		1,
-		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{PerDrawBinding::DecalInfo,
-		vk::DescriptorType::eUniformBuffer,
-		1,
-		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{PerDrawBinding::MovieData, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment},
-};
-static constexpr DescriptorSetTemplate s_perDrawTemplate(s_perDrawBindings);
+// The binding declarations themselves live in the header (MaterialSetBindings /
+// PerDrawSetBindings) because the dynamic-offset layout is derived from them there.
+static constexpr DescriptorSetTemplate s_materialTemplate(MaterialSetBindings);
+static constexpr DescriptorSetTemplate s_perDrawTemplate(PerDrawSetBindings);
 
 // ========== Static uniform binding mappings ==========
 
@@ -124,8 +92,9 @@ void DescriptorWriter::writeSet(DescriptorSetIndex setIndex, vk::DescriptorSet s
 	m_bindingSlots = {};
 	m_currentSet = setIndex;
 
-	// Dynamic offsets are consumed in binding order, so assign slots as the
-	// template is walked (templates list bindings in ascending binding number).
+	// Dynamic offsets are consumed in binding order, so assign slots as the template is walked
+	// (templates list bindings in ascending binding number). This must stay the same rule
+	// dynamic_offset_slot() applies — hence advancing by b.count, not by one binding.
 	uint32_t nextDynIndex = 0;
 	m_dynOffsets[static_cast<size_t>(setIndex)] = {};
 
@@ -147,8 +116,9 @@ void DescriptorWriter::writeSet(DescriptorSetIndex setIndex, vk::DescriptorSet s
 		bool isImage = (b.type == vk::DescriptorType::eCombinedImageSampler);
 		bool isAccelStruct = (b.type == vk::DescriptorType::eAccelerationStructureKHR);
 		if (b.type == vk::DescriptorType::eUniformBufferDynamic) {
-			Assert(nextDynIndex < MAX_DYNAMIC_OFFSETS_PER_SET);
-			slot.dynIndex = static_cast<int>(nextDynIndex++);
+			Assert(nextDynIndex + b.count <= MAX_DYNAMIC_OFFSETS_PER_SET);
+			slot.dynIndex = static_cast<int>(nextDynIndex);
+			nextDynIndex += b.count;
 		}
 		if (isImage) {
 			Assert(m_imageInfoCount + b.count <= MAX_IMAGE_INFOS);
@@ -187,10 +157,13 @@ void DescriptorWriter::writeSet(DescriptorSetIndex setIndex, vk::DescriptorSet s
 	}
 }
 
-ArrayView<uint32_t> DescriptorWriter::dynamicOffsets(DescriptorSetIndex firstSet, uint32_t setCount)
+void DescriptorWriter::bindSets(vk::CommandBuffer cmd,
+	vk::PipelineLayout layout,
+	DescriptorSetIndex firstSet,
+	ArrayView<vk::DescriptorSet> sets)
 {
 	size_t out = 0;
-	for (uint32_t i = 0; i < setCount; ++i) {
+	for (size_t i = 0; i < sets.size; ++i) {
 		const auto set = static_cast<DescriptorSetIndex>(static_cast<uint32_t>(firstSet) + i);
 		Assert(static_cast<uint32_t>(set) < static_cast<uint32_t>(DescriptorSetIndex::Count));
 
@@ -201,7 +174,12 @@ ArrayView<uint32_t> DescriptorWriter::dynamicOffsets(DescriptorSetIndex firstSet
 			m_dynOffsetScratch[out++] = m_dynOffsets[static_cast<size_t>(set)][j];
 		}
 	}
-	return {m_dynOffsetScratch.data(), out};
+
+	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+		layout,
+		static_cast<uint32_t>(firstSet),
+		vk::ArrayProxy<const vk::DescriptorSet>(static_cast<uint32_t>(sets.size), sets.data),
+		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(out), m_dynOffsetScratch.data()));
 }
 
 void DescriptorWriter::flush()
@@ -354,13 +332,19 @@ const DescriptorSetTemplate& VulkanDescriptorManager::getSetTemplate(DescriptorS
 
 uint32_t VulkanDescriptorManager::getDynamicOffsetCount(DescriptorSetIndex setIndex)
 {
-	uint32_t count = 0;
-	for (const auto& b : getSetTemplate(setIndex)) {
-		if (b.type == vk::DescriptorType::eUniformBufferDynamic) {
-			count += b.count;
-		}
+	// Constant per set (see the derived *_DYNAMIC_OFFSET_COUNT values), not a scan of the
+	// template — this runs on every descriptor set bind.
+	switch (setIndex) {
+	case DescriptorSetIndex::Global:
+		return GLOBAL_DYNAMIC_OFFSET_COUNT;
+	case DescriptorSetIndex::Material:
+		return MATERIAL_DYNAMIC_OFFSET_COUNT;
+	case DescriptorSetIndex::PerDraw:
+		return PERDRAW_DYNAMIC_OFFSET_COUNT;
+	default:
+		UNREACHABLE("Invalid descriptor set index %u!", static_cast<uint32_t>(setIndex));
+		return 0;
 	}
-	return count;
 }
 
 vk::DescriptorSetLayout VulkanDescriptorManager::getSetLayout(DescriptorSetIndex setIndex) const

--- a/code/graphics/vulkan/VulkanDescriptorManager.cpp
+++ b/code/graphics/vulkan/VulkanDescriptorManager.cpp
@@ -28,23 +28,45 @@ static constexpr DescriptorBindingTemplate s_globalTlasBinding{
 // (see VulkanDescriptorManager.h), rather than compiled in as a fixed constexpr array.
 
 static constexpr DescriptorBindingTemplate s_materialBindings[] = {
-	{MaterialBinding::ModelData,     vk::DescriptorType::eUniformBuffer,        1,  vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::TextureArray,  vk::DescriptorType::eCombinedImageSampler, 16, vk::ShaderStageFlagBits::eFragment, vk::ImageViewType::e2DArray},
-	{MaterialBinding::DecalGlobals,  vk::DescriptorType::eUniformBuffer,        1,  vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::TransformSSBO, vk::DescriptorType::eStorageBuffer,        1,  vk::ShaderStageFlagBits::eVertex},
-	{MaterialBinding::DepthMap,      vk::DescriptorType::eCombinedImageSampler, 1,  vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::SceneColor,    vk::DescriptorType::eCombinedImageSampler, 1,  vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::DistortionMap, vk::DescriptorType::eCombinedImageSampler, 1,  vk::ShaderStageFlagBits::eFragment},
-	{MaterialBinding::ShadowMapData, vk::DescriptorType::eUniformBuffer,        1,  vk::ShaderStageFlagBits::eVertex},
+	{MaterialBinding::ModelData,
+		vk::DescriptorType::eUniformBufferDynamic,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::TextureArray,
+		vk::DescriptorType::eCombinedImageSampler,
+		16,
+		vk::ShaderStageFlagBits::eFragment,
+		vk::ImageViewType::e2DArray},
+	{MaterialBinding::DecalGlobals,
+		vk::DescriptorType::eUniformBuffer,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::TransformSSBO, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eVertex},
+	{MaterialBinding::DepthMap, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::SceneColor, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::DistortionMap, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::ShadowMapData, vk::DescriptorType::eUniformBufferDynamic, 1, vk::ShaderStageFlagBits::eVertex},
 };
 static constexpr DescriptorSetTemplate s_materialTemplate(s_materialBindings);
 
 static constexpr DescriptorBindingTemplate s_perDrawBindings[] = {
-	{PerDrawBinding::GenericData, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{PerDrawBinding::Matrices,    vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{PerDrawBinding::NanoVGData,  vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{PerDrawBinding::DecalInfo,   vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
-	{PerDrawBinding::MovieData,   vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::GenericData,
+		vk::DescriptorType::eUniformBufferDynamic,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::Matrices,
+		vk::DescriptorType::eUniformBufferDynamic,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::NanoVGData,
+		vk::DescriptorType::eUniformBuffer,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::DecalInfo,
+		vk::DescriptorType::eUniformBuffer,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::MovieData, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment},
 };
 static constexpr DescriptorSetTemplate s_perDrawTemplate(s_perDrawBindings);
 
@@ -92,12 +114,20 @@ const vk::DescriptorImageInfo& DescriptorFallbacks::getImage(vk::ImageViewType t
 
 // ========== DescriptorWriter template-based methods ==========
 
-void DescriptorWriter::writeSet(vk::DescriptorSet set, const DescriptorSetTemplate& tmpl)
+void DescriptorWriter::writeSet(DescriptorSetIndex setIndex, vk::DescriptorSet set)
 {
 	Assert(m_fallbacks);
 
+	const DescriptorSetTemplate& tmpl = VulkanDescriptorManager::getSetTemplate(setIndex);
+
 	// Clear binding slots for this set
 	m_bindingSlots = {};
+	m_currentSet = setIndex;
+
+	// Dynamic offsets are consumed in binding order, so assign slots as the
+	// template is walked (templates list bindings in ascending binding number).
+	uint32_t nextDynIndex = 0;
+	m_dynOffsets[static_cast<size_t>(setIndex)] = {};
 
 	for (const auto& b : tmpl) {
 		Assert(m_writeCount < MAX_WRITES);
@@ -116,6 +146,10 @@ void DescriptorWriter::writeSet(vk::DescriptorSet set, const DescriptorSetTempla
 
 		bool isImage = (b.type == vk::DescriptorType::eCombinedImageSampler);
 		bool isAccelStruct = (b.type == vk::DescriptorType::eAccelerationStructureKHR);
+		if (b.type == vk::DescriptorType::eUniformBufferDynamic) {
+			Assert(nextDynIndex < MAX_DYNAMIC_OFFSETS_PER_SET);
+			slot.dynIndex = static_cast<int>(nextDynIndex++);
+		}
 		if (isImage) {
 			Assert(m_imageInfoCount + b.count <= MAX_IMAGE_INFOS);
 			auto* dst = &m_imageInfos[m_imageInfoCount];
@@ -144,10 +178,30 @@ void DescriptorWriter::writeSet(vk::DescriptorSet set, const DescriptorSetTempla
 		} else {
 			Assert(m_bufferInfoCount < MAX_BUFFER_INFOS);
 			m_bufferInfos[m_bufferInfoCount] = m_fallbacks->buffer;
+			// The fallback buffer info starts at offset 0, which is also the base a
+			// dynamic descriptor needs (its offset lives in the dynamic-offset array,
+			// left at 0 here until setBuffer supplies a real one).
 			w.pBufferInfo = &m_bufferInfos[m_bufferInfoCount];
 			slot.bufferInfo = &m_bufferInfos[m_bufferInfoCount++];
 		}
 	}
+}
+
+ArrayView<uint32_t> DescriptorWriter::dynamicOffsets(DescriptorSetIndex firstSet, uint32_t setCount)
+{
+	size_t out = 0;
+	for (uint32_t i = 0; i < setCount; ++i) {
+		const auto set = static_cast<DescriptorSetIndex>(static_cast<uint32_t>(firstSet) + i);
+		Assert(static_cast<uint32_t>(set) < static_cast<uint32_t>(DescriptorSetIndex::Count));
+
+		const uint32_t dynCount = VulkanDescriptorManager::getDynamicOffsetCount(set);
+		Assert(dynCount <= MAX_DYNAMIC_OFFSETS_PER_SET);
+		for (uint32_t j = 0; j < dynCount; ++j) {
+			Assert(out < m_dynOffsetScratch.size());
+			m_dynOffsetScratch[out++] = m_dynOffsets[static_cast<size_t>(set)][j];
+		}
+	}
+	return {m_dynOffsetScratch.data(), out};
 }
 
 void DescriptorWriter::flush()
@@ -167,6 +221,25 @@ void DescriptorWriter::setBuffer(uint32_t binding, const vk::DescriptorBufferInf
 	Assert(binding < MAX_BINDINGS_PER_SET);
 	auto& slot = m_bindingSlots[binding];
 	Assert(slot.bufferInfo);
+
+	if (slot.dynIndex >= 0) {
+		// Dynamic binding: the descriptor holds only {buffer, 0, range}; the caller's
+		// offset becomes the dynamic offset applied at bind time. Keeping it out of
+		// the descriptor is what lets the set survive an offset-only change.
+		auto& dyn = m_dynOffsets[static_cast<size_t>(m_currentSet)][static_cast<size_t>(slot.dynIndex)];
+		if (info.buffer) {
+			Assertion(info.offset <= static_cast<vk::DeviceSize>(UINT32_MAX),
+				"Dynamic uniform buffer offset " SIZE_T_ARG " does not fit in a uint32 dynamic offset!",
+				static_cast<size_t>(info.offset));
+			*slot.bufferInfo = vk::DescriptorBufferInfo(info.buffer, 0, info.range);
+			dyn = static_cast<uint32_t>(info.offset);
+		} else {
+			*slot.bufferInfo = m_fallbacks->buffer;
+			dyn = 0;
+		}
+		return;
+	}
+
 	if (info.buffer) {
 		*slot.bufferInfo = info;
 	} else {
@@ -279,6 +352,17 @@ const DescriptorSetTemplate& VulkanDescriptorManager::getSetTemplate(DescriptorS
 	}
 }
 
+uint32_t VulkanDescriptorManager::getDynamicOffsetCount(DescriptorSetIndex setIndex)
+{
+	uint32_t count = 0;
+	for (const auto& b : getSetTemplate(setIndex)) {
+		if (b.type == vk::DescriptorType::eUniformBufferDynamic) {
+			count += b.count;
+		}
+	}
+	return count;
+}
+
 vk::DescriptorSetLayout VulkanDescriptorManager::getSetLayout(DescriptorSetIndex setIndex) const
 {
 	return m_setLayouts[static_cast<size_t>(setIndex)].get();
@@ -294,22 +378,31 @@ vk::DescriptorSet VulkanDescriptorManager::allocateFrameSet(DescriptorSetIndex s
 	auto& pools = m_framePools[m_currentFrame];
 	++m_setsAllocatedThisFrame;
 
+	// Allocate through the non-throwing, non-allocating vulkan.hpp overload: this is
+	// one of the hottest calls in the backend (thousands per frame), and the
+	// vector-returning overload heap-allocates on every single one.
+	vk::DescriptorSetAllocateInfo allocInfo;
+	allocInfo.descriptorSetCount = 1;
+	allocInfo.pSetLayouts = &layout;
+
 	// Try allocating from the last pool in the list
 	if (!pools.empty()) {
-		vk::DescriptorSetAllocateInfo allocInfo;
 		allocInfo.descriptorPool = pools.back().get();
-		allocInfo.descriptorSetCount = 1;
-		allocInfo.pSetLayouts = &layout;
 
-		try {
-			auto sets = m_device.allocateDescriptorSets(allocInfo);
-			return sets[0];
-		} catch (const vk::OutOfPoolMemoryError&) {
-			// Pool exhausted, fall through to create a new one
+		vk::DescriptorSet set;
+		vk::Result result = m_device.allocateDescriptorSets(&allocInfo, &set);
+		if (result == vk::Result::eSuccess) {
+			return set;
+		}
+		if (result == vk::Result::eErrorOutOfPoolMemory) {
 			nprintf(("vulkan", "VulkanDescriptorManager: frame pool exhausted, allocating an additional pool chunk\n"));
-		} catch (const vk::FragmentedPoolError&) {
-			// Pool fragmented, fall through to create a new one
+		} else if (result == vk::Result::eErrorFragmentedPool) {
 			nprintf(("vulkan", "VulkanDescriptorManager: frame pool fragmented, allocating an additional pool chunk\n"));
+		} else {
+			nprintf(("vulkan",
+				"VulkanDescriptorManager: descriptor set allocation failed (%s)\n",
+				vk::to_string(result).c_str()));
+			return {};
 		}
 	}
 
@@ -318,18 +411,17 @@ vk::DescriptorSet VulkanDescriptorManager::allocateFrameSet(DescriptorSetIndex s
 	nprintf(("vulkandescriptor", "VulkanDescriptorManager: Grew frame %u pool count to %zu\n",
 		m_currentFrame, pools.size()));
 
-	vk::DescriptorSetAllocateInfo allocInfo;
 	allocInfo.descriptorPool = pools.back().get();
-	allocInfo.descriptorSetCount = 1;
-	allocInfo.pSetLayouts = &layout;
 
-	try {
-		auto sets = m_device.allocateDescriptorSets(allocInfo);
-		return sets[0];
-	} catch (const vk::SystemError& e) {
-		nprintf(("vulkan", "VulkanDescriptorManager: Failed to allocate frame descriptor set after pool growth: %s\n", e.what()));
+	vk::DescriptorSet set;
+	vk::Result result = m_device.allocateDescriptorSets(&allocInfo, &set);
+	if (result != vk::Result::eSuccess) {
+		nprintf(("vulkan",
+			"VulkanDescriptorManager: Failed to allocate frame descriptor set after pool growth: %s\n",
+			vk::to_string(result).c_str()));
 		return {};
 	}
+	return set;
 }
 
 void VulkanDescriptorManager::beginFrame()
@@ -403,9 +495,10 @@ vk::UniqueDescriptorPool VulkanDescriptorManager::createFramePool()
 	// constants in VulkanDescriptorManager.h. Additional pool chunks are created
 	// automatically when one is exhausted.
 	SCP_vector<vk::DescriptorPoolSize> poolSizes = {
-		{ vk::DescriptorType::eUniformBuffer, MAX_UNIFORM_BUFFERS_PER_POOL },
-		{ vk::DescriptorType::eCombinedImageSampler, MAX_SAMPLERS_PER_POOL },
-		{ vk::DescriptorType::eStorageBuffer, MAX_SETS_PER_POOL },
+		{vk::DescriptorType::eUniformBuffer, MAX_UNIFORM_BUFFERS_PER_POOL},
+		{vk::DescriptorType::eUniformBufferDynamic, MAX_DYNAMIC_UNIFORM_BUFFERS_PER_POOL},
+		{vk::DescriptorType::eCombinedImageSampler, MAX_SAMPLERS_PER_POOL},
+		{vk::DescriptorType::eStorageBuffer, MAX_SETS_PER_POOL},
 	};
 	if (m_raytracingEnabled) {
 		poolSizes.emplace_back(vk::DescriptorType::eAccelerationStructureKHR, MAX_SETS_PER_POOL);

--- a/code/graphics/vulkan/VulkanDescriptorManager.h
+++ b/code/graphics/vulkan/VulkanDescriptorManager.h
@@ -186,12 +186,20 @@ constexpr uint32_t dynamic_offset_count(const DescriptorBindingTemplate (&bindin
 	return count;
 }
 
+// Returned by dynamic_offset_slot() when the binding is not a dynamic descriptor of the set.
+constexpr uint32_t DYNAMIC_SLOT_INVALID = ~0u;
+
 /**
  * @brief Position of a dynamic binding within its set's dynamic-offset array
  *
- * If @c binding is not a dynamic binding of the given set, the throw is reached; a throw is not
- * a constant expression, so every use below (all of which initialize @c constexpr values) turns
- * a mistyped or non-dynamic binding constant into a compile error rather than a silent 0.
+ * If @c binding is not a dynamic binding of the given set, @c DYNAMIC_SLOT_INVALID is returned.
+ * Every use below pairs its constant with a static_assert against that sentinel, so a mistyped or
+ * non-dynamic binding constant is a compile error rather than a silent 0 — these constants index
+ * fixed-size dynamic-offset arrays at the bind call sites, so a leaked sentinel would be an
+ * out-of-bounds write.
+ *
+ * Do not "clean this up" back into a `throw` on the not-found path: MSVC rejects a constexpr
+ * function whose flow analysis can reach a throw (C3615), even when no evaluation takes that path.
  */
 template <size_t N>
 constexpr uint32_t dynamic_offset_slot(const DescriptorBindingTemplate (&bindings)[N], uint32_t binding)
@@ -206,7 +214,7 @@ constexpr uint32_t dynamic_offset_slot(const DescriptorBindingTemplate (&binding
 		}
 		slot += bindings[i].count;
 	}
-	throw "binding is not a dynamic descriptor of this set";
+	return DYNAMIC_SLOT_INVALID;
 }
 
 // The Global set declares no dynamic bindings; it contributes nothing to a bind call.
@@ -217,11 +225,19 @@ constexpr uint32_t PERDRAW_DYNAMIC_OFFSET_COUNT = dynamic_offset_count(PerDrawSe
 namespace MaterialDynamicSlot {
 constexpr uint32_t ModelData = dynamic_offset_slot(MaterialSetBindings, MaterialBinding::ModelData);
 constexpr uint32_t ShadowMapData = dynamic_offset_slot(MaterialSetBindings, MaterialBinding::ShadowMapData);
+static_assert(ModelData != DYNAMIC_SLOT_INVALID,
+	"MaterialBinding::ModelData is not a dynamic descriptor of the Material set.");
+static_assert(ShadowMapData != DYNAMIC_SLOT_INVALID,
+	"MaterialBinding::ShadowMapData is not a dynamic descriptor of the Material set.");
 }
 
 namespace PerDrawDynamicSlot {
 constexpr uint32_t GenericData = dynamic_offset_slot(PerDrawSetBindings, PerDrawBinding::GenericData);
 constexpr uint32_t Matrices = dynamic_offset_slot(PerDrawSetBindings, PerDrawBinding::Matrices);
+static_assert(GenericData != DYNAMIC_SLOT_INVALID,
+	"PerDrawBinding::GenericData is not a dynamic descriptor of the PerDraw set.");
+static_assert(Matrices != DYNAMIC_SLOT_INVALID,
+	"PerDrawBinding::Matrices is not a dynamic descriptor of the PerDraw set.");
 }
 
 /**

--- a/code/graphics/vulkan/VulkanDescriptorManager.h
+++ b/code/graphics/vulkan/VulkanDescriptorManager.h
@@ -53,10 +53,32 @@ struct DescriptorFallbacks {
 };
 
 /**
+ * @brief Descriptor set indices for the 3-tier layout
+ *
+ * Set 0: Global - per-frame data (lights, deferred globals, shadow maps)
+ * Set 1: Material - per-material data (model data, textures)
+ * Set 2: Per-Draw - per-draw-call data (generic data, matrices, etc.)
+ */
+enum class DescriptorSetIndex : uint32_t {
+	Global = 0,
+	Material = 1,
+	PerDraw = 2,
+
+	Count = 3
+};
+
+/**
  * @brief Stack-allocated batch writer for descriptor set updates.
  *
  * Usage: reset() + writeSet() (pre-fills all bindings with fallbacks)
  * + setBuffer/setImage overrides for real data + flush().
+ *
+ * Bindings declared as eUniformBufferDynamic get their offset split out of the
+ * descriptor and into the dynamic-offset array (see dynamicOffsets()): setBuffer
+ * writes {buffer, 0, range} into the descriptor and stashes the caller's offset.
+ * That is what lets a set whose only per-draw change is a UBO offset be written
+ * once and rebound many times. Callers must hand dynamicOffsets()/
+ * dynamicOffsetCount() for a set to vkCmdBindDescriptorSets when binding it.
  */
 class DescriptorWriter {
 public:
@@ -74,6 +96,9 @@ public:
 	static constexpr uint32_t MAX_IMAGE_INFOS = 24;      // image/sampler descriptors staged per batch
 	static constexpr uint32_t MAX_ACCEL_STRUCT_INFOS = 2; // TLAS descriptors staged per batch (RT)
 	static constexpr uint32_t MAX_BINDINGS_PER_SET = 16; // highest binding number addressable in a set
+	// Most dynamic (eUniformBufferDynamic) bindings any one set layout declares.
+	// Material has 2 (ModelData, ShadowMapData), PerDraw has 2 (GenericData, Matrices).
+	static constexpr uint32_t MAX_DYNAMIC_OFFSETS_PER_SET = 2;
 
 	void reset(vk::Device device, const DescriptorFallbacks& fallbacks) {
 		m_device = device;
@@ -82,13 +107,39 @@ public:
 		m_bufferInfoCount = 0;
 		m_imageInfoCount = 0;
 		m_accelStructInfoCount = 0;
+		m_dynOffsets = {};
 	}
 
-	void writeSet(vk::DescriptorSet set, const DescriptorSetTemplate& tmpl);
+	void writeSet(DescriptorSetIndex setIndex, vk::DescriptorSet set);
 
 	void setBuffer(uint32_t binding, const vk::DescriptorBufferInfo& info);
 	void setImage(uint32_t binding, const vk::DescriptorImageInfo& info);
 	void setImageArray(uint32_t binding, ArrayView<vk::DescriptorImageInfo> infos);
+
+	/**
+	 * @brief Dynamic offsets accumulated for a set, ordered by binding number.
+	 *
+	 * Only meaningful for a set this writer actually wrote; a set reused from a
+	 * memoization cache was not written here, so its caller owns the offsets.
+	 * Always sized to the set layout's dynamic descriptor count (offsets for
+	 * bindings left at their fallback stay 0).
+	 */
+	const uint32_t* dynamicOffsets(DescriptorSetIndex setIndex) const
+	{
+		return m_dynOffsets[static_cast<size_t>(setIndex)].data();
+	}
+
+	/**
+	 * @brief Dynamic offsets for a contiguous run of sets, concatenated in set order
+	 *
+	 * This is the layout vkCmdBindDescriptorSets expects when several sets are bound
+	 * in one call: each set contributes exactly its layout's dynamic descriptor count
+	 * (so a set declaring none contributes nothing, rather than padding). Returns a
+	 * view into writer-owned scratch, valid until the next call — never hold two of
+	 * these at once; for one-set-per-call binds use the per-set overload above,
+	 * whose storage is stable.
+	 */
+	ArrayView<uint32_t> dynamicOffsets(DescriptorSetIndex firstSet, uint32_t setCount);
 
 	void flush(); // defined in VulkanDescriptorManager.cpp (reports write stats to the manager)
 
@@ -100,6 +151,7 @@ private:
 		vk::DescriptorImageInfo* imageInfo = nullptr;    // non-null for image bindings
 		uint32_t count = 0;                              // descriptor count (1 or 16 for arrays)
 		vk::ImageViewType viewType = vk::ImageViewType::e2D;  // for fallback lookup
+		int dynIndex = -1;                                    // slot in m_dynOffsets, or -1 if not dynamic
 	};
 
 	vk::Device m_device;
@@ -111,25 +163,16 @@ private:
 	std::array<vk::AccelerationStructureKHR, MAX_ACCEL_STRUCT_INFOS> m_accelStructInfos;
 	std::array<vk::WriteDescriptorSetAccelerationStructureKHR, MAX_ACCEL_STRUCT_INFOS> m_asWriteInfos;
 	std::array<BindingSlot, MAX_BINDINGS_PER_SET> m_bindingSlots;
+	std::array<std::array<uint32_t, MAX_DYNAMIC_OFFSETS_PER_SET>, static_cast<size_t>(DescriptorSetIndex::Count)>
+		m_dynOffsets{};
+	// Scratch for the multi-set dynamicOffsets() overload.
+	std::array<uint32_t, static_cast<size_t>(DescriptorSetIndex::Count) * MAX_DYNAMIC_OFFSETS_PER_SET>
+		m_dynOffsetScratch{};
+	DescriptorSetIndex m_currentSet = DescriptorSetIndex::Global;
 	uint32_t m_writeCount = 0;
 	uint32_t m_bufferInfoCount = 0;
 	uint32_t m_imageInfoCount = 0;
 	uint32_t m_accelStructInfoCount = 0;
-};
-
-/**
- * @brief Descriptor set indices for the 3-tier layout
- *
- * Set 0: Global - per-frame data (lights, deferred globals, shadow maps)
- * Set 1: Material - per-material data (model data, textures)
- * Set 2: Per-Draw - per-draw-call data (generic data, matrices, etc.)
- */
-enum class DescriptorSetIndex : uint32_t {
-	Global = 0,
-	Material = 1,
-	PerDraw = 2,
-
-	Count = 3
 };
 
 // ========== Descriptor Binding Constants ==========
@@ -146,15 +189,18 @@ namespace GlobalBinding {
 }
 
 // Material Set (Set 1) bindings — per-material data
+// ModelData and ShadowMapData are *dynamic* UBOs: their offset moves every draw
+// while the rest of the set is unchanged, so keeping the offset out of the
+// descriptor is what makes the set cacheable across draws.
 namespace MaterialBinding {
-	static constexpr uint32_t ModelData    = 0; // UBO: model/material data
-	static constexpr uint32_t TextureArray = 1; // sampler2D[16]: material textures
-	static constexpr uint32_t DecalGlobals = 2; // UBO: decal globals
-	static constexpr uint32_t TransformSSBO = 3; // SSBO: batched transforms
-	static constexpr uint32_t DepthMap     = 4; // sampler2D: depth (soft particles)
-	static constexpr uint32_t SceneColor   = 5; // sampler2D: scene color (distortion)
-	static constexpr uint32_t DistortionMap = 6; // sampler2D: distortion texture
-	static constexpr uint32_t ShadowMapData = 7; // UBO: shadow map generation per-draw data (shadow_render_list)
+static constexpr uint32_t ModelData = 0;     // dynamic UBO: model/material data
+static constexpr uint32_t TextureArray = 1;  // sampler2D[16]: material textures
+static constexpr uint32_t DecalGlobals = 2;  // UBO: decal globals
+static constexpr uint32_t TransformSSBO = 3; // SSBO: batched transforms
+static constexpr uint32_t DepthMap = 4;      // sampler2D: depth (soft particles)
+static constexpr uint32_t SceneColor = 5;    // sampler2D: scene color (distortion)
+static constexpr uint32_t DistortionMap = 6; // sampler2D: distortion texture
+static constexpr uint32_t ShadowMapData = 7; // dynamic UBO: shadow map generation per-draw data (shadow_render_list)
 }
 
 // Texture array slot indices (elements within MaterialBinding::TextureArray)
@@ -169,12 +215,14 @@ namespace TextureSlot {
 }
 
 // PerDraw Set (Set 2) bindings — per-draw-call data
+// GenericData and Matrices are *dynamic* UBOs, for the same reason as the
+// Material set's ModelData.
 namespace PerDrawBinding {
-	static constexpr uint32_t GenericData  = 0; // UBO: generic shader data
-	static constexpr uint32_t Matrices     = 1; // UBO: transform matrices
-	static constexpr uint32_t NanoVGData   = 2; // UBO: NanoVG data
-	static constexpr uint32_t DecalInfo    = 3; // UBO: per-decal info
-	static constexpr uint32_t MovieData    = 4; // UBO: movie playback data
+static constexpr uint32_t GenericData = 0; // dynamic UBO: generic shader data
+static constexpr uint32_t Matrices = 1;    // dynamic UBO: transform matrices
+static constexpr uint32_t NanoVGData = 2;  // UBO: NanoVG data
+static constexpr uint32_t DecalInfo = 3;   // UBO: per-decal info
+static constexpr uint32_t MovieData = 4;   // UBO: movie playback data
 }
 
 
@@ -195,8 +243,19 @@ public:
 	// larger chunks waste memory, smaller chunks allocate pools more often.
 	// MAX_SETS_PER_POOL supports ~330 draw calls (3 sets each) per chunk; the per-
 	// type multipliers cover the worst-case bindings a single set can request.
+	// One chunk now covers a dense scene outright: with the dynamic-UBO descriptor
+	// memoization in applyMaterial/renderShadowDraw, a big asteroid field at ~1350
+	// model draws settles at ~250 sets/frame, so growth is back to being the rare
+	// case it was meant to be. (The same scene needed ~2500 sets/frame before that.)
+	// Deliberately left at the original size rather than raised: the per-frame
+	// growth this used to log was a symptom of the churn, not of undersizing, and
+	// FSO targets low-end GPUs where a larger pool is real wasted memory.
 	static constexpr uint32_t MAX_SETS_PER_POOL = 1024;
-	static constexpr uint32_t MAX_UNIFORM_BUFFERS_PER_POOL = MAX_SETS_PER_POOL * 9;   // up to 9 UBOs per draw
+	// Worst case per set is 3 static UBOs (Global, PerDraw) and 2 dynamic (Material:
+	// ModelData + ShadowMapData; PerDraw: GenericData + Matrices). Total UBO
+	// capacity per chunk is slightly below what this was before the dynamic split.
+	static constexpr uint32_t MAX_UNIFORM_BUFFERS_PER_POOL = MAX_SETS_PER_POOL * 5;         // static UBOs
+	static constexpr uint32_t MAX_DYNAMIC_UNIFORM_BUFFERS_PER_POOL = MAX_SETS_PER_POOL * 2; // dynamic UBOs
 	static constexpr uint32_t MAX_SAMPLERS_PER_POOL = MAX_SETS_PER_POOL * 16;         // up to 16 samplers per material set
 
 	VulkanDescriptorManager() = default;
@@ -253,6 +312,15 @@ public:
 	 * @brief Get the set template for a given set index
 	 */
 	static const DescriptorSetTemplate& getSetTemplate(DescriptorSetIndex setIndex);
+
+	/**
+	 * @brief Number of dynamic (eUniformBufferDynamic) descriptors in a set layout
+	 *
+	 * vkCmdBindDescriptorSets requires exactly this many entries in pDynamicOffsets,
+	 * so every bind site must agree with the layout. VulkanStateTracker asserts on
+	 * it; raw cmd.bindDescriptorSets() callers should pass the matching count.
+	 */
+	static uint32_t getDynamicOffsetCount(DescriptorSetIndex setIndex);
 
 	/**
 	 * @brief Get descriptor set layout for a given set index

--- a/code/graphics/vulkan/VulkanDescriptorManager.h
+++ b/code/graphics/vulkan/VulkanDescriptorManager.h
@@ -67,114 +67,6 @@ enum class DescriptorSetIndex : uint32_t {
 	Count = 3
 };
 
-/**
- * @brief Stack-allocated batch writer for descriptor set updates.
- *
- * Usage: reset() + writeSet() (pre-fills all bindings with fallbacks)
- * + setBuffer/setImage overrides for real data + flush().
- *
- * Bindings declared as eUniformBufferDynamic get their offset split out of the
- * descriptor and into the dynamic-offset array (see dynamicOffsets()): setBuffer
- * writes {buffer, 0, range} into the descriptor and stashes the caller's offset.
- * That is what lets a set whose only per-draw change is a UBO offset be written
- * once and rebound many times. Callers must hand dynamicOffsets()/
- * dynamicOffsetCount() for a set to vkCmdBindDescriptorSets when binding it.
- */
-class DescriptorWriter {
-public:
-	// Fixed capacities for the stack-allocated staging arrays below — NOT Vulkan
-	// hardware limits. They bound a single vkUpdateDescriptorSets batch (one
-	// writeSet), sized to comfortably cover the largest descriptor set layout the
-	// engine builds. Because the backing arrays live on the stack (see m_writes
-	// etc.), the numbers carry no runtime cost beyond that fixed footprint; the
-	// only failure mode is under-sizing, which is Assert-guarded at fill time in
-	// DescriptorWriter::writeSet (e.g. `Assert(m_writeCount < MAX_WRITES)`) so an
-	// oversized layout trips loudly in debug rather than silently overflowing.
-	// Raise these if a future set layout legitimately needs more bindings/infos.
-	static constexpr uint32_t MAX_WRITES = 32;           // distinct bindings written per batch
-	static constexpr uint32_t MAX_BUFFER_INFOS = 20;     // buffer descriptors staged per batch
-	static constexpr uint32_t MAX_IMAGE_INFOS = 24;      // image/sampler descriptors staged per batch
-	static constexpr uint32_t MAX_ACCEL_STRUCT_INFOS = 2; // TLAS descriptors staged per batch (RT)
-	static constexpr uint32_t MAX_BINDINGS_PER_SET = 16; // highest binding number addressable in a set
-	// Most dynamic (eUniformBufferDynamic) bindings any one set layout declares.
-	// Material has 2 (ModelData, ShadowMapData), PerDraw has 2 (GenericData, Matrices).
-	static constexpr uint32_t MAX_DYNAMIC_OFFSETS_PER_SET = 2;
-
-	void reset(vk::Device device, const DescriptorFallbacks& fallbacks) {
-		m_device = device;
-		m_fallbacks = &fallbacks;
-		m_writeCount = 0;
-		m_bufferInfoCount = 0;
-		m_imageInfoCount = 0;
-		m_accelStructInfoCount = 0;
-		m_dynOffsets = {};
-	}
-
-	void writeSet(DescriptorSetIndex setIndex, vk::DescriptorSet set);
-
-	void setBuffer(uint32_t binding, const vk::DescriptorBufferInfo& info);
-	void setImage(uint32_t binding, const vk::DescriptorImageInfo& info);
-	void setImageArray(uint32_t binding, ArrayView<vk::DescriptorImageInfo> infos);
-
-	/**
-	 * @brief Dynamic offsets accumulated for a set, ordered by binding number.
-	 *
-	 * Only meaningful for a set this writer actually wrote; a set reused from a
-	 * memoization cache was not written here, so its caller owns the offsets.
-	 * Always sized to the set layout's dynamic descriptor count (offsets for
-	 * bindings left at their fallback stay 0).
-	 */
-	const uint32_t* dynamicOffsets(DescriptorSetIndex setIndex) const
-	{
-		return m_dynOffsets[static_cast<size_t>(setIndex)].data();
-	}
-
-	/**
-	 * @brief Dynamic offsets for a contiguous run of sets, concatenated in set order
-	 *
-	 * This is the layout vkCmdBindDescriptorSets expects when several sets are bound
-	 * in one call: each set contributes exactly its layout's dynamic descriptor count
-	 * (so a set declaring none contributes nothing, rather than padding). Returns a
-	 * view into writer-owned scratch, valid until the next call — never hold two of
-	 * these at once; for one-set-per-call binds use the per-set overload above,
-	 * whose storage is stable.
-	 */
-	ArrayView<uint32_t> dynamicOffsets(DescriptorSetIndex firstSet, uint32_t setCount);
-
-	void flush(); // defined in VulkanDescriptorManager.cpp (reports write stats to the manager)
-
-private:
-	// Per-binding lookup for the current writeSet, indexed by binding number.
-	// Populated by writeSet, used by setBuffer/setImage/setImageArray for O(1) access.
-	struct BindingSlot {
-		vk::DescriptorBufferInfo* bufferInfo = nullptr;  // non-null for buffer bindings
-		vk::DescriptorImageInfo* imageInfo = nullptr;    // non-null for image bindings
-		uint32_t count = 0;                              // descriptor count (1 or 16 for arrays)
-		vk::ImageViewType viewType = vk::ImageViewType::e2D;  // for fallback lookup
-		int dynIndex = -1;                                    // slot in m_dynOffsets, or -1 if not dynamic
-	};
-
-	vk::Device m_device;
-	const DescriptorFallbacks* m_fallbacks = nullptr;
-
-	std::array<vk::WriteDescriptorSet, MAX_WRITES> m_writes;
-	std::array<vk::DescriptorBufferInfo, MAX_BUFFER_INFOS> m_bufferInfos;
-	std::array<vk::DescriptorImageInfo, MAX_IMAGE_INFOS> m_imageInfos;
-	std::array<vk::AccelerationStructureKHR, MAX_ACCEL_STRUCT_INFOS> m_accelStructInfos;
-	std::array<vk::WriteDescriptorSetAccelerationStructureKHR, MAX_ACCEL_STRUCT_INFOS> m_asWriteInfos;
-	std::array<BindingSlot, MAX_BINDINGS_PER_SET> m_bindingSlots;
-	std::array<std::array<uint32_t, MAX_DYNAMIC_OFFSETS_PER_SET>, static_cast<size_t>(DescriptorSetIndex::Count)>
-		m_dynOffsets{};
-	// Scratch for the multi-set dynamicOffsets() overload.
-	std::array<uint32_t, static_cast<size_t>(DescriptorSetIndex::Count) * MAX_DYNAMIC_OFFSETS_PER_SET>
-		m_dynOffsetScratch{};
-	DescriptorSetIndex m_currentSet = DescriptorSetIndex::Global;
-	uint32_t m_writeCount = 0;
-	uint32_t m_bufferInfoCount = 0;
-	uint32_t m_imageInfoCount = 0;
-	uint32_t m_accelStructInfoCount = 0;
-};
-
 // ========== Descriptor Binding Constants ==========
 
 // Global Set (Set 0) bindings — per-frame data
@@ -225,6 +117,230 @@ static constexpr uint32_t DecalInfo = 3;   // UBO: per-decal info
 static constexpr uint32_t MovieData = 4;   // UBO: movie playback data
 }
 
+// ========== Set layout templates ==========
+//
+// These describe the fixed set layouts. Everything downstream that needs to know
+// which bindings are dynamic, how many there are, or which dynamic-offset slot a
+// given binding occupies is derived from them below rather than restated, so the
+// declarations here are the only place that ordering exists.
+
+inline constexpr DescriptorBindingTemplate MaterialSetBindings[] = {
+	{MaterialBinding::ModelData,
+		vk::DescriptorType::eUniformBufferDynamic,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::TextureArray,
+		vk::DescriptorType::eCombinedImageSampler,
+		16,
+		vk::ShaderStageFlagBits::eFragment,
+		vk::ImageViewType::e2DArray},
+	{MaterialBinding::DecalGlobals,
+		vk::DescriptorType::eUniformBuffer,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::TransformSSBO, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eVertex},
+	{MaterialBinding::DepthMap, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::SceneColor, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::DistortionMap, vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment},
+	{MaterialBinding::ShadowMapData, vk::DescriptorType::eUniformBufferDynamic, 1, vk::ShaderStageFlagBits::eVertex},
+};
+
+inline constexpr DescriptorBindingTemplate PerDrawSetBindings[] = {
+	{PerDrawBinding::GenericData,
+		vk::DescriptorType::eUniformBufferDynamic,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::Matrices,
+		vk::DescriptorType::eUniformBufferDynamic,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::NanoVGData,
+		vk::DescriptorType::eUniformBuffer,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::DecalInfo,
+		vk::DescriptorType::eUniformBuffer,
+		1,
+		vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment},
+	{PerDrawBinding::MovieData, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eFragment},
+};
+
+// ========== Dynamic-offset layout, derived from the templates above ==========
+//
+// vkCmdBindDescriptorSets consumes a set's dynamic offsets in ascending binding
+// order, one entry per eUniformBufferDynamic descriptor. Both the count and the
+// slot each binding occupies are computed from the set templates so a call site
+// can never disagree with the layout it is binding against — reordering a template
+// moves the derived slots with it instead of silently feeding a shader the wrong
+// uniforms.
+
+template <size_t N>
+constexpr uint32_t dynamic_offset_count(const DescriptorBindingTemplate (&bindings)[N])
+{
+	uint32_t count = 0;
+	for (size_t i = 0; i < N; ++i) {
+		if (bindings[i].type == vk::DescriptorType::eUniformBufferDynamic) {
+			count += bindings[i].count;
+		}
+	}
+	return count;
+}
+
+/**
+ * @brief Position of a dynamic binding within its set's dynamic-offset array
+ *
+ * If @c binding is not a dynamic binding of the given set, the throw is reached; a throw is not
+ * a constant expression, so every use below (all of which initialize @c constexpr values) turns
+ * a mistyped or non-dynamic binding constant into a compile error rather than a silent 0.
+ */
+template <size_t N>
+constexpr uint32_t dynamic_offset_slot(const DescriptorBindingTemplate (&bindings)[N], uint32_t binding)
+{
+	uint32_t slot = 0;
+	for (size_t i = 0; i < N; ++i) {
+		if (bindings[i].type != vk::DescriptorType::eUniformBufferDynamic) {
+			continue;
+		}
+		if (bindings[i].binding == binding) {
+			return slot;
+		}
+		slot += bindings[i].count;
+	}
+	throw "binding is not a dynamic descriptor of this set";
+}
+
+// The Global set declares no dynamic bindings; it contributes nothing to a bind call.
+constexpr uint32_t GLOBAL_DYNAMIC_OFFSET_COUNT = 0;
+constexpr uint32_t MATERIAL_DYNAMIC_OFFSET_COUNT = dynamic_offset_count(MaterialSetBindings);
+constexpr uint32_t PERDRAW_DYNAMIC_OFFSET_COUNT = dynamic_offset_count(PerDrawSetBindings);
+
+namespace MaterialDynamicSlot {
+constexpr uint32_t ModelData = dynamic_offset_slot(MaterialSetBindings, MaterialBinding::ModelData);
+constexpr uint32_t ShadowMapData = dynamic_offset_slot(MaterialSetBindings, MaterialBinding::ShadowMapData);
+}
+
+namespace PerDrawDynamicSlot {
+constexpr uint32_t GenericData = dynamic_offset_slot(PerDrawSetBindings, PerDrawBinding::GenericData);
+constexpr uint32_t Matrices = dynamic_offset_slot(PerDrawSetBindings, PerDrawBinding::Matrices);
+}
+
+/**
+ * @brief Stack-allocated batch writer for descriptor set updates.
+ *
+ * Usage: reset() + writeSet() (pre-fills all bindings with fallbacks)
+ * + setBuffer/setImage overrides for real data + flush().
+ *
+ * Bindings declared as eUniformBufferDynamic get their offset split out of the
+ * descriptor and into the dynamic-offset array (see dynamicOffsets()): setBuffer
+ * writes {buffer, 0, range} into the descriptor and stashes the caller's offset.
+ * That is what lets a set whose only per-draw change is a UBO offset be written
+ * once and rebound many times. Callers must hand dynamicOffsets()/
+ * VulkanDescriptorManager::getDynamicOffsetCount() for a set to
+ * vkCmdBindDescriptorSets when binding it.
+ */
+class DescriptorWriter {
+public:
+	// Fixed capacities for the stack-allocated staging arrays below — NOT Vulkan
+	// hardware limits. They bound a single vkUpdateDescriptorSets batch (one
+	// writeSet), sized to comfortably cover the largest descriptor set layout the
+	// engine builds. Because the backing arrays live on the stack (see m_writes
+	// etc.), the numbers carry no runtime cost beyond that fixed footprint; the
+	// only failure mode is under-sizing, which is Assert-guarded at fill time in
+	// DescriptorWriter::writeSet (e.g. `Assert(m_writeCount < MAX_WRITES)`) so an
+	// oversized layout trips loudly in debug rather than silently overflowing.
+	// Raise these if a future set layout legitimately needs more bindings/infos.
+	static constexpr uint32_t MAX_WRITES = 32;           // distinct bindings written per batch
+	static constexpr uint32_t MAX_BUFFER_INFOS = 20;     // buffer descriptors staged per batch
+	static constexpr uint32_t MAX_IMAGE_INFOS = 24;      // image/sampler descriptors staged per batch
+	static constexpr uint32_t MAX_ACCEL_STRUCT_INFOS = 2; // TLAS descriptors staged per batch (RT)
+	static constexpr uint32_t MAX_BINDINGS_PER_SET = 16; // highest binding number addressable in a set
+	// Most dynamic (eUniformBufferDynamic) bindings any one set layout declares. Derived from
+	// the templates rather than counted by hand, so adding a dynamic binding resizes the
+	// storage that holds its offset automatically.
+	static constexpr uint32_t MAX_DYNAMIC_OFFSETS_PER_SET =
+		MATERIAL_DYNAMIC_OFFSET_COUNT > PERDRAW_DYNAMIC_OFFSET_COUNT ? MATERIAL_DYNAMIC_OFFSET_COUNT
+																	 : PERDRAW_DYNAMIC_OFFSET_COUNT;
+
+	void reset(vk::Device device, const DescriptorFallbacks& fallbacks) {
+		m_device = device;
+		m_fallbacks = &fallbacks;
+		m_writeCount = 0;
+		m_bufferInfoCount = 0;
+		m_imageInfoCount = 0;
+		m_accelStructInfoCount = 0;
+		m_dynOffsets = {};
+	}
+
+	void writeSet(DescriptorSetIndex setIndex, vk::DescriptorSet set);
+
+	void setBuffer(uint32_t binding, const vk::DescriptorBufferInfo& info);
+	void setImage(uint32_t binding, const vk::DescriptorImageInfo& info);
+	void setImageArray(uint32_t binding, ArrayView<vk::DescriptorImageInfo> infos);
+
+	/**
+	 * @brief Dynamic offsets accumulated for a single set, ordered by binding number.
+	 *
+	 * Only meaningful for a set this writer actually wrote; a set reused from a
+	 * memoization cache was not written here, so its caller owns the offsets.
+	 * Always sized to the set layout's dynamic descriptor count (offsets for
+	 * bindings left at their fallback stay 0). Points at stable per-set storage —
+	 * valid until the next writeSet() of that set.
+	 */
+	const uint32_t* dynamicOffsets(DescriptorSetIndex setIndex) const
+	{
+		return m_dynOffsets[static_cast<size_t>(setIndex)].data();
+	}
+
+	/**
+	 * @brief Binds a contiguous run of sets in one vkCmdBindDescriptorSets call
+	 *
+	 * Concatenates the run's dynamic offsets in set order, which is the layout
+	 * vkCmdBindDescriptorSets expects: each set contributes exactly its layout's
+	 * dynamic descriptor count (a set declaring none contributes nothing, rather
+	 * than padding). @c sets must list the sets for @c firstSet onwards, in order.
+	 *
+	 * Binding here rather than handing the offsets back to the caller keeps the
+	 * concatenation buffer's lifetime contained: it is writer-owned scratch, reused
+	 * by the next call, and never outlives the command it was built for.
+	 */
+	void bindSets(vk::CommandBuffer cmd,
+		vk::PipelineLayout layout,
+		DescriptorSetIndex firstSet,
+		ArrayView<vk::DescriptorSet> sets);
+
+	void flush(); // defined in VulkanDescriptorManager.cpp (reports write stats to the manager)
+
+private:
+	// Per-binding lookup for the current writeSet, indexed by binding number.
+	// Populated by writeSet, used by setBuffer/setImage/setImageArray for O(1) access.
+	struct BindingSlot {
+		vk::DescriptorBufferInfo* bufferInfo = nullptr;  // non-null for buffer bindings
+		vk::DescriptorImageInfo* imageInfo = nullptr;    // non-null for image bindings
+		uint32_t count = 0;                              // descriptor count (1 or 16 for arrays)
+		vk::ImageViewType viewType = vk::ImageViewType::e2D;  // for fallback lookup
+		int dynIndex = -1;                                    // slot in m_dynOffsets, or -1 if not dynamic
+	};
+
+	vk::Device m_device;
+	const DescriptorFallbacks* m_fallbacks = nullptr;
+
+	std::array<vk::WriteDescriptorSet, MAX_WRITES> m_writes;
+	std::array<vk::DescriptorBufferInfo, MAX_BUFFER_INFOS> m_bufferInfos;
+	std::array<vk::DescriptorImageInfo, MAX_IMAGE_INFOS> m_imageInfos;
+	std::array<vk::AccelerationStructureKHR, MAX_ACCEL_STRUCT_INFOS> m_accelStructInfos;
+	std::array<vk::WriteDescriptorSetAccelerationStructureKHR, MAX_ACCEL_STRUCT_INFOS> m_asWriteInfos;
+	std::array<BindingSlot, MAX_BINDINGS_PER_SET> m_bindingSlots;
+	std::array<std::array<uint32_t, MAX_DYNAMIC_OFFSETS_PER_SET>, static_cast<size_t>(DescriptorSetIndex::Count)>
+		m_dynOffsets{};
+	// Scratch used by bindSets() to concatenate a run of sets' offsets.
+	std::array<uint32_t, static_cast<size_t>(DescriptorSetIndex::Count) * MAX_DYNAMIC_OFFSETS_PER_SET>
+		m_dynOffsetScratch{};
+	DescriptorSetIndex m_currentSet = DescriptorSetIndex::Global;
+	uint32_t m_writeCount = 0;
+	uint32_t m_bufferInfoCount = 0;
+	uint32_t m_imageInfoCount = 0;
+	uint32_t m_accelStructInfoCount = 0;
+};
 
 /**
  * @brief Manages Vulkan descriptor sets, pools, and layouts

--- a/code/graphics/vulkan/VulkanDraw.cpp
+++ b/code/graphics/vulkan/VulkanDraw.cpp
@@ -686,8 +686,12 @@ void VulkanDrawManager::renderModel(model_material* material_info, indexed_verte
 	stateTracker->getCommandBuffer().drawIndexed(dp.indexCount, 1, dp.firstIndex, dp.baseVertex, 0);
 }
 
-void VulkanDrawManager::renderShadowDraw(gr_buffer_handle ubo_handle, size_t ubo_offset, size_t ubo_size,
-                                          vertex_buffer* buffer, indexed_vertex_source* vert_src, size_t texi) const
+void VulkanDrawManager::renderShadowDraw(gr_buffer_handle ubo_handle,
+	size_t ubo_offset,
+	size_t ubo_size,
+	vertex_buffer* buffer,
+	indexed_vertex_source* vert_src,
+	size_t texi)
 {
 	if (!buffer || !vert_src) {
 		return;
@@ -754,51 +758,89 @@ void VulkanDrawManager::renderShadowDraw(gr_buffer_handle ubo_handle, size_t ubo
 	// (bound separately, per-frame, via shadow_cascade_params_bind) both live in
 	// the fixed 3-tier layout alongside the batched-submodel transform buffer;
 	// no material textures are needed for depth-only rendering.
+	//
+	// All three sets are memoized across the shadow pass (see m_cachedShadowSets).
+	// ShadowMapData is a dynamic binding, so the only thing that changes from one
+	// shadow draw to the next -- its UBO offset -- rides in the dynamic-offset array
+	// and leaves the set contents untouched. Without that this path allocated and
+	// fully rewrote three descriptor sets per shadow draw, times the cascade count.
 	{
-		DescriptorWriter writer;
-		writer.reset(descManager->getDevice(), descManager->getFallbacks());
-
-		vk::DescriptorSet globalSet = descManager->allocateFrameSet(DescriptorSetIndex::Global);
-		Assert(globalSet);
-		writer.writeSet(globalSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Global));
+		ShadowSetInputs shadowInputs;
 		{
-			const auto& pending = getPendingUniformBinding(static_cast<size_t>(uniform_block_type::ShadowCascadeParams));
-			if (pending.valid) {
-				vk::Buffer buf = bufferManager->getVkBuffer(pending.bufferHandle);
+			const auto& cascade =
+				getPendingUniformBinding(static_cast<size_t>(uniform_block_type::ShadowCascadeParams));
+			shadowInputs.cascadeHandle = cascade.bufferHandle.value();
+			shadowInputs.cascadeOffset = cascade.offset;
+			shadowInputs.cascadeSize = cascade.size;
+			shadowInputs.cascadeValid = cascade.valid;
+			shadowInputs.shadowDataHandle = ubo_handle.value();
+			shadowInputs.shadowDataSize = ubo_size; // offset is dynamic, so not part of the key
+			auto& tf = g_transformBuffers[descManager->getCurrentFrame()];
+			if (tf.buffer && tf.lastUploadSize > 0) {
+				shadowInputs.transformBuffer = tf.buffer;
+				shadowInputs.transformOffset = tf.lastUploadOffset;
+				shadowInputs.transformSize = tf.lastUploadSize;
+			}
+		}
+
+		if (!m_cachedShadowValid || shadowInputs != m_cachedShadowInputs) {
+			DescriptorWriter writer;
+			writer.reset(descManager->getDevice(), descManager->getFallbacks());
+
+			m_cachedShadowGlobalSet = descManager->allocateFrameSet(DescriptorSetIndex::Global);
+			Assert(m_cachedShadowGlobalSet);
+			writer.writeSet(DescriptorSetIndex::Global, m_cachedShadowGlobalSet);
+			if (shadowInputs.cascadeValid) {
+				vk::Buffer buf = bufferManager->getVkBuffer(gr_buffer_handle(shadowInputs.cascadeHandle));
 				if (buf) {
-					writer.setBuffer(GlobalBinding::ShadowCascadeParams, {buf, pending.offset, pending.size});
+					writer.setBuffer(GlobalBinding::ShadowCascadeParams,
+						{buf, shadowInputs.cascadeOffset, shadowInputs.cascadeSize});
 				}
 			}
-		}
 
-		vk::DescriptorSet materialSet = descManager->allocateFrameSet(DescriptorSetIndex::Material);
-		Assert(materialSet);
-		writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
-		{
-			vk::Buffer buf = bufferManager->getVkBuffer(ubo_handle);
-			if (buf) {
-				writer.setBuffer(MaterialBinding::ShadowMapData,
-					{buf, static_cast<vk::DeviceSize>(ubo_offset), static_cast<vk::DeviceSize>(ubo_size)});
+			m_cachedShadowMaterialSet = descManager->allocateFrameSet(DescriptorSetIndex::Material);
+			Assert(m_cachedShadowMaterialSet);
+			writer.writeSet(DescriptorSetIndex::Material, m_cachedShadowMaterialSet);
+			{
+				vk::Buffer buf = bufferManager->getVkBuffer(ubo_handle);
+				if (buf) {
+					// Offset 0: the real offset is supplied per draw as a dynamic offset.
+					writer.setBuffer(MaterialBinding::ShadowMapData, {buf, 0, static_cast<vk::DeviceSize>(ubo_size)});
+				}
 			}
-		}
-		{
-			uint32_t tfIdx = descManager->getCurrentFrame();
-			auto& tf = g_transformBuffers[tfIdx];
-			if (tf.buffer && tf.lastUploadSize > 0) {
-				writer.setBuffer(MaterialBinding::TransformSSBO, {tf.buffer,
-				                 static_cast<vk::DeviceSize>(tf.lastUploadOffset),
-				                 static_cast<vk::DeviceSize>(tf.lastUploadSize)});
+			if (shadowInputs.transformBuffer) {
+				writer.setBuffer(MaterialBinding::TransformSSBO,
+					{shadowInputs.transformBuffer,
+						static_cast<vk::DeviceSize>(shadowInputs.transformOffset),
+						static_cast<vk::DeviceSize>(shadowInputs.transformSize)});
 			}
+
+			m_cachedShadowPerDrawSet = descManager->allocateFrameSet(DescriptorSetIndex::PerDraw);
+			Assert(m_cachedShadowPerDrawSet);
+			writer.writeSet(DescriptorSetIndex::PerDraw, m_cachedShadowPerDrawSet);
+			writer.flush();
+
+			m_cachedShadowInputs = shadowInputs;
+			m_cachedShadowValid = true;
 		}
 
-		vk::DescriptorSet perDrawSet = descManager->allocateFrameSet(DescriptorSetIndex::PerDraw);
-		Assert(perDrawSet);
-		writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
-		writer.flush();
+		// applyMaterial's caches deliberately are NOT invalidated here. They record
+		// what a descriptor set *contains*, and the shadow pass allocates its own
+		// sets rather than overwriting theirs. Which set is currently bound is
+		// tracked separately by VulkanStateTracker, and this path binds through it,
+		// so the next applyMaterial cache hit still rebinds its set correctly. (That
+		// is what separates this from the ImGui case invalidateDrawStateCaches()
+		// exists for: ImGui binds on the command buffer behind the tracker's back.)
 
-		stateTracker->bindDescriptorSet(DescriptorSetIndex::Global, globalSet);
-		stateTracker->bindDescriptorSet(DescriptorSetIndex::Material, materialSet);
-		stateTracker->bindDescriptorSet(DescriptorSetIndex::PerDraw, perDrawSet);
+		const uint32_t materialDynOffsets[2] = {
+			0,                                 // MaterialBinding::ModelData (unused here)
+			static_cast<uint32_t>(ubo_offset), // MaterialBinding::ShadowMapData
+		};
+		static constexpr uint32_t perDrawDynOffsets[2] = {0, 0};
+
+		stateTracker->bindDescriptorSet(DescriptorSetIndex::Global, m_cachedShadowGlobalSet);
+		stateTracker->bindDescriptorSet(DescriptorSetIndex::Material, m_cachedShadowMaterialSet, materialDynOffsets);
+		stateTracker->bindDescriptorSet(DescriptorSetIndex::PerDraw, m_cachedShadowPerDrawSet, perDrawDynOffsets);
 	}
 
 	vk::Buffer vbuffer = bufferManager->getVkBuffer(vert_src->Vbuffer_handle);
@@ -960,6 +1002,10 @@ void VulkanDrawManager::resetFrameStats()
 	m_cachedMaterialValid = false;
 	m_cachedPerDrawSet = nullptr;
 	m_cachedPerDrawValid = false;
+	m_cachedShadowGlobalSet = nullptr;
+	m_cachedShadowMaterialSet = nullptr;
+	m_cachedShadowPerDrawSet = nullptr;
+	m_cachedShadowValid = false;
 }
 
 void VulkanDrawManager::printFrameStats()
@@ -1345,6 +1391,30 @@ bool VulkanDrawManager::applyMaterial(material* mat, primitive_type prim_type, v
 			}
 		};
 
+		// Dynamic offsets for the Material/PerDraw sets, ordered by binding number.
+		// Computed here rather than read back from the writer because the whole point
+		// of the dynamic bindings is that these change on draws where the set itself
+		// is reused from cache and never written.
+		const auto dynOffsetOf = [&](uniform_block_type blockType) -> uint32_t {
+			const auto& pending = m_pendingUniformBindings[static_cast<size_t>(blockType)];
+			if (!pending.valid || !bufferManager->getVkBuffer(pending.bufferHandle)) {
+				return 0; // falls back to the dummy buffer, which is bound at offset 0
+			}
+			return static_cast<uint32_t>(pending.offset);
+		};
+		// ShadowMapData is never bound on this path, so its descriptor still holds the
+		// fallback buffer and its dynamic offset must stay 0: the fallback is bound as
+		// {buffer, 0, FALLBACK_UNIFORM_BUFFER_SIZE}, i.e. spanning the whole buffer, so
+		// any non-zero dynamic offset would push offset+range past the end of it.
+		const uint32_t materialDynOffsets[2] = {
+			dynOffsetOf(uniform_block_type::ModelData), // MaterialBinding::ModelData
+			0,                                          // MaterialBinding::ShadowMapData (shadow pass only)
+		};
+		const uint32_t perDrawDynOffsets[2] = {
+			dynOffsetOf(uniform_block_type::GenericData), // PerDrawBinding::GenericData
+			dynOffsetOf(uniform_block_type::Matrices),    // PerDrawBinding::Matrices
+		};
+
 		// Set 0: Global (memoized per frame — see m_cachedGlobalSet). Rebuilt only
 		// when a Global input changed: a pending Global UBO (m_globalSetDirty set in
 		// setPendingUniformBinding), the shadow TLAS (invalidateGlobalSet from
@@ -1356,7 +1426,7 @@ bool VulkanDrawManager::applyMaterial(material* mat, primitive_type prim_type, v
 		if (m_globalSetDirty || !m_cachedGlobalSet || shadowReady != m_cachedGlobalHadShadow) {
 			m_cachedGlobalSet = descManager->allocateFrameSet(DescriptorSetIndex::Global);
 			Assert(m_cachedGlobalSet);
-			writer.writeSet(m_cachedGlobalSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Global));
+			writer.writeSet(DescriptorSetIndex::Global, m_cachedGlobalSet);
 			bindPendingUBOs(DescriptorSetIndex::Global);
 			if (shadowReady) {
 				writer.setImage(GlobalBinding::ShadowMap, pp->getShadowTextureInfo());
@@ -1393,9 +1463,14 @@ bool VulkanDrawManager::applyMaterial(material* mat, primitive_type prim_type, v
 		matInputs.sceneColorInfo = m_sceneColorInfo;
 		matInputs.distMapInfo = m_distMapInfo;
 		{
+			// ModelData's offset is deliberately NOT part of the key: it is a dynamic
+			// binding, so an offset-only change is carried by materialDynOffsets and
+			// leaves the set's contents identical. Buffer and size still matter --
+			// both live in the descriptor.
 			const auto& md = m_pendingUniformBindings[static_cast<size_t>(uniform_block_type::ModelData)];
 			const auto& dg = m_pendingUniformBindings[static_cast<size_t>(uniform_block_type::DecalGlobals)];
-			matInputs.uboHandle[0] = md.bufferHandle.value(); matInputs.uboOffset[0] = md.offset;
+			matInputs.uboHandle[0] = md.bufferHandle.value();
+			matInputs.uboOffset[0] = 0;
 			matInputs.uboSize[0] = md.size; matInputs.uboValid[0] = md.valid;
 			matInputs.uboHandle[1] = dg.bufferHandle.value(); matInputs.uboOffset[1] = dg.offset;
 			matInputs.uboSize[1] = dg.size; matInputs.uboValid[1] = dg.valid;
@@ -1409,7 +1484,7 @@ bool VulkanDrawManager::applyMaterial(material* mat, primitive_type prim_type, v
 		} else {
 			materialSet = descManager->allocateFrameSet(DescriptorSetIndex::Material);
 			Assert(materialSet);
-			writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+			writer.writeSet(DescriptorSetIndex::Material, materialSet);
 			bindPendingUBOs(DescriptorSetIndex::Material);
 			if (matInputs.transformBuffer) {
 				writer.setBuffer(MaterialBinding::TransformSSBO,
@@ -1436,7 +1511,9 @@ bool VulkanDrawManager::applyMaterial(material* mat, primitive_type prim_type, v
 			for (int i = 0; i < NUM_PERDRAW_UBOS; ++i) {
 				const auto& p = m_pendingUniformBindings[static_cast<size_t>(pdTypes[i])];
 				pdInputs.uboHandle[i] = p.bufferHandle.value();
-				pdInputs.uboOffset[i] = p.offset;
+				// GenericData (0) and Matrices (1) are dynamic bindings — their offset
+				// rides in perDrawDynOffsets and is not part of the set's contents.
+				pdInputs.uboOffset[i] = (i <= 1) ? 0 : p.offset;
 				pdInputs.uboSize[i] = p.size;
 				pdInputs.uboValid[i] = p.valid;
 			}
@@ -1448,7 +1525,7 @@ bool VulkanDrawManager::applyMaterial(material* mat, primitive_type prim_type, v
 		} else {
 			perDrawSet = descManager->allocateFrameSet(DescriptorSetIndex::PerDraw);
 			Assert(perDrawSet);
-			writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+			writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 			bindPendingUBOs(DescriptorSetIndex::PerDraw);
 			m_cachedPerDrawSet = perDrawSet;
 			m_cachedPerDrawInputs = pdInputs;
@@ -1456,8 +1533,8 @@ bool VulkanDrawManager::applyMaterial(material* mat, primitive_type prim_type, v
 		}
 		writer.flush();
 		stateTracker->bindDescriptorSet(DescriptorSetIndex::Global, globalSet);
-		stateTracker->bindDescriptorSet(DescriptorSetIndex::Material, materialSet);
-		stateTracker->bindDescriptorSet(DescriptorSetIndex::PerDraw, perDrawSet);
+		stateTracker->bindDescriptorSet(DescriptorSetIndex::Material, materialSet, materialDynOffsets);
+		stateTracker->bindDescriptorSet(DescriptorSetIndex::PerDraw, perDrawSet, perDrawDynOffsets);
 	}
 
 	// Update tracked state for FSO compatibility

--- a/code/graphics/vulkan/VulkanDraw.cpp
+++ b/code/graphics/vulkan/VulkanDraw.cpp
@@ -832,11 +832,12 @@ void VulkanDrawManager::renderShadowDraw(gr_buffer_handle ubo_handle,
 		// is what separates this from the ImGui case invalidateDrawStateCaches()
 		// exists for: ImGui binds on the command buffer behind the tracker's back.)
 
-		const uint32_t materialDynOffsets[2] = {
-			0,                                 // MaterialBinding::ModelData (unused here)
-			static_cast<uint32_t>(ubo_offset), // MaterialBinding::ShadowMapData
-		};
-		static constexpr uint32_t perDrawDynOffsets[2] = {0, 0};
+		// ShadowMapData is the one thing that moves per shadow draw; every other dynamic binding
+		// on this path holds the fallback buffer and so must stay at offset 0.
+		uint32_t materialDynOffsets[MATERIAL_DYNAMIC_OFFSET_COUNT] = {};
+		materialDynOffsets[MaterialDynamicSlot::ShadowMapData] = static_cast<uint32_t>(ubo_offset);
+
+		static constexpr uint32_t perDrawDynOffsets[PERDRAW_DYNAMIC_OFFSET_COUNT] = {};
 
 		stateTracker->bindDescriptorSet(DescriptorSetIndex::Global, m_cachedShadowGlobalSet);
 		stateTracker->bindDescriptorSet(DescriptorSetIndex::Material, m_cachedShadowMaterialSet, materialDynOffsets);
@@ -1402,18 +1403,16 @@ bool VulkanDrawManager::applyMaterial(material* mat, primitive_type prim_type, v
 			}
 			return static_cast<uint32_t>(pending.offset);
 		};
-		// ShadowMapData is never bound on this path, so its descriptor still holds the
-		// fallback buffer and its dynamic offset must stay 0: the fallback is bound as
-		// {buffer, 0, FALLBACK_UNIFORM_BUFFER_SIZE}, i.e. spanning the whole buffer, so
-		// any non-zero dynamic offset would push offset+range past the end of it.
-		const uint32_t materialDynOffsets[2] = {
-			dynOffsetOf(uniform_block_type::ModelData), // MaterialBinding::ModelData
-			0,                                          // MaterialBinding::ShadowMapData (shadow pass only)
-		};
-		const uint32_t perDrawDynOffsets[2] = {
-			dynOffsetOf(uniform_block_type::GenericData), // PerDrawBinding::GenericData
-			dynOffsetOf(uniform_block_type::Matrices),    // PerDrawBinding::Matrices
-		};
+		// Zero-initialized, then filled by name: MaterialDynamicSlot::ShadowMapData is left at 0
+		// because ShadowMapData is never bound on this path, so its descriptor still holds the
+		// fallback buffer -- bound as {buffer, 0, FALLBACK_UNIFORM_BUFFER_SIZE}, i.e. spanning the
+		// whole buffer, so any non-zero dynamic offset would push offset+range past the end of it.
+		uint32_t materialDynOffsets[MATERIAL_DYNAMIC_OFFSET_COUNT] = {};
+		materialDynOffsets[MaterialDynamicSlot::ModelData] = dynOffsetOf(uniform_block_type::ModelData);
+
+		uint32_t perDrawDynOffsets[PERDRAW_DYNAMIC_OFFSET_COUNT] = {};
+		perDrawDynOffsets[PerDrawDynamicSlot::GenericData] = dynOffsetOf(uniform_block_type::GenericData);
+		perDrawDynOffsets[PerDrawDynamicSlot::Matrices] = dynOffsetOf(uniform_block_type::Matrices);
 
 		// Set 0: Global (memoized per frame — see m_cachedGlobalSet). Rebuilt only
 		// when a Global input changed: a pending Global UBO (m_globalSetDirty set in

--- a/code/graphics/vulkan/VulkanDraw.h
+++ b/code/graphics/vulkan/VulkanDraw.h
@@ -287,6 +287,25 @@ class VulkanDrawManager {
 	void invalidateGlobalSet() { m_globalSetDirty = true; }
 
 	/**
+	 * @brief Invalidate every memoized descriptor-set cache (Global + Material + PerDraw)
+	 *
+	 * These previous-set caches (see the class comments above m_cachedGlobalSet /
+	 * m_cachedMaterialSet / m_cachedPerDrawSet) assume nothing rebinds a *different*
+	 * descriptor set on the command buffer between applyMaterial() calls behind their
+	 * back. Code that renders directly on the command buffer without going through
+	 * applyMaterial (currently: ImGui's Vulkan backend, drawing into the same active
+	 * composition pass) breaks that assumption -- call this right afterward, alongside
+	 * VulkanStateTracker::invalidateExternalBindings(), so the next applyMaterial() rebuilds
+	 * and rebinds every set instead of trusting stale cached handles.
+	 */
+	void invalidateDrawStateCaches()
+	{
+		m_globalSetDirty = true;
+		m_cachedMaterialValid = false;
+		m_cachedPerDrawValid = false;
+	}
+
+	/**
 	 * @brief Get current texture addressing mode
 	 */
 	int getTextureAddressing() const
@@ -449,6 +468,14 @@ class VulkanDrawManager {
 	mutable FrameStats m_frameStats;
 	int m_frameStatsFrameNum = 0;
 
+  public:
+	/**
+	 * @brief Read-only access to this frame's diagnostic counters, e.g. for the ImGui profiler
+	 * overlay's -gr_debug section (see printFrameStats() for the nprintf equivalent)
+	 */
+	const FrameStats& getFrameStats() const { return m_frameStats; }
+
+  private:
 	// First-N debug-log counter for on-demand texture binds; a member rather
 	// than a function-local static so it resets on renderer restart. mutable because
 	// bindMaterialTextures is const. Gates nprintf spam only.

--- a/code/graphics/vulkan/VulkanDraw.h
+++ b/code/graphics/vulkan/VulkanDraw.h
@@ -212,7 +212,7 @@ class VulkanDrawManager {
 		size_t ubo_size,
 		vertex_buffer* buffer,
 		indexed_vertex_source* vert_src,
-		size_t texi) const;
+		size_t texi);
 
 	/**
 	 * @brief Draw a unit sphere with the given material
@@ -303,6 +303,7 @@ class VulkanDrawManager {
 		m_globalSetDirty = true;
 		m_cachedMaterialValid = false;
 		m_cachedPerDrawValid = false;
+		m_cachedShadowValid = false;
 	}
 
 	/**
@@ -566,6 +567,41 @@ class VulkanDrawManager {
 	vk::DescriptorSet m_cachedPerDrawSet = nullptr;
 	PerDrawSetInputs m_cachedPerDrawInputs;
 	bool m_cachedPerDrawValid = false;
+
+	// ---- Shadow-pass descriptor memoization (renderShadowDraw) ----
+	// The shadow pass doesn't go through applyMaterial, so it gets its own cache.
+	// All three of its sets are constant across the whole pass: the only per-draw
+	// input, the ShadowMapData UBO offset, is a dynamic binding and therefore not
+	// part of the set contents. Reset per frame with the rest (resetFrameStats).
+	struct ShadowSetInputs {
+		int cascadeHandle = -1;
+		vk::DeviceSize cascadeOffset = 0;
+		vk::DeviceSize cascadeSize = 0;
+		bool cascadeValid = false;
+		int shadowDataHandle = -1;
+		size_t shadowDataSize = 0;
+		vk::Buffer transformBuffer = nullptr;
+		size_t transformOffset = 0;
+		size_t transformSize = 0;
+
+		bool operator==(const ShadowSetInputs& o) const
+		{
+			return cascadeHandle == o.cascadeHandle && cascadeOffset == o.cascadeOffset &&
+				   cascadeSize == o.cascadeSize && cascadeValid == o.cascadeValid &&
+				   shadowDataHandle == o.shadowDataHandle && shadowDataSize == o.shadowDataSize &&
+				   transformBuffer == o.transformBuffer && transformOffset == o.transformOffset &&
+				   transformSize == o.transformSize;
+		}
+		bool operator!=(const ShadowSetInputs& o) const
+		{
+			return !(*this == o);
+		}
+	};
+	vk::DescriptorSet m_cachedShadowGlobalSet = nullptr;
+	vk::DescriptorSet m_cachedShadowMaterialSet = nullptr;
+	vk::DescriptorSet m_cachedShadowPerDrawSet = nullptr;
+	ShadowSetInputs m_cachedShadowInputs;
+	bool m_cachedShadowValid = false;
 
 	// Texture overrides for material bindings 4-6.
 	vk::DescriptorImageInfo m_depthTextureInfo; // binding 4: depth/position for soft particles

--- a/code/graphics/vulkan/VulkanDrawAPI.cpp
+++ b/code/graphics/vulkan/VulkanDrawAPI.cpp
@@ -748,12 +748,12 @@ void vulkan_calculate_irrmap()
 		// Set 0: Global (all fallback)
 		vk::DescriptorSet globalSet = descManager->allocateFrameSet(DescriptorSetIndex::Global);
 		Assert(globalSet);
-		writer.writeSet(globalSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Global));
+		writer.writeSet(DescriptorSetIndex::Global, globalSet);
 
 		// Set 1: Material (envmap cubemap at element 0 of texture array)
 		vk::DescriptorSet materialSet = descManager->allocateFrameSet(DescriptorSetIndex::Material);
 		Assert(materialSet);
-		writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+		writer.writeSet(DescriptorSetIndex::Material, materialSet);
 		{
 			std::array<vk::DescriptorImageInfo, VulkanDescriptorManager::MAX_TEXTURE_BINDINGS> texImages;
 			texImages.fill(descManager->getFallbacks().texture2D);
@@ -764,14 +764,18 @@ void vulkan_calculate_irrmap()
 		// Set 2: PerDraw (face UBO at binding 0)
 		vk::DescriptorSet perDrawSet = descManager->allocateFrameSet(DescriptorSetIndex::PerDraw);
 		Assert(perDrawSet);
-		writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+		writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 		writer.setBuffer(PerDrawBinding::GenericData, {faceUBO,
 			static_cast<vk::DeviceSize>(face) * UBO_SLOT_SIZE, UBO_SLOT_SIZE});
 		writer.flush();
 
 		// Bind all descriptor sets
-		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout,
-			0, {globalSet, materialSet, perDrawSet}, {});
+		const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Global, 3);
+		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+			pipelineLayout,
+			0,
+			{globalSet, materialSet, perDrawSet},
+			vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
 
 		// Draw fullscreen triangle
 		cmd.draw(3, 1, 0, 0);

--- a/code/graphics/vulkan/VulkanDrawAPI.cpp
+++ b/code/graphics/vulkan/VulkanDrawAPI.cpp
@@ -770,12 +770,8 @@ void vulkan_calculate_irrmap()
 		writer.flush();
 
 		// Bind all descriptor sets
-		const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Global, 3);
-		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-			pipelineLayout,
-			0,
-			{globalSet, materialSet, perDrawSet},
-			vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
+		const vk::DescriptorSet sets[] = {globalSet, materialSet, perDrawSet};
+		writer.bindSets(cmd, pipelineLayout, DescriptorSetIndex::Global, sets);
 
 		// Draw fullscreen triangle
 		cmd.draw(3, 1, 0, 0);

--- a/code/graphics/vulkan/VulkanMemory.cpp
+++ b/code/graphics/vulkan/VulkanMemory.cpp
@@ -140,7 +140,8 @@ VmaMemoryUsage VulkanMemoryManager::toVmaUsage(MemoryUsage usage)
 	}
 }
 
-bool VulkanMemoryManager::allocateBufferMemory(vk::Buffer buffer, MemoryUsage usage, VulkanAllocation& allocation)
+bool VulkanMemoryManager::allocateBufferMemory(vk::Buffer buffer, MemoryUsage usage, VulkanAllocation& allocation,
+	MemoryPurpose purpose)
 {
 	if (!m_initialized) {
 		nprintf(("vulkan", "VulkanMemoryManager::allocateBufferMemory called before initialization!\n"));
@@ -176,14 +177,17 @@ bool VulkanMemoryManager::allocateBufferMemory(vk::Buffer buffer, MemoryUsage us
 
 	allocation.size = allocInfo.size;
 	allocation.mappedPtr = allocInfo.pMappedData;
+	allocation.purpose = purpose;
 
 	++m_allocationCount;
 	m_totalAllocatedBytes += static_cast<size_t>(allocation.size);
+	m_bytesByPurpose[static_cast<size_t>(purpose)] += static_cast<size_t>(allocation.size);
 
 	return true;
 }
 
-bool VulkanMemoryManager::allocateImageMemory(vk::Image image, MemoryUsage usage, VulkanAllocation& allocation)
+bool VulkanMemoryManager::allocateImageMemory(vk::Image image, MemoryUsage usage, VulkanAllocation& allocation,
+	MemoryPurpose purpose)
 {
 	if (!m_initialized) {
 		nprintf(("vulkan", "VulkanMemoryManager::allocateImageMemory called before initialization!\n"));
@@ -219,9 +223,11 @@ bool VulkanMemoryManager::allocateImageMemory(vk::Image image, MemoryUsage usage
 
 	allocation.size = allocInfo.size;
 	allocation.mappedPtr = allocInfo.pMappedData;
+	allocation.purpose = purpose;
 
 	++m_allocationCount;
 	m_totalAllocatedBytes += static_cast<size_t>(allocation.size);
+	m_bytesByPurpose[static_cast<size_t>(purpose)] += static_cast<size_t>(allocation.size);
 
 	return true;
 }
@@ -242,10 +248,12 @@ void VulkanMemoryManager::freeAllocation(VulkanAllocation& allocation)
 
 	--m_allocationCount;
 	m_totalAllocatedBytes -= static_cast<size_t>(allocation.size);
+	m_bytesByPurpose[static_cast<size_t>(allocation.purpose)] -= static_cast<size_t>(allocation.size);
 
 	allocation.vmaAlloc = VK_NULL_HANDLE;
 	allocation.size = 0;
 	allocation.mappedPtr = nullptr;
+	allocation.purpose = MemoryPurpose::Unknown;
 }
 
 void* VulkanMemoryManager::mapMemory(VulkanAllocation& allocation)

--- a/code/graphics/vulkan/VulkanMemory.h
+++ b/code/graphics/vulkan/VulkanMemory.h
@@ -31,6 +31,19 @@ class VulkanRenderer;
 constexpr uint32_t VulkanApiVersion = VK_API_VERSION_1_2;
 
 /**
+ * @brief What an allocation is used for, for the profiler overlay's per-purpose GPU memory
+ * breakdown. Unknown covers anything not worth categorizing for that panel (transient staging
+ * buffers, uniform buffers -- the latter are already tracked separately via
+ * UniformBufferManager/gr_debug_stats).
+ */
+enum class MemoryPurpose {
+	Unknown,
+	Texture,
+	Geometry,
+	RenderTarget
+};
+
+/**
  * @brief Memory allocation info returned when allocating GPU memory.
  *
  * Wraps a VmaAllocation handle. Callers should use isValid() instead of
@@ -40,6 +53,7 @@ struct VulkanAllocation {
 	VmaAllocation vmaAlloc = VK_NULL_HANDLE;
 	vk::DeviceSize size = 0;
 	void* mappedPtr = nullptr;  // Non-null if memory is persistently mapped
+	MemoryPurpose purpose = MemoryPurpose::Unknown;
 
 	bool isValid() const { return vmaAlloc != VK_NULL_HANDLE; }
 };
@@ -94,18 +108,24 @@ public:
 	 * @param buffer The buffer to allocate memory for
 	 * @param usage The intended memory usage pattern
 	 * @param[out] allocation Output allocation info
+	 * @param purpose What the buffer is used for, for the per-purpose memory breakdown. Defaults
+	 *        to Unknown for callers that don't care about that breakdown (staging buffers, etc).
 	 * @return true on success
 	 */
-	bool allocateBufferMemory(vk::Buffer buffer, MemoryUsage usage, VulkanAllocation& allocation);
+	bool allocateBufferMemory(vk::Buffer buffer, MemoryUsage usage, VulkanAllocation& allocation,
+		MemoryPurpose purpose = MemoryPurpose::Unknown);
 
 	/**
 	 * @brief Allocate memory for an image
 	 * @param image The image to allocate memory for
 	 * @param usage The intended memory usage pattern
 	 * @param[out] allocation Output allocation info
+	 * @param purpose What the image is used for, for the per-purpose memory breakdown. Defaults
+	 *        to Unknown for callers that don't care about that breakdown.
 	 * @return true on success
 	 */
-	bool allocateImageMemory(vk::Image image, MemoryUsage usage, VulkanAllocation& allocation);
+	bool allocateImageMemory(vk::Image image, MemoryUsage usage, VulkanAllocation& allocation,
+		MemoryPurpose purpose = MemoryPurpose::Unknown);
 
 	/**
 	 * @brief Free a previous allocation
@@ -148,6 +168,10 @@ public:
 	size_t getAllocationCount() const { return m_allocationCount; }
 	size_t getTotalAllocatedBytes() const { return m_totalAllocatedBytes; }
 
+	size_t getTextureBytes() const { return m_bytesByPurpose[static_cast<size_t>(MemoryPurpose::Texture)]; }
+	size_t getGeometryBytes() const { return m_bytesByPurpose[static_cast<size_t>(MemoryPurpose::Geometry)]; }
+	size_t getRenderTargetBytes() const { return m_bytesByPurpose[static_cast<size_t>(MemoryPurpose::RenderTarget)]; }
+
 private:
 	static VmaMemoryUsage toVmaUsage(MemoryUsage usage);
 
@@ -155,6 +179,7 @@ private:
 
 	size_t m_allocationCount = 0;
 	size_t m_totalAllocatedBytes = 0;
+	size_t m_bytesByPurpose[4] = {}; // indexed by MemoryPurpose
 
 	bool m_initialized = false;
 };

--- a/code/graphics/vulkan/VulkanPipeline.cpp
+++ b/code/graphics/vulkan/VulkanPipeline.cpp
@@ -394,9 +394,26 @@ vk::UniquePipeline VulkanPipelineManager::createPipeline(const PipelineConfig& c
 	}
 
 	// Input assembly
+	//
+	// Primitive restart is enabled for every topology that permits it, rather than disabled
+	// outright. Metal always performs primitive restart on indexed draws and cannot turn it off, so
+	// MoltenVK rejects a strip/fan pipeline that asks to disable it -- vkCreateGraphicsPipelines
+	// fails with VK_ERROR_FEATURE_NOT_PRESENT ("Metal does not support disabling primitive
+	// restart"). getPipeline() then returns a null pipeline and the draw is skipped, which on macOS
+	// silently dropped the entire 2D/UI/HUD path (gr_bitmap and friends render quads as
+	// PRIM_TYPE_TRISTRIP; see graphics/render.cpp) while leaving ImGui -- which builds its own
+	// TRIANGLE_LIST pipeline -- as the only thing still on screen.
+	//
+	// Enabling it changes nothing for FSO's geometry: an index buffer is promoted to 32-bit as soon
+	// as a mesh reaches USHRT_MAX vertices (VB_FLAG_LARGE_INDEX, see modelinterp.cpp), so 0xFFFF is
+	// never a real 16-bit index, and 0xFFFFFFFF is unreachable for 32-bit ones. Neither restart
+	// sentinel can collide with live index data.
+	//
+	// List topologies must keep it disabled: the spec only allows primitiveRestartEnable on them
+	// with VK_EXT_primitive_topology_list_restart, which FSO does not request.
 	vk::PipelineInputAssemblyStateCreateInfo inputAssembly;
 	inputAssembly.topology = convertPrimitiveType(config.primitiveType);
-	inputAssembly.primitiveRestartEnable = VK_FALSE;
+	inputAssembly.primitiveRestartEnable = topologySupportsPrimitiveRestart(inputAssembly.topology);
 
 	// Viewport state (dynamic)
 	vk::PipelineViewportStateCreateInfo viewportState;

--- a/code/graphics/vulkan/VulkanPostProcessing.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessing.cpp
@@ -645,7 +645,7 @@ void VulkanPostProcessor::blitToSwapChain(vk::CommandBuffer cmd)
 	// Set 1: Material — source texture at array slot 0
 	vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 	Assert(materialSet);
-	writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+	writer.writeSet(DescriptorSetIndex::Material, materialSet);
 	{
 		std::array<vk::DescriptorImageInfo, VulkanDescriptorManager::MAX_TEXTURE_BINDINGS> texArrayInfos;
 		texArrayInfos.fill(descriptorMgr->getFallbacks().texture2D);
@@ -659,7 +659,7 @@ void VulkanPostProcessor::blitToSwapChain(vk::CommandBuffer cmd)
 	// Set 2: PerDraw — tonemapping UBO (from the per-frame scratch ring)
 	vk::DescriptorSet perDrawSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::PerDraw);
 	Assert(perDrawSet);
-	writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+	writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 
 	// LDR path: passthrough (tonemapping already ran). Fallback path: live
 	// parameters from the engine lighting profile.
@@ -690,8 +690,12 @@ void VulkanPostProcessor::blitToSwapChain(vk::CommandBuffer cmd)
 			{m_ctx.scratchRing.buffer(), slotOffset, m_ctx.scratchRing.slotSize()});
 	}
 	writer.flush();
-	stateTracker->bindDescriptorSet(DescriptorSetIndex::Material, materialSet);
-	stateTracker->bindDescriptorSet(DescriptorSetIndex::PerDraw, perDrawSet);
+	stateTracker->bindDescriptorSet(DescriptorSetIndex::Material,
+		materialSet,
+		writer.dynamicOffsets(DescriptorSetIndex::Material));
+	stateTracker->bindDescriptorSet(DescriptorSetIndex::PerDraw,
+		perDrawSet,
+		writer.dynamicOffsets(DescriptorSetIndex::PerDraw));
 
 	// Draw fullscreen triangle (3 vertices from gl_VertexIndex, no vertex buffer)
 	cmd.draw(3, 1, 0, 0);
@@ -758,7 +762,7 @@ void VulkanPostProcessor::encodeToSwapChainPass(vk::CommandBuffer cmd, vk::Rende
 
 	vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 	Assert(materialSet);
-	writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+	writer.writeSet(DescriptorSetIndex::Material, materialSet);
 	{
 		std::array<vk::DescriptorImageInfo, VulkanDescriptorManager::MAX_TEXTURE_BINDINGS> texArrayInfos;
 		texArrayInfos.fill(descriptorMgr->getFallbacks().texture2D);
@@ -769,7 +773,7 @@ void VulkanPostProcessor::encodeToSwapChainPass(vk::CommandBuffer cmd, vk::Rende
 
 	vk::DescriptorSet perDrawSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::PerDraw);
 	Assert(perDrawSet);
-	writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+	writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 	{
 		vk::DeviceSize slotOffset =
 			m_ctx.scratchRing.alloc(descriptorMgr->getCurrentFrame(), uboData, uboSize);
@@ -778,9 +782,12 @@ void VulkanPostProcessor::encodeToSwapChainPass(vk::CommandBuffer cmd, vk::Rende
 	}
 	writer.flush();
 
-	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout,
+	const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
+	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+		pipelineLayout,
 		static_cast<uint32_t>(DescriptorSetIndex::Material),
-		{materialSet, perDrawSet}, {});
+		{materialSet, perDrawSet},
+		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
 
 	cmd.draw(3, 1, 0, 0);
 	cmd.endRenderPass();

--- a/code/graphics/vulkan/VulkanPostProcessing.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessing.cpp
@@ -782,12 +782,8 @@ void VulkanPostProcessor::encodeToSwapChainPass(vk::CommandBuffer cmd, vk::Rende
 	}
 	writer.flush();
 
-	const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
-	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-		pipelineLayout,
-		static_cast<uint32_t>(DescriptorSetIndex::Material),
-		{materialSet, perDrawSet},
-		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
+	const vk::DescriptorSet sets[] = {materialSet, perDrawSet};
+	writer.bindSets(cmd, pipelineLayout, DescriptorSetIndex::Material, sets);
 
 	cmd.draw(3, 1, 0, 0);
 	cmd.endRenderPass();

--- a/code/graphics/vulkan/VulkanPostProcessingBloom.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingBloom.cpp
@@ -170,7 +170,8 @@ bool VulkanBloom::createTargets()
 			return false;
 		}
 
-		if (!m_ctx->memoryManager->allocateImageMemory(m_tex[i].image, MemoryUsage::GpuOnly, m_tex[i].allocation)) {
+		if (!m_ctx->memoryManager->allocateImageMemory(
+				m_tex[i].image, MemoryUsage::GpuOnly, m_tex[i].allocation, MemoryPurpose::RenderTarget)) {
 			nprintf(("vulkan", "VulkanBloom: Failed to allocate bloom image %zu memory!\n", i));
 			return false;
 		}

--- a/code/graphics/vulkan/VulkanPostProcessingCommon.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingCommon.cpp
@@ -204,19 +204,11 @@ void PostProcessContext::drawFullscreenTriangle(vk::CommandBuffer cmd, vk::Rende
 	// contiguous (0,1,2), so when Global is (re)bound here it and Material/PerDraw
 	// go in one call; otherwise Set 0 is left as whatever frame setup bound.
 	if (bindGlobalSet) {
-		const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Global, 3);
-		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-			pipelineLayout,
-			static_cast<uint32_t>(DescriptorSetIndex::Global),
-			{globalSet, materialSet, perDrawSet},
-			vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
+		const vk::DescriptorSet sets[] = {globalSet, materialSet, perDrawSet};
+		writer.bindSets(cmd, pipelineLayout, DescriptorSetIndex::Global, sets);
 	} else {
-		const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
-		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-			pipelineLayout,
-			static_cast<uint32_t>(DescriptorSetIndex::Material),
-			{materialSet, perDrawSet},
-			vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
+		const vk::DescriptorSet sets[] = {materialSet, perDrawSet};
+		writer.bindSets(cmd, pipelineLayout, DescriptorSetIndex::Material, sets);
 	}
 
 	cmd.draw(3, 1, 0, 0);
@@ -305,12 +297,8 @@ void PostProcessContext::drawFullscreenTriangleMulti(vk::CommandBuffer cmd, vk::
 	}
 	writer.flush();
 
-	const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
-	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-		pipelineLayout,
-		static_cast<uint32_t>(DescriptorSetIndex::Material),
-		{materialSet, perDrawSet},
-		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
+	const vk::DescriptorSet sets[] = {materialSet, perDrawSet};
+	writer.bindSets(cmd, pipelineLayout, DescriptorSetIndex::Material, sets);
 
 	cmd.draw(3, 1, 0, 0);
 	cmd.endRenderPass();

--- a/code/graphics/vulkan/VulkanPostProcessingCommon.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingCommon.cpp
@@ -175,13 +175,13 @@ void PostProcessContext::drawFullscreenTriangle(vk::CommandBuffer cmd, vk::Rende
 	if (bindGlobalSet) {
 		globalSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Global);
 		Assert(globalSet);
-		writer.writeSet(globalSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Global));
+		writer.writeSet(DescriptorSetIndex::Global, globalSet);
 	}
 
 	// Set 1: Material
 	vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 	Assert(materialSet);
-	writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+	writer.writeSet(DescriptorSetIndex::Material, materialSet);
 	{
 		std::array<vk::DescriptorImageInfo, VulkanDescriptorManager::MAX_TEXTURE_BINDINGS> texArrayInfos;
 		texArrayInfos.fill(descriptorMgr->getFallbacks().texture2D);
@@ -193,7 +193,7 @@ void PostProcessContext::drawFullscreenTriangle(vk::CommandBuffer cmd, vk::Rende
 	// Set 2: PerDraw
 	vk::DescriptorSet perDrawSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::PerDraw);
 	Assert(perDrawSet);
-	writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+	writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 	if (uboData != nullptr && uboSize > 0 && scratchRing.isValid()) {
 		vk::DeviceSize slotOffset = scratchRing.alloc(descriptorMgr->getCurrentFrame(), uboData, uboSize);
 		writer.setBuffer(PerDrawBinding::GenericData, {scratchRing.buffer(), slotOffset, scratchRing.slotSize()});
@@ -204,13 +204,19 @@ void PostProcessContext::drawFullscreenTriangle(vk::CommandBuffer cmd, vk::Rende
 	// contiguous (0,1,2), so when Global is (re)bound here it and Material/PerDraw
 	// go in one call; otherwise Set 0 is left as whatever frame setup bound.
 	if (bindGlobalSet) {
-		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout,
+		const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Global, 3);
+		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+			pipelineLayout,
 			static_cast<uint32_t>(DescriptorSetIndex::Global),
-			{globalSet, materialSet, perDrawSet}, {});
+			{globalSet, materialSet, perDrawSet},
+			vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
 	} else {
-		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout,
+		const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
+		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+			pipelineLayout,
 			static_cast<uint32_t>(DescriptorSetIndex::Material),
-			{materialSet, perDrawSet}, {});
+			{materialSet, perDrawSet},
+			vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
 	}
 
 	cmd.draw(3, 1, 0, 0);
@@ -280,7 +286,7 @@ void PostProcessContext::drawFullscreenTriangleMulti(vk::CommandBuffer cmd, vk::
 
 	vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 	Assert(materialSet);
-	writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+	writer.writeSet(DescriptorSetIndex::Material, materialSet);
 	{
 		std::array<vk::DescriptorImageInfo, VulkanDescriptorManager::MAX_TEXTURE_BINDINGS> texArrayInfos;
 		texArrayInfos.fill(descriptorMgr->getFallbacks().texture2D);
@@ -292,16 +298,19 @@ void PostProcessContext::drawFullscreenTriangleMulti(vk::CommandBuffer cmd, vk::
 
 	vk::DescriptorSet perDrawSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::PerDraw);
 	Assert(perDrawSet);
-	writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+	writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 	if (uboData != nullptr && uboSize > 0 && scratchRing.isValid()) {
 		vk::DeviceSize slotOffset = scratchRing.alloc(descriptorMgr->getCurrentFrame(), uboData, uboSize);
 		writer.setBuffer(PerDrawBinding::GenericData, {scratchRing.buffer(), slotOffset, scratchRing.slotSize()});
 	}
 	writer.flush();
 
-	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout,
+	const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
+	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+		pipelineLayout,
 		static_cast<uint32_t>(DescriptorSetIndex::Material),
-		{materialSet, perDrawSet}, {});
+		{materialSet, perDrawSet},
+		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
 
 	cmd.draw(3, 1, 0, 0);
 	cmd.endRenderPass();

--- a/code/graphics/vulkan/VulkanPostProcessingCommon.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingCommon.cpp
@@ -333,7 +333,7 @@ bool PostProcessContext::createImage(uint32_t width, uint32_t height, vk::Format
 	}
 
 	// Allocate memory
-	if (!memoryManager->allocateImageMemory(outImage, MemoryUsage::GpuOnly, outAllocation)) {
+	if (!memoryManager->allocateImageMemory(outImage, MemoryUsage::GpuOnly, outAllocation, MemoryPurpose::RenderTarget)) {
 		nprintf(("vulkan", "VulkanPostProcessor: Failed to allocate image memory!\n"));
 		device.destroyImage(outImage);
 		outImage = nullptr;

--- a/code/graphics/vulkan/VulkanPostProcessingFog.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingFog.cpp
@@ -419,7 +419,8 @@ void VulkanFog::renderVolumetric(vk::CommandBuffer cmd)
 			return;
 		}
 
-		Verification(m_ctx->memoryManager->allocateImageMemory(m_emissiveMipmapped.image, MemoryUsage::GpuOnly, m_emissiveMipmapped.allocation),
+		Verification(m_ctx->memoryManager->allocateImageMemory(m_emissiveMipmapped.image, MemoryUsage::GpuOnly,
+			m_emissiveMipmapped.allocation, MemoryPurpose::RenderTarget),
 			"Failed to allocate memory for mipmapped emissive image");
 
 		// Create full-mip-chain view for LOD sampling

--- a/code/graphics/vulkan/VulkanPostProcessingFog.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingFog.cpp
@@ -326,12 +326,8 @@ void VulkanFog::renderScene(vk::CommandBuffer cmd)
 	writer.flush();
 
 	// Bind descriptor sets and draw
-	const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
-	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-		pipelineLayout,
-		static_cast<uint32_t>(DescriptorSetIndex::Material),
-		{materialSet, perDrawSet},
-		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
+	const vk::DescriptorSet sets[] = {materialSet, perDrawSet};
+	writer.bindSets(cmd, pipelineLayout, DescriptorSetIndex::Material, sets);
 
 	cmd.draw(3, 1, 0, 0);
 	cmd.endRenderPass();
@@ -651,12 +647,8 @@ void VulkanFog::renderVolumetric(vk::CommandBuffer cmd)
 	writer.flush();
 
 	// Bind descriptor sets and draw
-	const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
-	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-		pipelineLayout,
-		static_cast<uint32_t>(DescriptorSetIndex::Material),
-		{materialSet, perDrawSet},
-		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
+	const vk::DescriptorSet sets[] = {materialSet, perDrawSet};
+	writer.bindSets(cmd, pipelineLayout, DescriptorSetIndex::Material, sets);
 
 	cmd.draw(3, 1, 0, 0);
 	cmd.endRenderPass();

--- a/code/graphics/vulkan/VulkanPostProcessingFog.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingFog.cpp
@@ -304,7 +304,7 @@ void VulkanFog::renderScene(vk::CommandBuffer cmd)
 	// Set 1: Material
 	vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 	Assert(materialSet);
-	writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+	writer.writeSet(DescriptorSetIndex::Material, materialSet);
 	{
 		std::array<vk::DescriptorImageInfo, VulkanDescriptorManager::MAX_TEXTURE_BINDINGS> texArrayInfos;
 		texArrayInfos.fill(descriptorMgr->getFallbacks().texture2D);
@@ -316,7 +316,7 @@ void VulkanFog::renderScene(vk::CommandBuffer cmd)
 	// Set 2: PerDraw — fog UBO (from the per-frame scratch ring)
 	vk::DescriptorSet perDrawSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::PerDraw);
 	Assert(perDrawSet);
-	writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+	writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 	{
 		vk::DeviceSize slotOffset =
 			m_ctx->scratchRing.alloc(descriptorMgr->getCurrentFrame(), &fogData, sizeof(fogData));
@@ -326,9 +326,12 @@ void VulkanFog::renderScene(vk::CommandBuffer cmd)
 	writer.flush();
 
 	// Bind descriptor sets and draw
-	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout,
+	const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
+	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+		pipelineLayout,
 		static_cast<uint32_t>(DescriptorSetIndex::Material),
-		{materialSet, perDrawSet}, {});
+		{materialSet, perDrawSet},
+		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
 
 	cmd.draw(3, 1, 0, 0);
 	cmd.endRenderPass();
@@ -614,7 +617,7 @@ void VulkanFog::renderVolumetric(vk::CommandBuffer cmd)
 	// Set 1: Material
 	vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 	Assert(materialSet);
-	writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+	writer.writeSet(DescriptorSetIndex::Material, materialSet);
 	{
 		std::array<vk::DescriptorImageInfo, VulkanDescriptorManager::MAX_TEXTURE_BINDINGS> texArrayInfos;
 		texArrayInfos.fill(descriptorMgr->getFallbacks().texture2D);
@@ -638,7 +641,7 @@ void VulkanFog::renderVolumetric(vk::CommandBuffer cmd)
 	// Set 2: PerDraw — volumetric fog UBO (from the per-frame scratch ring)
 	vk::DescriptorSet perDrawSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::PerDraw);
 	Assert(perDrawSet);
-	writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+	writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 	{
 		vk::DeviceSize slotOffset =
 			m_ctx->scratchRing.alloc(descriptorMgr->getCurrentFrame(), &volData, sizeof(volData));
@@ -648,9 +651,12 @@ void VulkanFog::renderVolumetric(vk::CommandBuffer cmd)
 	writer.flush();
 
 	// Bind descriptor sets and draw
-	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout,
+	const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Material, 2);
+	cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+		pipelineLayout,
 		static_cast<uint32_t>(DescriptorSetIndex::Material),
-		{materialSet, perDrawSet}, {});
+		{materialSet, perDrawSet},
+		vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
 
 	cmd.draw(3, 1, 0, 0);
 	cmd.endRenderPass();

--- a/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
@@ -777,7 +777,7 @@ void VulkanDeferredLighting::render(vk::CommandBuffer cmd)
 		// Set 0: Global
 		vk::DescriptorSet globalSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Global);
 		if (!globalSet) return false;
-		writer.writeSet(globalSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Global));
+		writer.writeSet(DescriptorSetIndex::Global, globalSet);
 		writer.setBuffer(GlobalBinding::Lights, {m_deferredUBO,
 			lightDataOffset + (li * lightDataSize), sizeof(graphics::deferred_light_data)});
 		writer.setBuffer(GlobalBinding::DeferredData, {m_deferredUBO,
@@ -790,19 +790,24 @@ void VulkanDeferredLighting::render(vk::CommandBuffer cmd)
 		// Set 1: Material
 		vk::DescriptorSet materialSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::Material);
 		if (!materialSet) return false;
-		writer.writeSet(materialSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::Material));
+		writer.writeSet(DescriptorSetIndex::Material, materialSet);
 		writer.setImageArray(MaterialBinding::TextureArray, gbufTexArray);
 
 		// Set 2: PerDraw
 		vk::DescriptorSet perDrawSet = descriptorMgr->allocateFrameSet(DescriptorSetIndex::PerDraw);
 		if (!perDrawSet) return false;
-		writer.writeSet(perDrawSet, VulkanDescriptorManager::getSetTemplate(DescriptorSetIndex::PerDraw));
+		writer.writeSet(DescriptorSetIndex::PerDraw, perDrawSet);
 		writer.setBuffer(PerDrawBinding::Matrices, {m_deferredUBO,
 			matrixDataOffset + (li * matrixDataSize), sizeof(graphics::matrix_uniforms)});
 		writer.flush();
 
 		std::array<vk::DescriptorSet, 3> sets = { globalSet, materialSet, perDrawSet };
-		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, sets, {});
+		const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Global, 3);
+		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+			pipelineLayout,
+			0,
+			sets,
+			vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
 
 		return true;
 	};

--- a/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
@@ -801,13 +801,8 @@ void VulkanDeferredLighting::render(vk::CommandBuffer cmd)
 			matrixDataOffset + (li * matrixDataSize), sizeof(graphics::matrix_uniforms)});
 		writer.flush();
 
-		std::array<vk::DescriptorSet, 3> sets = { globalSet, materialSet, perDrawSet };
-		const auto dynOffsets = writer.dynamicOffsets(DescriptorSetIndex::Global, 3);
-		cmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
-			pipelineLayout,
-			0,
-			sets,
-			vk::ArrayProxy<const uint32_t>(static_cast<uint32_t>(dynOffsets.size), dynOffsets.data));
+		const vk::DescriptorSet sets[] = {globalSet, materialSet, perDrawSet};
+		writer.bindSets(cmd, pipelineLayout, DescriptorSetIndex::Global, sets);
 
 		return true;
 	};

--- a/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
@@ -70,7 +70,8 @@ bool VulkanDeferredLighting::initLightVolumes()
 			return false;
 		}
 
-		if (!m_ctx->memoryManager->allocateBufferMemory(m_sphereMesh.vbo, MemoryUsage::CpuToGpu, m_sphereMesh.vboAlloc)) {
+		if (!m_ctx->memoryManager->allocateBufferMemory(
+				m_sphereMesh.vbo, MemoryUsage::CpuToGpu, m_sphereMesh.vboAlloc, MemoryPurpose::Geometry)) {
 			m_ctx->device.destroyBuffer(m_sphereMesh.vbo);
 			m_sphereMesh.vbo = nullptr;
 			return false;
@@ -95,7 +96,8 @@ bool VulkanDeferredLighting::initLightVolumes()
 			return false;
 		}
 
-		if (!m_ctx->memoryManager->allocateBufferMemory(m_sphereMesh.ibo, MemoryUsage::CpuToGpu, m_sphereMesh.iboAlloc)) {
+		if (!m_ctx->memoryManager->allocateBufferMemory(
+				m_sphereMesh.ibo, MemoryUsage::CpuToGpu, m_sphereMesh.iboAlloc, MemoryPurpose::Geometry)) {
 			m_ctx->device.destroyBuffer(m_sphereMesh.ibo);
 			m_sphereMesh.ibo = nullptr;
 			return false;
@@ -126,7 +128,8 @@ bool VulkanDeferredLighting::initLightVolumes()
 			return false;
 		}
 
-		if (!m_ctx->memoryManager->allocateBufferMemory(m_cylinderMesh.vbo, MemoryUsage::CpuToGpu, m_cylinderMesh.vboAlloc)) {
+		if (!m_ctx->memoryManager->allocateBufferMemory(
+				m_cylinderMesh.vbo, MemoryUsage::CpuToGpu, m_cylinderMesh.vboAlloc, MemoryPurpose::Geometry)) {
 			m_ctx->device.destroyBuffer(m_cylinderMesh.vbo);
 			m_cylinderMesh.vbo = nullptr;
 			return false;
@@ -150,7 +153,8 @@ bool VulkanDeferredLighting::initLightVolumes()
 			return false;
 		}
 
-		if (!m_ctx->memoryManager->allocateBufferMemory(m_cylinderMesh.ibo, MemoryUsage::CpuToGpu, m_cylinderMesh.iboAlloc)) {
+		if (!m_ctx->memoryManager->allocateBufferMemory(
+				m_cylinderMesh.ibo, MemoryUsage::CpuToGpu, m_cylinderMesh.iboAlloc, MemoryPurpose::Geometry)) {
 			m_ctx->device.destroyBuffer(m_cylinderMesh.ibo);
 			m_cylinderMesh.ibo = nullptr;
 			return false;

--- a/code/graphics/vulkan/VulkanPostProcessingMSAA.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingMSAA.cpp
@@ -206,7 +206,8 @@ bool VulkanDeferredGBuffer::createMsaaTargets()
 			return false;
 		}
 
-		if (!m_ctx->memoryManager->allocateImageMemory(m_msaaDepthImage, MemoryUsage::GpuOnly, m_msaaDepthAlloc)) {
+		if (!m_ctx->memoryManager->allocateImageMemory(
+				m_msaaDepthImage, MemoryUsage::GpuOnly, m_msaaDepthAlloc, MemoryPurpose::RenderTarget)) {
 			nprintf(("vulkan", "VulkanPostProcessor: Failed to allocate MSAA depth memory!\n"));
 			m_ctx->device.destroyImage(m_msaaDepthImage);
 			m_msaaDepthImage = nullptr;

--- a/code/graphics/vulkan/VulkanPostProcessingShadow.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingShadow.cpp
@@ -70,7 +70,8 @@ bool VulkanShadowMap::init(PostProcessContext& ctx)
 			return false;
 		}
 
-		if (!m_ctx->memoryManager->allocateImageMemory(m_depth.image, MemoryUsage::GpuOnly, m_depth.allocation)) {
+		if (!m_ctx->memoryManager->allocateImageMemory(
+				m_depth.image, MemoryUsage::GpuOnly, m_depth.allocation, MemoryPurpose::RenderTarget)) {
 			m_ctx->device.destroyImage(m_depth.image);
 			m_depth.image = nullptr;
 			return false;

--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -63,7 +63,7 @@ void VulkanRenderer::createCompositionResources()
 		auto image = m_device->createImageUnique(imageInfo);
 
 		VulkanAllocation alloc{};
-		m_memoryManager->allocateImageMemory(image.get(), MemoryUsage::GpuOnly, alloc);
+		m_memoryManager->allocateImageMemory(image.get(), MemoryUsage::GpuOnly, alloc, MemoryPurpose::RenderTarget);
 
 		vk::ImageViewCreateInfo viewInfo;
 		viewInfo.image = image.get();
@@ -271,7 +271,8 @@ void VulkanRenderer::createDepthResources()
 	m_depthImage = m_device->createImageUnique(imageInfo);
 
 	// Allocate GPU memory for the depth image
-	m_memoryManager->allocateImageMemory(m_depthImage.get(), MemoryUsage::GpuOnly, m_depthImageMemory);
+	m_memoryManager->allocateImageMemory(
+		m_depthImage.get(), MemoryUsage::GpuOnly, m_depthImageMemory, MemoryPurpose::RenderTarget);
 
 	// Create depth image view
 	vk::ImageViewCreateInfo viewInfo;

--- a/code/graphics/vulkan/VulkanRendererSetup.cpp
+++ b/code/graphics/vulkan/VulkanRendererSetup.cpp
@@ -879,6 +879,15 @@ bool VulkanRenderer::createLogicalDevice(const PhysicalDeviceValues& deviceValue
 			enabledExtensions.push_back(VK_EXT_HDR_METADATA_EXTENSION_NAME);
 			mprintf(("Vulkan: Enabling %s (HDR10 metadata)\n", VK_EXT_HDR_METADATA_EXTENSION_NAME));
 		}
+		// Required by the Vulkan Portability subset whenever the physical device
+		// advertises it (MoltenVK / macOS). Creating a device without it is
+		// undefined behavior and trips VUID-VkDeviceCreateInfo-pProperties-04451.
+		// The extension-name macro lives in vulkan_beta.h (VK_ENABLE_BETA_EXTENSIONS);
+		// our headers do not enable that, so use the literal string instead.
+		if (strcmp(ext.extensionName, "VK_KHR_portability_subset") == 0) {
+			enabledExtensions.push_back("VK_KHR_portability_subset");
+			mprintf(("Vulkan: Enabling VK_KHR_portability_subset\n"));
+		}
 		if (strcmp(ext.extensionName, VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME) == 0) {
 			hasAccelerationStructureExt = true;
 		}

--- a/code/graphics/vulkan/VulkanState.cpp
+++ b/code/graphics/vulkan/VulkanState.cpp
@@ -251,25 +251,47 @@ void VulkanStateTracker::bindPipeline(vk::Pipeline pipeline, vk::PipelineLayout 
 	}
 }
 
-void VulkanStateTracker::bindDescriptorSet(DescriptorSetIndex setIndex, vk::DescriptorSet set,
-                                            const SCP_vector<uint32_t>& dynamicOffsets)
+void VulkanStateTracker::bindDescriptorSet(DescriptorSetIndex setIndex,
+	vk::DescriptorSet set,
+	const uint32_t* dynamicOffsets)
 {
 	Assertion(m_cmdBuffer, "bindDescriptorSet called without active command buffer!");
 	Assertion(m_currentPipelineLayout, "bindDescriptorSet called without bound pipeline layout!");
 	Assertion(set, "bindDescriptorSet called with null descriptor set!");
 
 	auto index = static_cast<uint32_t>(setIndex);
+	const uint32_t dynCount = VulkanDescriptorManager::getDynamicOffsetCount(setIndex);
+	Assertion(dynCount == 0 || dynamicOffsets != nullptr,
+		"bindDescriptorSet: set %u declares %u dynamic descriptors but no offsets were supplied!",
+		index,
+		dynCount);
 
-	if (m_boundDescriptorSets[index] != set) {
-		m_cmdBuffer.bindDescriptorSets(
-			vk::PipelineBindPoint::eGraphics,
+	// The redundancy check has to cover the dynamic offsets too, not just the set
+	// handle: with dynamic UBOs the common case is the *same* set rebound with a new
+	// offset every draw, and skipping that bind would silently feed every draw the
+	// previous draw's uniforms.
+	auto& boundDyn = m_boundDynamicOffsets[index];
+	bool offsetsChanged = false;
+	for (uint32_t i = 0; i < dynCount; ++i) {
+		if (boundDyn[i] != dynamicOffsets[i]) {
+			offsetsChanged = true;
+			break;
+		}
+	}
+
+	if (m_boundDescriptorSets[index] != set || offsetsChanged) {
+		m_cmdBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
 			m_currentPipelineLayout,
 			index,
-			1, &set,
-			static_cast<uint32_t>(dynamicOffsets.size()),
-			dynamicOffsets.empty() ? nullptr : dynamicOffsets.data());
+			1,
+			&set,
+			dynCount,
+			dynCount > 0 ? dynamicOffsets : nullptr);
 
 		m_boundDescriptorSets[index] = set;
+		for (uint32_t i = 0; i < dynCount; ++i) {
+			boundDyn[i] = dynamicOffsets[i];
+		}
 	}
 }
 

--- a/code/graphics/vulkan/VulkanState.h
+++ b/code/graphics/vulkan/VulkanState.h
@@ -134,10 +134,15 @@ class VulkanStateTracker {
 
 	/**
 	 * @brief Bind descriptor set
+	 *
+	 * @param dynamicOffsets Offsets for the set layout's eUniformBufferDynamic
+	 *        bindings, ordered by binding number. Must point to at least
+	 *        VulkanDescriptorManager::getDynamicOffsetCount(setIndex) entries
+	 *        (DescriptorWriter::dynamicOffsets() produces exactly that); may be
+	 *        null only for a set that declares none.
 	 */
-	void bindDescriptorSet(DescriptorSetIndex setIndex,
-		vk::DescriptorSet set,
-		const SCP_vector<uint32_t>& dynamicOffsets = {});
+	void
+	bindDescriptorSet(DescriptorSetIndex setIndex, vk::DescriptorSet set, const uint32_t* dynamicOffsets = nullptr);
 
 	// ========== Buffer Binding ==========
 
@@ -312,6 +317,11 @@ class VulkanStateTracker {
 
 	// Descriptor sets
 	std::array<vk::DescriptorSet, static_cast<size_t>(DescriptorSetIndex::Count)> m_boundDescriptorSets;
+	// Dynamic offsets the currently-bound set was bound with, so an offset-only
+	// change still forces a rebind (see bindDescriptorSet).
+	std::array<std::array<uint32_t, DescriptorWriter::MAX_DYNAMIC_OFFSETS_PER_SET>,
+		static_cast<size_t>(DescriptorSetIndex::Count)>
+		m_boundDynamicOffsets{};
 
 	// Dynamic state
 	vk::Viewport m_viewport;

--- a/code/graphics/vulkan/VulkanTexture.cpp
+++ b/code/graphics/vulkan/VulkanTexture.cpp
@@ -2427,7 +2427,7 @@ bool VulkanTextureManager::createImage(uint32_t width, uint32_t height, uint32_t
 		return false;
 	}
 
-	if (!m_memoryManager->allocateImageMemory(image, memUsage, allocation)) {
+	if (!m_memoryManager->allocateImageMemory(image, memUsage, allocation, MemoryPurpose::Texture)) {
 		m_device.destroyImage(image);
 		image = nullptr;
 		return false;

--- a/code/graphics/vulkan/gr_vulkan.cpp
+++ b/code/graphics/vulkan/gr_vulkan.cpp
@@ -200,6 +200,19 @@ void vulkan_get_debug_stats(gr_debug_stats& stats)
 	stats.pipeline_count = getPipelineManager()->getPipelineCount();
 }
 
+void vulkan_get_memory_stats(gr_memory_stats& stats)
+{
+	auto* memoryManager = getMemoryManager();
+	if (memoryManager == nullptr) {
+		return;
+	}
+
+	stats.gpu_purpose_valid = true;
+	stats.gpu_texture_bytes = memoryManager->getTextureBytes();
+	stats.gpu_geometry_bytes = memoryManager->getGeometryBytes();
+	stats.gpu_render_target_bytes = memoryManager->getRenderTargetBytes();
+}
+
 void vulkan_push_debug_group(const char* name)
 {
 	auto* renderer = getRendererInstance();
@@ -558,6 +571,7 @@ void init_function_pointers()
 	gr_screen.gf_is_capable = vulkan_is_capable;
 	gr_screen.gf_get_property = vulkan_get_property;
 	gr_screen.gf_get_debug_stats = vulkan_get_debug_stats;
+	gr_screen.gf_get_memory_stats = vulkan_get_memory_stats;
 
 	gr_screen.gf_push_debug_group = vulkan_push_debug_group;
 	gr_screen.gf_pop_debug_group = vulkan_pop_debug_group;

--- a/code/graphics/vulkan/gr_vulkan.cpp
+++ b/code/graphics/vulkan/gr_vulkan.cpp
@@ -181,6 +181,25 @@ bool vulkan_get_property(gr_property prop, void* dest)
 	}
 }
 
+void vulkan_get_debug_stats(gr_debug_stats& stats)
+{
+	const auto& frameStats = getDrawManager()->getFrameStats();
+
+	stats.draw_stats_valid = true;
+	stats.draw_calls = frameStats.drawCalls;
+	stats.draw_indexed_calls = frameStats.drawIndexedCalls;
+	stats.total_vertices = frameStats.totalVertices;
+	stats.total_indices = frameStats.totalIndices;
+	stats.apply_material_calls = frameStats.applyMaterialCalls;
+	stats.apply_material_failures = frameStats.applyMaterialFailures;
+	stats.no_pipeline_skips = frameStats.noPipelineSkips;
+	stats.on_demand_texture_uploads = frameStats.onDemandTextureUploads;
+
+	stats.descriptor_sets_allocated = static_cast<int>(getDescriptorManager()->getSetsAllocatedThisFrame());
+	stats.descriptor_writes = static_cast<int>(getDescriptorManager()->getWritesThisFrame());
+	stats.pipeline_count = getPipelineManager()->getPipelineCount();
+}
+
 void vulkan_push_debug_group(const char* name)
 {
 	auto* renderer = getRendererInstance();
@@ -218,12 +237,16 @@ void vulkan_imgui_render_draw_data()
 	if (renderer) {
 		ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), renderer->getVkCurrentCommandBuffer());
 
-		// ImGui recorded its own pipeline/descriptor/viewport/scissor binds
-		// directly on the command buffer, mid-pass. Anything the engine draws
-		// before the next pass boundary (e.g. gr_flip's debug overlay or cached
-		// UI model instances) would otherwise run with ImGui's pipeline still
-		// bound because the tracker believes its own pipeline is current.
+		// ImGui just bound its own pipeline/descriptor set directly on the command buffer,
+		// inside the same (already-active) render pass FSO's own draws share -- it can't begin
+		// its own pass here, unlike the other raw recorders whose staleness setRenderPass()
+		// alone recovers from. Without this, the next tracked draw (e.g. a HUD gauge rendered
+		// after the profiler overlay) can skip rebinding its own pipeline/descriptor set because
+		// the tracker's/draw-manager's cached handles still match what THEY last bound, even
+		// though ImGui has since changed what's actually bound on the command buffer -- see
+		// VulkanStateTracker::invalidateExternalBindings().
 		getStateTracker()->invalidateExternalBindings();
+		getDrawManager()->invalidateDrawStateCaches();
 	}
 }
 
@@ -534,6 +557,7 @@ void init_function_pointers()
 
 	gr_screen.gf_is_capable = vulkan_is_capable;
 	gr_screen.gf_get_property = vulkan_get_property;
+	gr_screen.gf_get_debug_stats = vulkan_get_debug_stats;
 
 	gr_screen.gf_push_debug_group = vulkan_push_debug_group;
 	gr_screen.gf_pop_debug_group = vulkan_pop_debug_group;

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -415,12 +415,11 @@ void LabManager::onFrame(float frametime) {
 	
 	if (Cmdline_show_imgui_debug)
 		ImGui::ShowDemoWindow();
-	ImGui::Render();
-	gr_imgui_render_draw_data();
 
 	if (CloseThis)
 		close();
 
+	// gr_flip() renders and submits the ImGui frame opened above.
 	gr_flip();
 }
 

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -256,8 +256,9 @@ void LabRenderer::renderModel(float frametime) {
 
 	gr_reset_clip();
 	gr_set_color_fast(&HUD_color_debug);
-	if (Cmdline_frame_profile) {
-		tracing::frame_profile_process_frame();
+	// The legacy -profile_frame_time text dump. gr_flip() drains the profiler, so this only
+	// renders what the previous frame produced.
+	if (Cmdline_frame_profile && tracing::frame_profiling_active()) {
 		gr_string(gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 100 + gr_get_font_height() + 1,
 			tracing::get_frame_profile_output().c_str(), GR_RESIZE_NONE);
 	}

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -65,7 +65,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1933 // This is the next available ID
+// #define XSTR_SIZE	1934 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/code/missionui/missionpause.cpp
+++ b/code/missionui/missionpause.cpp
@@ -25,8 +25,6 @@
 #include "object/object.h"
 #include "popup/popup.h"
 #include "sound/audiostr.h"
-#include "tracing/ProfilerOverlay.h"
-#include "tracing/tracing.h"
 #include "ui/ui.h"
 #include "weapon/weapon.h"
 
@@ -236,14 +234,6 @@ void pause_do()
 	// a very unique case where we shouldn't be doing the page flip because we're inside of popup code
 	if(!popup_active()){
 		if(Pause_type == PAUSE_TYPE_NORMAL) {
-			// PAUSE_TYPE_NORMAL freezes the sim entirely and never runs game_frame(), so unlike
-			// PAUSE_TYPE_VIEWER (rendered via game_show_framerate() in game_do_full_frame()) the
-			// overlay needs its own draw call here -- otherwise ImGui never gets a NewFrame()/Render()
-			// cycle while paused this way, so it can't compute hover state for the SDL input-forwarding
-			// check in handle_sdl_event(), and drags/resizes fall through to whatever's listening below it.
-			if (tracing::Profiler_overlay_enabled) {
-				tracing::profiler_overlay_draw();
-			}
 			gr_flip();
 		}
 	} else {

--- a/code/missionui/missionpause.cpp
+++ b/code/missionui/missionpause.cpp
@@ -25,8 +25,10 @@
 #include "object/object.h"
 #include "popup/popup.h"
 #include "sound/audiostr.h"
+#include "tracing/ProfilerOverlay.h"
+#include "tracing/tracing.h"
 #include "ui/ui.h"
-#include "weapon/weapon.h"	
+#include "weapon/weapon.h"
 
 
 
@@ -234,6 +236,14 @@ void pause_do()
 	// a very unique case where we shouldn't be doing the page flip because we're inside of popup code
 	if(!popup_active()){
 		if(Pause_type == PAUSE_TYPE_NORMAL) {
+			// PAUSE_TYPE_NORMAL freezes the sim entirely and never runs game_frame(), so unlike
+			// PAUSE_TYPE_VIEWER (rendered via game_show_framerate() in game_do_full_frame()) the
+			// overlay needs its own draw call here -- otherwise ImGui never gets a NewFrame()/Render()
+			// cycle while paused this way, so it can't compute hover state for the SDL input-forwarding
+			// check in handle_sdl_event(), and drags/resizes fall through to whatever's listening below it.
+			if (tracing::Profiler_overlay_enabled) {
+				tracing::profiler_overlay_draw();
+			}
 			gr_flip();
 		}
 	} else {

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1057,6 +1057,19 @@ SCP_set<int> model_get_textures_used(const polymodel* pm, int submodel);
 // Returns a pointer to the polymodel structure for model 'n'
 polymodel *model_get(int model_num);
 
+/**
+ * @brief Memory usage summary across all currently loaded polygon models, for the profiler
+ * overlay's memory panel
+ */
+struct model_memory_stats {
+	bool valid = false;
+	int model_count = 0;
+	size_t vertex_bytes = 0;   // sum of vert_source.Vertex_list_size across loaded models
+	size_t index_bytes = 0;    // sum of vert_source.Index_list_size across loaded models
+	size_t bsp_data_bytes = 0; // sum of submodel[].bsp_data_size (collision/interp tree data)
+};
+model_memory_stats model_get_memory_stats();
+
 int num_model_instances();
 polymodel_instance* model_get_instance(int model_instance_num);
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -405,6 +405,28 @@ void model_page_in_stop()
 	}
 }
 
+model_memory_stats model_get_memory_stats()
+{
+	model_memory_stats stats;
+	stats.valid = true;
+
+	for (const auto pm : Polygon_models) {
+			if (pm == nullptr) {
+			continue;
+		}
+
+		stats.model_count++;
+		stats.vertex_bytes += pm->vert_source.Vertex_list_size;
+		stats.index_bytes += pm->vert_source.Index_list_size;
+
+		for (int j = 0; j < pm->n_models; j++) {
+			stats.bsp_data_bytes += pm->submodel[j].bsp_data_size;
+		}
+	}
+
+	return stats;
+}
+
 void model_init()
 {
 	int i;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -532,6 +532,19 @@ int obj_allocate(bool essential)
 	return objnum;
 }
 
+object_memory_stats obj_get_memory_stats()
+{
+	object_memory_stats stats;
+
+	stats.objects_used = Num_objects;
+	stats.objects_peak = num_objects_hwm;
+
+	stats.ships_used = ship_get_num_ships();
+	stats.weapons_used = Num_weapons;
+
+	return stats;
+}
+
 /**
  * Frees up an object  
  *

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -432,5 +432,23 @@ void physics_apply_pstate_to_object(object* objp, const physics_snapshot& source
  */
 int obj_raw_pof_create(const char* pof_filename, const matrix* orient, const vec3d* pos);
 
+/**
+ * @brief Occupancy snapshot of the object/ship/weapon pools, for the profiler overlay's memory panel
+ *
+ * @details These pools are fixed-size static arrays, so their footprint is a compile-time
+ * constant; what's actually useful to report is how full they are.
+ */
+struct object_memory_stats {
+	int objects_used = 0;
+	int objects_max = MAX_OBJECTS;
+	int objects_peak = 0;
+
+	int ships_used = 0;
+	int ships_max = MAX_SHIPS;
+
+	int weapons_used = 0;
+	int weapons_max = MAX_WEAPONS;
+};
+object_memory_stats obj_get_memory_stats();
 
 #endif

--- a/code/options/manager/ingame_options_manager.cpp
+++ b/code/options/manager/ingame_options_manager.cpp
@@ -176,12 +176,11 @@ void OptConfigurator::onFrame() {
 	
 	if (Cmdline_show_imgui_debug)
 		ImGui::ShowDemoWindow();
-	ImGui::Render();
-	gr_imgui_render_draw_data();
 
 	if (CloseThis) {
 		close();
 	}
 
+	// gr_flip() renders and submits the ImGui frame opened above.
 	gr_flip();
 }

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -820,11 +820,10 @@ static void handle_sdl_event(const SDL_Event& event) {
 	using namespace os::events;
 
 	bool imgui_processed_this = false;
+	// The profiler overlay is drawn from gr_flip(), so it can be on screen in any state — it
+	// needs input forwarded wherever it is active, not in a fixed list of states.
 	if ((gameseq_get_state() == GS_STATE_LAB) || (gameseq_get_state() == GS_STATE_INGAME_OPTIONS) ||
-		// The frame profiler overlay keeps rendering while the game is paused (viewer-pause
-		// gameplay frames still run; see game_do_full_frame()), so forward input here too --
-		// otherwise ImGui never sees a mouse event and the window can't be dragged/resized.
-		(tracing::Profiler_overlay_enabled && gameseq_get_state() == GS_STATE_GAME_PAUSED)) {
+		tracing::frame_profiling_active()) {
 		//In these states, we always need to forward inputs to ImGUI, and depending on the ImGUI state and the input type, we must consume it here instead of passing it to FSO.
 		const SDL_Event imgui_event = scale_imgui_mouse_event(event);
 		ImGui_ImplSDL3_ProcessEvent(&imgui_event);

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -15,6 +15,7 @@
 #include "graphics/2d.h"
 #include "graphics/openxr.h"
 #include "io/joy_ff.h"
+#include "tracing/tracing.h"
 
 #include <fcntl.h>
 #include <utf8.h>
@@ -819,7 +820,11 @@ static void handle_sdl_event(const SDL_Event& event) {
 	using namespace os::events;
 
 	bool imgui_processed_this = false;
-	if ((gameseq_get_state() == GS_STATE_LAB) || (gameseq_get_state() == GS_STATE_INGAME_OPTIONS)) {
+	if ((gameseq_get_state() == GS_STATE_LAB) || (gameseq_get_state() == GS_STATE_INGAME_OPTIONS) ||
+		// The frame profiler overlay keeps rendering while the game is paused (viewer-pause
+		// gameplay frames still run; see game_do_full_frame()), so forward input here too --
+		// otherwise ImGui never sees a mouse event and the window can't be dragged/resized.
+		(tracing::Profiler_overlay_enabled && gameseq_get_state() == GS_STATE_GAME_PAUSED)) {
 		//In these states, we always need to forward inputs to ImGUI, and depending on the ImGUI state and the input type, we must consume it here instead of passing it to FSO.
 		const SDL_Event imgui_event = scale_imgui_mouse_event(event);
 		ImGui_ImplSDL3_ProcessEvent(&imgui_event);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -868,11 +868,16 @@ ship_obj *get_ship_obj_ptr_from_index(int index)
  */
 int ship_get_num_ships()
 {
-	int count;
-	ship_obj *so;
+	int count = 0;
 
-	count = 0;
-	for ( so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so) )
+	// Ship_obj_list is only list_init()'d by ship_obj_list_init(), which runs on entering gameplay;
+	// this can be called before that (e.g. by the profiler overlay's memory stats from the main
+	// menu), in which case GET_FIRST() returns the list head's zero-initialized null next pointer.
+	if (GET_FIRST(&Ship_obj_list) == nullptr) {
+		return count;
+	}
+
+	for ( ship_obj const* so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so) )
 	{
 		if (Objects[so->objnum].flags[Object::Object_Flags::Should_be_dead])
 			continue;

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1784,6 +1784,8 @@ add_file_folder("Tracing"
 	tracing/MainFrameTimer.cpp
 	tracing/Monitor.h
 	tracing/Monitor.cpp
+	tracing/ProfilerOverlay.h
+	tracing/ProfilerOverlay.cpp
 	tracing/scopes.cpp
 	tracing/scopes.h
 	tracing/ThreadedEventProcessor.h

--- a/code/tracing/FrameProfiler.cpp
+++ b/code/tracing/FrameProfiler.cpp
@@ -336,10 +336,8 @@ void FrameProfiler::build_overlay_snapshot(const SCP_vector<uint64_t>& self_time
 	overlaySnapshot.top_contributors.clear();
 	overlaySnapshot.other_nanosec = 0;
 
-	constexpr size_t MAX_CONTRIBUTORS = 5;
-
 	for (size_t i = 0; i < sorted.size(); i++) {
-		if (i < MAX_CONTRIBUTORS) {
+		if (i < FRAME_OVERLAY_MAX_CONTRIBUTORS) {
 			overlaySnapshot.top_contributors.push_back({sorted[i].first->getName(), sorted[i].second});
 		} else {
 			overlaySnapshot.other_nanosec += sorted[i].second;

--- a/code/tracing/FrameProfiler.cpp
+++ b/code/tracing/FrameProfiler.cpp
@@ -357,7 +357,7 @@ void FrameProfiler::processFrame() {
 	std::sort(_bufferedEvents.begin(), _bufferedEvents.end(), event_sorter);
 
 	// Overlay fast path: per-category self-time via a single stack walk (see accumulate_self_times).
-	const size_t category_count = static_cast<size_t>(Category::getCount());
+	const auto category_count = static_cast<size_t>(Category::getCount());
 	SCP_vector<uint64_t> self_time_by_id(category_count, 0);
 	SCP_vector<const Category*> category_by_id(category_count, nullptr);
 	uint64_t total = 0;

--- a/code/tracing/FrameProfiler.cpp
+++ b/code/tracing/FrameProfiler.cpp
@@ -279,6 +279,44 @@ void FrameProfiler::dump_output(SCP_stringstream& out,
 SCP_string FrameProfiler::getContent() {
 	return content;
 }
+
+void FrameProfiler::build_overlay_snapshot(SCP_vector<profile_sample>& samples) {
+	SCP_unordered_map<SCP_string, uint64_t> self_time_by_name;
+	uint64_t total = 0;
+
+	for (auto& sample : samples) {
+		Assert(sample.open_profiles == 0);
+
+		uint64_t self_time = sample.accumulator - sample.children_sample_time;
+		self_time_by_name[sample.name] += self_time;
+
+		if (sample.parent < 0) {
+			// Top-level samples' accumulators are inclusive of all their children, so summing
+			// them gives the total traced time for the frame (MainFrame itself isn't in `samples`).
+			total += sample.accumulator;
+		}
+	}
+
+	SCP_vector<std::pair<SCP_string, uint64_t>> sorted(self_time_by_name.begin(), self_time_by_name.end());
+	std::sort(sorted.begin(), sorted.end(), [](const std::pair<SCP_string, uint64_t>& a, const std::pair<SCP_string, uint64_t>& b) {
+		return a.second > b.second;
+	});
+
+	overlaySnapshot.valid = true;
+	overlaySnapshot.total_nanosec = total;
+	overlaySnapshot.top_contributors.clear();
+	overlaySnapshot.other_nanosec = 0;
+
+	constexpr size_t MAX_CONTRIBUTORS = 5;
+
+	for (size_t i = 0; i < sorted.size(); i++) {
+		if (i < MAX_CONTRIBUTORS) {
+			overlaySnapshot.top_contributors.push_back({sorted[i].first, sorted[i].second});
+		} else {
+			overlaySnapshot.other_nanosec += sorted[i].second;
+		}
+	}
+}
 void FrameProfiler::processFrame() {
 
 	std::lock_guard<std::mutex> vectorGuard(_eventsMutex);
@@ -318,6 +356,7 @@ void FrameProfiler::processFrame() {
 	_bufferedEvents.clear();
 
 	dump_output(stream, start_profile_time, end_profile_time, samples);
+	build_overlay_snapshot(samples);
 
 	content = stream.str();
 }

--- a/code/tracing/FrameProfiler.cpp
+++ b/code/tracing/FrameProfiler.cpp
@@ -3,6 +3,7 @@
 
 #include "FrameProfiler.h"
 
+#include "cmdline/cmdline.h"
 #include "globalincs/systemvars.h"
 
 using namespace tracing;
@@ -119,6 +120,46 @@ void process_end(SCP_vector<profile_sample>& samples, const trace_event& evt) {
 }
 
 namespace tracing {
+
+void accumulate_self_times(const SCP_vector<trace_event>& events,
+	SCP_vector<uint64_t>& self_time_by_id,
+	SCP_vector<const Category*>& category_by_id,
+	uint64_t& total) {
+	total = 0;
+	if (events.empty()) {
+		return;
+	}
+
+	SCP_vector<int> open_stack; // category ids of currently-open scopes
+	open_stack.reserve(32);
+	uint64_t last_ts = events.front().timestamp;
+
+	for (const auto& evt : events) {
+		if (!open_stack.empty()) {
+			const uint64_t delta = evt.timestamp - last_ts;
+			self_time_by_id[open_stack.back()] += delta;
+			total += delta;
+		}
+		last_ts = evt.timestamp;
+
+		if (evt.category == nullptr) {
+			// Can't happen today (processEvent filters these out), but keep last_ts advanced above
+			// so a stray null-category event could never cause the next delta to span it.
+			continue;
+		}
+
+		const int id = evt.category->getId();
+		category_by_id[id] = evt.category;
+
+		if (evt.type == EventType::Begin) {
+			open_stack.push_back(id);
+		} else if (evt.type == EventType::End) {
+			if (!open_stack.empty()) {
+				open_stack.pop_back();
+			}
+		}
+	}
+}
 
 FrameProfiler::FrameProfiler() {
 
@@ -280,27 +321,19 @@ SCP_string FrameProfiler::getContent() {
 	return content;
 }
 
-void FrameProfiler::build_overlay_snapshot(SCP_vector<profile_sample>& samples) {
-	SCP_unordered_map<SCP_string, uint64_t> self_time_by_name;
-	uint64_t total = 0;
-
-	for (auto& sample : samples) {
-		Assert(sample.open_profiles == 0);
-
-		uint64_t self_time = sample.accumulator - sample.children_sample_time;
-		self_time_by_name[sample.name] += self_time;
-
-		if (sample.parent < 0) {
-			// Top-level samples' accumulators are inclusive of all their children, so summing
-			// them gives the total traced time for the frame (MainFrame itself isn't in `samples`).
-			total += sample.accumulator;
+void FrameProfiler::build_overlay_snapshot(const SCP_vector<uint64_t>& self_time_by_id,
+	const SCP_vector<const Category*>& category_by_id,
+	uint64_t total) {
+	SCP_vector<std::pair<const Category*, uint64_t>> sorted;
+	for (size_t id = 0; id < self_time_by_id.size(); id++) {
+		if (self_time_by_id[id] > 0 && category_by_id[id] != nullptr) {
+			sorted.emplace_back(category_by_id[id], self_time_by_id[id]);
 		}
 	}
-
-	SCP_vector<std::pair<SCP_string, uint64_t>> sorted(self_time_by_name.begin(), self_time_by_name.end());
-	std::sort(sorted.begin(), sorted.end(), [](const std::pair<SCP_string, uint64_t>& a, const std::pair<SCP_string, uint64_t>& b) {
-		return a.second > b.second;
-	});
+	std::sort(sorted.begin(), sorted.end(),
+		[](const std::pair<const Category*, uint64_t>& a, const std::pair<const Category*, uint64_t>& b) {
+			return a.second > b.second;
+		});
 
 	overlaySnapshot.valid = true;
 	overlaySnapshot.total_nanosec = total;
@@ -311,7 +344,7 @@ void FrameProfiler::build_overlay_snapshot(SCP_vector<profile_sample>& samples) 
 
 	for (size_t i = 0; i < sorted.size(); i++) {
 		if (i < MAX_CONTRIBUTORS) {
-			overlaySnapshot.top_contributors.push_back({sorted[i].first, sorted[i].second});
+			overlaySnapshot.top_contributors.push_back({sorted[i].first->getName(), sorted[i].second});
 		} else {
 			overlaySnapshot.other_nanosec += sorted[i].second;
 		}
@@ -323,42 +356,40 @@ void FrameProfiler::processFrame() {
 
 	std::sort(_bufferedEvents.begin(), _bufferedEvents.end(), event_sorter);
 
-	SCP_stringstream stream;
+	// Overlay fast path: per-category self-time via a single stack walk (see accumulate_self_times).
+	const size_t category_count = static_cast<size_t>(Category::getCount());
+	SCP_vector<uint64_t> self_time_by_id(category_count, 0);
+	SCP_vector<const Category*> category_by_id(category_count, nullptr);
+	uint64_t total = 0;
 
-	SCP_vector<profile_sample> samples;
+	accumulate_self_times(_bufferedEvents, self_time_by_id, category_by_id, total);
+	build_overlay_snapshot(self_time_by_id, category_by_id, total);
 
-	bool start_found = false;
-	bool end_found = false;
-	uint64_t start_profile_time = 0;
-	uint64_t end_profile_time = 0;
+	// Legacy on-screen text dump (-profile_frame_time). This still builds the full parent/child
+	// sample tree (process_begin/process_end) and the min/avg/max history, both O(n^2); only pay for
+	// it when that output is actually consumed, not for the overlay.
+	if (Cmdline_frame_profile) {
+		SCP_stringstream stream;
+		SCP_vector<profile_sample> samples;
 
-	for (auto& event : _bufferedEvents) {
-		if (!start_found) {
-			start_profile_time = event.timestamp;
-			start_found = true;
+		for (auto& event : _bufferedEvents) {
+			switch (event.type) {
+				case EventType::Begin:
+					process_begin(samples, event);
+					break;
+				case EventType::End:
+					process_end(samples, event);
+					break;
+				default:
+					break;
+			}
 		}
-		if (!end_found) {
-			end_profile_time = event.timestamp;
-			end_found = true;
-		}
 
-		switch (event.type) {
-			case EventType::Begin:
-				process_begin(samples, event);
-				break;
-			case EventType::End:
-				process_end(samples, event);
-				break;
-			default:
-				break;
-		}
+		dump_output(stream, 0, 0, samples);
+		content = stream.str();
 	}
+
 	_bufferedEvents.clear();
-
-	dump_output(stream, start_profile_time, end_profile_time, samples);
-	build_overlay_snapshot(samples);
-
-	content = stream.str();
 }
 
 }

--- a/code/tracing/FrameProfiler.cpp
+++ b/code/tracing/FrameProfiler.cpp
@@ -121,15 +121,14 @@ void process_end(SCP_vector<profile_sample>& samples, const trace_event& evt) {
 
 namespace tracing {
 
-void accumulate_self_times(const SCP_vector<trace_event>& events,
-	SCP_vector<uint64_t>& self_time_by_id,
-	SCP_vector<const Category*>& category_by_id,
-	uint64_t& total) {
-	total = 0;
+uint64_t accumulate_self_times(const SCP_vector<trace_event>& events, SCP_vector<uint64_t>& self_time_by_id) {
+	self_time_by_id.assign(static_cast<size_t>(Category::getCount()), 0);
+
 	if (events.empty()) {
-		return;
+		return 0;
 	}
 
+	uint64_t total = 0;
 	SCP_vector<int> open_stack; // category ids of currently-open scopes
 	open_stack.reserve(32);
 	uint64_t last_ts = events.front().timestamp;
@@ -137,7 +136,7 @@ void accumulate_self_times(const SCP_vector<trace_event>& events,
 	for (const auto& evt : events) {
 		if (!open_stack.empty()) {
 			const uint64_t delta = evt.timestamp - last_ts;
-			self_time_by_id[open_stack.back()] += delta;
+			self_time_by_id[static_cast<size_t>(open_stack.back())] += delta;
 			total += delta;
 		}
 		last_ts = evt.timestamp;
@@ -148,17 +147,16 @@ void accumulate_self_times(const SCP_vector<trace_event>& events,
 			continue;
 		}
 
-		const int id = evt.category->getId();
-		category_by_id[id] = evt.category;
-
 		if (evt.type == EventType::Begin) {
-			open_stack.push_back(id);
+			open_stack.push_back(evt.category->getId());
 		} else if (evt.type == EventType::End) {
 			if (!open_stack.empty()) {
 				open_stack.pop_back();
 			}
 		}
 	}
+
+	return total;
 }
 
 FrameProfiler::FrameProfiler() {
@@ -321,13 +319,11 @@ SCP_string FrameProfiler::getContent() {
 	return content;
 }
 
-void FrameProfiler::build_overlay_snapshot(const SCP_vector<uint64_t>& self_time_by_id,
-	const SCP_vector<const Category*>& category_by_id,
-	uint64_t total) {
+void FrameProfiler::build_overlay_snapshot(const SCP_vector<uint64_t>& self_time_by_id, uint64_t total) {
 	SCP_vector<std::pair<const Category*, uint64_t>> sorted;
 	for (size_t id = 0; id < self_time_by_id.size(); id++) {
-		if (self_time_by_id[id] > 0 && category_by_id[id] != nullptr) {
-			sorted.emplace_back(category_by_id[id], self_time_by_id[id]);
+		if (self_time_by_id[id] > 0) {
+			sorted.emplace_back(&Category::getById(static_cast<int>(id)), self_time_by_id[id]);
 		}
 	}
 	std::sort(sorted.begin(), sorted.end(),
@@ -357,13 +353,9 @@ void FrameProfiler::processFrame() {
 	std::sort(_bufferedEvents.begin(), _bufferedEvents.end(), event_sorter);
 
 	// Overlay fast path: per-category self-time via a single stack walk (see accumulate_self_times).
-	const auto category_count = static_cast<size_t>(Category::getCount());
-	SCP_vector<uint64_t> self_time_by_id(category_count, 0);
-	SCP_vector<const Category*> category_by_id(category_count, nullptr);
-	uint64_t total = 0;
-
-	accumulate_self_times(_bufferedEvents, self_time_by_id, category_by_id, total);
-	build_overlay_snapshot(self_time_by_id, category_by_id, total);
+	// _selfTimeScratch is a member so the per-frame run reuses its allocation.
+	const uint64_t total = accumulate_self_times(_bufferedEvents, _selfTimeScratch);
+	build_overlay_snapshot(_selfTimeScratch, total);
 
 	// Legacy on-screen text dump (-profile_frame_time). This still builds the full parent/child
 	// sample tree (process_begin/process_end) and the min/avg/max history, both O(n^2); only pay for

--- a/code/tracing/FrameProfiler.h
+++ b/code/tracing/FrameProfiler.h
@@ -13,6 +13,23 @@
 
 namespace tracing {
 
+/**
+ * Computes per-category exclusive (self) time for a frame's trace events in a single pass.
+ *
+ * @c events must already be sorted into transition order (by @c event_id, i.e. call order), as a
+ * stream of Begin/End events. A stack of currently-open scopes is maintained; the time between two
+ * consecutive transitions is attributed to the innermost open scope. Results are keyed by
+ * @c Category::getId(): @c self_time_by_id and @c category_by_id must both be sized to at least
+ * @c Category::getCount() (the former zero-initialized). @c total receives the sum of all self-times
+ * (the total traced frame time). This is O(events) with no tree building or string comparisons.
+ *
+ * Declared here (rather than kept file-local) so it can be unit-tested directly.
+ */
+void accumulate_self_times(const SCP_vector<trace_event>& events,
+	SCP_vector<uint64_t>& self_time_by_id,
+	SCP_vector<const Category*>& category_by_id,
+	uint64_t& total);
+
 struct profile_sample_history {
 	bool valid;
 	//char name[256];
@@ -73,9 +90,13 @@ class FrameProfiler {
 
 	/**
 	 * Builds the structured overlay snapshot (see frame_overlay_snapshot) from this frame's
-	 * processed sample tree. Called once per processFrame(), alongside dump_output().
+	 * per-category self-time. self_time_by_id and category_by_id are indexed by Category::getId();
+	 * total is the sum of all self-times (i.e. total traced frame time). Called once per
+	 * processFrame().
 	 */
-	void build_overlay_snapshot(SCP_vector<profile_sample>& samples);
+	void build_overlay_snapshot(const SCP_vector<uint64_t>& self_time_by_id,
+								const SCP_vector<const Category*>& category_by_id,
+								uint64_t total);
 
  public:
 	FrameProfiler();

--- a/code/tracing/FrameProfiler.h
+++ b/code/tracing/FrameProfiler.h
@@ -40,6 +40,8 @@ class FrameProfiler {
 
 	SCP_vector<profile_sample_history> history;
 
+	frame_overlay_snapshot overlaySnapshot;
+
 	std::int64_t _mainThreadID = -1;
 
 	SCP_string content;
@@ -69,6 +71,11 @@ class FrameProfiler {
 					 uint64_t end_profile_time,
 					 SCP_vector<profile_sample>& samples);
 
+	/**
+	 * Builds the structured overlay snapshot (see frame_overlay_snapshot) from this frame's
+	 * processed sample tree. Called once per processFrame(), alongside dump_output().
+	 */
+	void build_overlay_snapshot(SCP_vector<profile_sample>& samples);
 
  public:
 	FrameProfiler();
@@ -79,6 +86,8 @@ class FrameProfiler {
 	void processFrame();
 
 	SCP_string getContent();
+
+	const frame_overlay_snapshot& getOverlaySnapshot() const { return overlaySnapshot; }
 };
 
 }

--- a/code/tracing/FrameProfiler.h
+++ b/code/tracing/FrameProfiler.h
@@ -18,17 +18,18 @@ namespace tracing {
  *
  * @c events must already be sorted into transition order (by @c event_id, i.e. call order), as a
  * stream of Begin/End events. A stack of currently-open scopes is maintained; the time between two
- * consecutive transitions is attributed to the innermost open scope. Results are keyed by
- * @c Category::getId(): @c self_time_by_id and @c category_by_id must both be sized to at least
- * @c Category::getCount() (the former zero-initialized). @c total receives the sum of all self-times
- * (the total traced frame time). This is O(events) with no tree building or string comparisons.
+ * consecutive transitions is attributed to the innermost open scope.
  *
- * Declared here (rather than kept file-local) so it can be unit-tested directly.
+ * @c self_time_by_id is resized and zeroed to @c Category::getCount() entries and filled with each
+ * category's self time, indexed by @c Category::getId() (recover the category with
+ * @c Category::getById()). Pass the same vector every frame to reuse its allocation.
+ *
+ * @return the sum of all self-times, i.e. the total traced frame time.
+ *
+ * This is O(events) with no tree building or string comparisons. Declared here (rather than kept
+ * file-local) so it can be unit-tested directly.
  */
-void accumulate_self_times(const SCP_vector<trace_event>& events,
-	SCP_vector<uint64_t>& self_time_by_id,
-	SCP_vector<const Category*>& category_by_id,
-	uint64_t& total);
+uint64_t accumulate_self_times(const SCP_vector<trace_event>& events, SCP_vector<uint64_t>& self_time_by_id);
 
 struct profile_sample_history {
 	bool valid;
@@ -58,6 +59,9 @@ class FrameProfiler {
 	SCP_vector<profile_sample_history> history;
 
 	frame_overlay_snapshot overlaySnapshot;
+
+	// Reused across frames by accumulate_self_times() so the per-frame walk allocates nothing.
+	SCP_vector<uint64_t> _selfTimeScratch;
 
 	std::int64_t _mainThreadID = -1;
 
@@ -90,13 +94,10 @@ class FrameProfiler {
 
 	/**
 	 * Builds the structured overlay snapshot (see frame_overlay_snapshot) from this frame's
-	 * per-category self-time. self_time_by_id and category_by_id are indexed by Category::getId();
-	 * total is the sum of all self-times (i.e. total traced frame time). Called once per
-	 * processFrame().
+	 * per-category self-time. self_time_by_id is indexed by Category::getId(); total is the sum of
+	 * all self-times (i.e. total traced frame time). Called once per processFrame().
 	 */
-	void build_overlay_snapshot(const SCP_vector<uint64_t>& self_time_by_id,
-								const SCP_vector<const Category*>& category_by_id,
-								uint64_t total);
+	void build_overlay_snapshot(const SCP_vector<uint64_t>& self_time_by_id, uint64_t total);
 
  public:
 	FrameProfiler();

--- a/code/tracing/ProfilerOverlay.cpp
+++ b/code/tracing/ProfilerOverlay.cpp
@@ -100,13 +100,11 @@ void draw_pie_chart(const frame_overlay_snapshot& snapshot) {
 	static SCP_string label_storage[MAX_SLICES];
 	static const char* labels[MAX_SLICES];
 	double pct_values[MAX_SLICES];
-	double ms_values[MAX_SLICES];
 	int count = 0;
 
 	auto add_slice = [&](const SCP_string& name, uint64_t self_nanosec) {
 		label_storage[count] = name;
 		labels[count] = label_storage[count].c_str();
-		ms_values[count] = static_cast<double>(self_nanosec) / NANOSEC_PER_MS;
 		pct_values[count] = 100.0 * static_cast<double>(self_nanosec) / static_cast<double>(snapshot.total_nanosec);
 		count++;
 	};
@@ -151,10 +149,48 @@ void draw_pie_chart(const frame_overlay_snapshot& snapshot) {
 	for (int i = 0; i < count; i++) {
 		ImGui::ColorButton(labels[i], slice_colors[i], ImGuiColorEditFlags_NoTooltip, ImVec2(12, 12));
 		ImGui::SameLine();
-		ImGui::Text("%s: %.2f ms (%.1f%%)", labels[i], ms_values[i], pct_values[i]);
+		ImGui::Text("%s: %.1f%%", labels[i], pct_values[i]);
 	}
 
 	ImGui::Columns(1);
+}
+
+/**
+ * Draws whichever -gr_debug stat groups the active graphics backend collects (see
+ * gr_get_debug_stats()). Silently omits a group if its "valid" flag is unset, so this stays a
+ * no-op for backends (or builds) that don't populate a given group.
+ */
+void draw_graphics_debug_stats() {
+	gr_debug_stats stats = gr_get_debug_stats();
+
+	if (!stats.uniform_buffer_valid && !stats.draw_stats_valid) {
+		return;
+	}
+
+	ImGui::Separator();
+	ImGui::TextUnformatted("Graphics API stats (-gr_debug)");
+
+	if (stats.uniform_buffer_valid) {
+		ImGui::Text("Uniform buffer: " SIZE_T_ARG " / " SIZE_T_ARG " bytes used",
+			stats.uniform_buffer_used,
+			stats.uniform_buffer_size);
+	}
+
+	if (stats.draw_stats_valid) {
+		ImGui::Text("Draw calls: %d (%d indexed)", stats.draw_calls, stats.draw_indexed_calls);
+		ImGui::Text("Vertices: %d   Indices: %d", stats.total_vertices, stats.total_indices);
+		ImGui::Text("Material applies: %d (%d failed, %d no pipeline)",
+			stats.apply_material_calls,
+			stats.apply_material_failures,
+			stats.no_pipeline_skips);
+		ImGui::Text("Descriptor sets: %d   writes: %d   pipelines: " SIZE_T_ARG,
+			stats.descriptor_sets_allocated,
+			stats.descriptor_writes,
+			stats.pipeline_count);
+		if (stats.on_demand_texture_uploads > 0) {
+			ImGui::Text("On-demand texture uploads: %d", stats.on_demand_texture_uploads);
+		}
+	}
 }
 
 } // namespace
@@ -174,7 +210,7 @@ void profiler_overlay_draw() {
 	ImGui::NewFrame();
 
 	ImGui::SetNextWindowPos(ImVec2(20, 20), ImGuiCond_FirstUseEver);
-	ImGui::SetNextWindowSize(ImVec2(380, 420), ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowSize(ImVec2(380, 480), ImGuiCond_FirstUseEver);
 	ImGui::Begin("Frame Profiler", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
 
 	if (!frame_profiling_active() || History_ms.empty()) {
@@ -194,6 +230,8 @@ void profiler_overlay_draw() {
 
 		draw_pie_chart(get_frame_profiler_overlay_snapshot());
 	}
+
+	draw_graphics_debug_stats();
 
 	ImGui::End();
 

--- a/code/tracing/ProfilerOverlay.cpp
+++ b/code/tracing/ProfilerOverlay.cpp
@@ -1,0 +1,204 @@
+//
+//
+
+#include "ProfilerOverlay.h"
+
+#include "tracing.h"
+
+#include "graphics/2d.h"
+
+// ImPlot's Plot*() functions are templates that get instantiated here (unlike ImGui's ordinary
+// function API), and their header-inline ImPool<ImPlotItem>::Add() uses memcpy on the
+// non-trivially-copyable ImPlotItem -- which trips pstypes.h's memcpy-safety macro. That macro
+// exists to catch accidental memcpy of non-POD engine types; ImPlotItem is third-party-internal
+// and already safe, so suppress it for just these headers.
+#pragma push_macro("memcpy")
+#undef memcpy
+#include "imgui.h"
+#include "implot.h"
+#include "implot_internal.h"
+#pragma pop_macro("memcpy")
+#include "backends/imgui_impl_sdl.h"
+
+#include <algorithm>
+#include <numeric>
+
+namespace tracing {
+
+namespace {
+
+constexpr size_t HISTORY_SIZE = 300; // ~5s at 60 FPS
+constexpr double NANOSEC_PER_MS = 1'000'000.0;
+
+SCP_vector<float> History_ms;
+
+void push_history(float frame_ms) {
+	History_ms.push_back(frame_ms);
+	if (History_ms.size() > HISTORY_SIZE) {
+		History_ms.erase(History_ms.begin());
+	}
+}
+
+float history_average() {
+	if (History_ms.empty()) {
+		return 0.0f;
+	}
+	float sum = std::accumulate(History_ms.begin(), History_ms.end(), 0.0f);
+	return sum / static_cast<float>(History_ms.size());
+}
+
+float history_median() {
+	if (History_ms.empty()) {
+		return 0.0f;
+	}
+
+	SCP_vector<float> sorted_copy(History_ms.begin(), History_ms.end());
+	size_t mid = sorted_copy.size() / 2;
+	std::nth_element(sorted_copy.begin(), sorted_copy.begin() + mid, sorted_copy.end());
+	float median = sorted_copy[mid];
+
+	if (sorted_copy.size() % 2 == 0) {
+		std::nth_element(sorted_copy.begin(), sorted_copy.begin() + mid - 1, sorted_copy.end());
+		median = (median + sorted_copy[mid - 1]) * 0.5f;
+	}
+
+	return median;
+}
+
+void draw_frametime_graph() {
+	if (History_ms.empty()) {
+		return;
+	}
+
+	if (ImPlot::BeginPlot("##frametime_ms",
+			ImVec2(-1, 90),
+			ImPlotFlags_NoMouseText | ImPlotFlags_NoLegend | ImPlotFlags_NoTitle)) {
+		ImPlot::SetupAxes(nullptr,
+			"ms",
+			ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoGridLines,
+			ImPlotAxisFlags_AutoFit);
+		ImPlot::SetupAxisLimits(ImAxis_X1, 0, static_cast<double>(History_ms.size()), ImPlotCond_Always);
+
+		ImPlot::PlotLine("frametime", History_ms.data(), static_cast<int>(History_ms.size()));
+
+		ImPlot::EndPlot();
+	}
+}
+
+/**
+ * Draws the pie chart (left) and a text legend with matching swatch colors (right). Slice colors
+ * come from ImPlot's own per-item color assignment (keyed by category name), which stays stable
+ * across frames as long as the same names keep appearing -- no manual palette bookkeeping needed.
+ */
+void draw_pie_chart(const frame_overlay_snapshot& snapshot) {
+	if (snapshot.total_nanosec == 0) {
+		return;
+	}
+
+	constexpr int MAX_SLICES = 6; // top 5 contributors + "Other"
+
+	static SCP_string label_storage[MAX_SLICES];
+	static const char* labels[MAX_SLICES];
+	double pct_values[MAX_SLICES];
+	double ms_values[MAX_SLICES];
+	int count = 0;
+
+	auto add_slice = [&](const SCP_string& name, uint64_t self_nanosec) {
+		label_storage[count] = name;
+		labels[count] = label_storage[count].c_str();
+		ms_values[count] = static_cast<double>(self_nanosec) / NANOSEC_PER_MS;
+		pct_values[count] = 100.0 * static_cast<double>(self_nanosec) / static_cast<double>(snapshot.total_nanosec);
+		count++;
+	};
+
+	for (auto& contributor : snapshot.top_contributors) {
+		if (count >= MAX_SLICES) {
+			break;
+		}
+		add_slice(contributor.name, contributor.self_nanosec);
+	}
+	if (snapshot.other_nanosec > 0 && count < MAX_SLICES) {
+		add_slice("Other", snapshot.other_nanosec);
+	}
+
+	if (count == 0) {
+		return;
+	}
+
+	ImVec4 slice_colors[MAX_SLICES];
+
+	ImGui::Columns(2, nullptr, false);
+	ImGui::SetColumnWidth(0, 190);
+
+	if (ImPlot::BeginPlot("##frametime_pie",
+			ImVec2(180, 180),
+			ImPlotFlags_Equal | ImPlotFlags_NoMouseText | ImPlotFlags_NoLegend)) {
+		ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations);
+		ImPlot::SetupAxesLimits(0, 1, 0, 1, ImPlotCond_Always);
+
+		ImPlot::PlotPieChart(labels, pct_values, count, 0.5, 0.5, 0.4, "%.1f%%");
+
+		for (int i = 0; i < count; i++) {
+			ImPlotItem* item = ImPlot::GetItem(labels[i]);
+			slice_colors[i] = item ? ImGui::ColorConvertU32ToFloat4(item->Color) : ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+		}
+
+		ImPlot::EndPlot();
+	}
+
+	ImGui::NextColumn();
+
+	for (int i = 0; i < count; i++) {
+		ImGui::ColorButton(labels[i], slice_colors[i], ImGuiColorEditFlags_NoTooltip, ImVec2(12, 12));
+		ImGui::SameLine();
+		ImGui::Text("%s: %.2f ms (%.1f%%)", labels[i], ms_values[i], pct_values[i]);
+	}
+
+	ImGui::Columns(1);
+}
+
+} // namespace
+
+void profiler_overlay_record_frame() {
+	const frame_overlay_snapshot& snapshot = get_frame_profiler_overlay_snapshot();
+	if (!snapshot.valid) {
+		return;
+	}
+
+	push_history(static_cast<float>(static_cast<double>(snapshot.total_nanosec) / NANOSEC_PER_MS));
+}
+
+void profiler_overlay_draw() {
+	gr_imgui_new_frame();
+	ImGui_ImplSDL2_NewFrame(gr_screen.max_w, gr_screen.max_h);
+	ImGui::NewFrame();
+
+	ImGui::SetNextWindowPos(ImVec2(20, 20), ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowSize(ImVec2(380, 420), ImGuiCond_FirstUseEver);
+	ImGui::Begin("Frame Profiler", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
+
+	if (!frame_profiling_active() || History_ms.empty()) {
+		ImGui::TextUnformatted("Collecting data...");
+	} else {
+		float avg_ms = history_average();
+		float median_ms = history_median();
+
+		ImGui::Text("Avg: %.2f ms (%.0f FPS)   Median: %.2f ms",
+			avg_ms,
+			avg_ms > 0.0f ? 1000.0f / avg_ms : 0.0f,
+			median_ms);
+
+		draw_frametime_graph();
+
+		ImGui::Separator();
+
+		draw_pie_chart(get_frame_profiler_overlay_snapshot());
+	}
+
+	ImGui::End();
+
+	ImGui::Render();
+	gr_imgui_render_draw_data();
+}
+
+} // namespace tracing

--- a/code/tracing/ProfilerOverlay.cpp
+++ b/code/tracing/ProfilerOverlay.cpp
@@ -6,6 +6,9 @@
 #include "tracing.h"
 
 #include "graphics/2d.h"
+#include "io/timer.h"
+#include "model/model.h"
+#include "object/object.h"
 
 // ImPlot's Plot*() functions are templates that get instantiated here (unlike ImGui's ordinary
 // function API), and their header-inline ImPool<ImPlotItem>::Add() uses memcpy on the
@@ -100,16 +103,19 @@ ImU32 color_for_name(const char* name) {
 
 /**
  * Draws a single 100%-stacked horizontal "frame budget" bar: one row whose width is split into
- * segments proportional to each category's share of the frame's traced time (top 5 contributors +
- * "Other"), followed by a legend with matching swatches, absolute ms and percentage. Cheaper than a
- * pie chart -- it's a handful of ImDrawList rectangles with no ImPlot plot setup.
+ * segments proportional to each category's share of the frame's traced time (the snapshot's
+ * top contributors, see FRAME_OVERLAY_MAX_CONTRIBUTORS, + "Other"), followed by a legend with
+ * matching swatches, absolute ms and percentage. Cheaper than a pie chart -- it's a handful of
+ * ImDrawList rectangles with no ImPlot plot setup.
  */
 void draw_frame_budget_bar(const frame_overlay_snapshot& snapshot) {
 	if (snapshot.total_nanosec == 0) {
 		return;
 	}
 
-	constexpr int MAX_SEGMENTS = 6; // top 5 contributors + "Other"
+	// +1 for "Other": snapshot.top_contributors holds at most FRAME_OVERLAY_MAX_CONTRIBUTORS
+	// entries (see tracing.h), so that's the real bound on how many segments can ever exist here.
+	constexpr int MAX_SEGMENTS = static_cast<int>(FRAME_OVERLAY_MAX_CONTRIBUTORS) + 1;
 	constexpr ImU32 OTHER_COLOR = IM_COL32(130, 130, 130, 255);
 
 	struct segment {
@@ -124,7 +130,12 @@ void draw_frame_budget_bar(const frame_overlay_snapshot& snapshot) {
 
 	const auto total = static_cast<double>(snapshot.total_nanosec);
 
+	// Self-defending against MAX_SEGMENTS regardless of caller bookkeeping, since this writes into
+	// a fixed-size array: silently drops anything past capacity rather than overflowing it.
 	auto add_segment = [&](const char* name, uint64_t self_nanosec, ImU32 color) {
+		if (count >= MAX_SEGMENTS) {
+			return;
+		}
 		segments[count].name = name;
 		segments[count].pct = 100.0 * static_cast<double>(self_nanosec) / total;
 		segments[count].ms = static_cast<float>(static_cast<double>(self_nanosec) / NANOSEC_PER_MS);
@@ -133,12 +144,9 @@ void draw_frame_budget_bar(const frame_overlay_snapshot& snapshot) {
 	};
 
 	for (const auto& contributor : snapshot.top_contributors) {
-		if (count >= MAX_SEGMENTS) {
-			break;
-		}
 		add_segment(contributor.name.c_str(), contributor.self_nanosec, color_for_name(contributor.name.c_str()));
 	}
-	if (snapshot.other_nanosec > 0 && count < MAX_SEGMENTS) {
+	if (snapshot.other_nanosec > 0) {
 		add_segment("Other", snapshot.other_nanosec, OTHER_COLOR);
 	}
 
@@ -215,6 +223,117 @@ void draw_graphics_debug_stats() {
 	}
 }
 
+// Memory stats describe level-scope state (loaded models, live object pools, GPU heaps), not
+// per-frame state, so they're refreshed on an interval rather than walked every frame like the
+// timing data above -- that avoids perturbing the very frame cost this overlay measures.
+constexpr int MEMORY_STATS_REFRESH_INTERVAL_MS = 1000;
+
+bool Memory_stats_initialized = false;
+int Last_memory_stats_refresh_ms = 0;
+object_memory_stats Cached_object_memory_stats;
+model_memory_stats Cached_model_memory_stats;
+gr_memory_stats Cached_gr_memory_stats;
+
+void refresh_memory_stats_if_needed() {
+	int now_ms = timer_get_milliseconds();
+	if (Memory_stats_initialized && (now_ms - Last_memory_stats_refresh_ms) < MEMORY_STATS_REFRESH_INTERVAL_MS) {
+		return;
+	}
+
+	Cached_object_memory_stats = obj_get_memory_stats();
+	Cached_model_memory_stats = model_get_memory_stats();
+	Cached_gr_memory_stats = gr_get_memory_stats();
+
+	Last_memory_stats_refresh_ms = now_ms;
+	Memory_stats_initialized = true;
+}
+
+/**
+ * Formats a byte count as a human-readable string using the largest unit that keeps at least one
+ * digit before the decimal point (e.g. "12.3 MB"). Returned by value: several call sites below pass
+ * multiple format_bytes() results as arguments to the same ImGui::Text() call, and every temporary
+ * in a function call's argument list lives until the end of that call, so this needs no buffer
+ * management to stay safe -- unlike returning a pointer into any kind of shared/reused storage.
+ */
+SCP_string format_bytes(size_t bytes) {
+	constexpr double KB = 1024.0;
+	constexpr double MB = KB * 1024.0;
+	constexpr double GB = MB * 1024.0;
+
+	char buf[32];
+	if (auto b = static_cast<double>(bytes); b >= GB) {
+		snprintf(buf, sizeof(buf), "%.2f GB", b / GB);
+	} else if (b >= MB) {
+		snprintf(buf, sizeof(buf), "%.2f MB", b / MB);
+	} else if (b >= KB) {
+		snprintf(buf, sizeof(buf), "%.2f KB", b / KB);
+	} else {
+		snprintf(buf, sizeof(buf), SIZE_T_ARG " B", bytes);
+	}
+
+	return SCP_string(buf);
+}
+
+/**
+ * Draws pool occupancy (used / max) for the object, ship, and weapon pools. These are fixed-size
+ * static arrays, so their byte footprint is a compile-time constant -- occupancy is the only
+ * signal worth showing.
+ */
+void draw_object_memory_stats() {
+	const object_memory_stats& stats = Cached_object_memory_stats;
+
+	ImGui::Separator();
+	ImGui::TextUnformatted("Object Management");
+	ImGui::Text("Objects: %d / %d (peak %d)", stats.objects_used, stats.objects_max, stats.objects_peak);
+	ImGui::Text("Ships:   %d / %d", stats.ships_used, stats.ships_max);
+	ImGui::Text("Weapons: %d / %d", stats.weapons_used, stats.weapons_max);
+}
+
+/**
+ * Draws model and texture memory usage. The GPU-heap numbers (live, reflects frees as models
+ * unload) and the per-model summed numbers (from currently loaded models) are two different views
+ * of related-but-not-identical data and are deliberately not added together into a single total.
+ */
+void draw_asset_memory_stats() {
+	const model_memory_stats& model_stats = Cached_model_memory_stats;
+	const gr_memory_stats& gr_stats = Cached_gr_memory_stats;
+
+	if (!model_stats.valid && !gr_stats.model_heap_valid && !gr_stats.locked_bitmap_ram_valid) {
+		return;
+	}
+
+	ImGui::Separator();
+	ImGui::TextUnformatted("Assets");
+
+	if (model_stats.valid) {
+		ImGui::Text("Models loaded: %d", model_stats.model_count);
+		ImGui::Text("  Vertex data: %s   Index data: %s   BSP/collision: %s",
+			format_bytes(model_stats.vertex_bytes).c_str(),
+			format_bytes(model_stats.index_bytes).c_str(),
+			format_bytes(model_stats.bsp_data_bytes).c_str());
+	}
+
+	if (gr_stats.locked_bitmap_ram_valid) {
+		ImGui::Text("Bitmaps (locked): %s", format_bytes(gr_stats.locked_bitmap_ram_bytes).c_str());
+	}
+
+	if (gr_stats.model_heap_valid) {
+		ImGui::Text("GPU model vertex heap: %s / %s",
+			format_bytes(gr_stats.model_vertex_heap_used).c_str(),
+			format_bytes(gr_stats.model_vertex_heap_size).c_str());
+		ImGui::Text("GPU model index heap:  %s / %s",
+			format_bytes(gr_stats.model_index_heap_used).c_str(),
+			format_bytes(gr_stats.model_index_heap_size).c_str());
+	}
+
+	if (gr_stats.gpu_purpose_valid) {
+		ImGui::Text("GPU textures: %s   geometry: %s   render targets: %s",
+			format_bytes(gr_stats.gpu_texture_bytes).c_str(),
+			format_bytes(gr_stats.gpu_geometry_bytes).c_str(),
+			format_bytes(gr_stats.gpu_render_target_bytes).c_str());
+	}
+}
+
 } // namespace
 
 void profiler_overlay_frame() {
@@ -259,6 +378,12 @@ void profiler_overlay_frame() {
 	}
 
 	draw_graphics_debug_stats();
+
+	refresh_memory_stats_if_needed();
+	if (ImGui::CollapsingHeader("Memory", ImGuiTreeNodeFlags_DefaultOpen)) {
+		draw_object_memory_stats();
+		draw_asset_memory_stats();
+	}
 
 	ImGui::End();
 }

--- a/code/tracing/ProfilerOverlay.cpp
+++ b/code/tracing/ProfilerOverlay.cpp
@@ -16,7 +16,6 @@
 #undef memcpy
 #include "imgui.h"
 #include "implot.h"
-#include "implot_internal.h"
 #pragma pop_macro("memcpy")
 #include "backends/imgui_impl_sdl3.h"
 
@@ -86,73 +85,97 @@ void draw_frametime_graph() {
 }
 
 /**
- * Draws the pie chart (left) and a text legend with matching swatch colors (right). Slice colors
- * come from ImPlot's own per-item color assignment (keyed by category name), which stays stable
- * across frames as long as the same names keep appearing -- no manual palette bookkeeping needed.
+ * Maps a category name to a stable color, so a given category keeps the same color across frames
+ * regardless of how its rank shifts in the breakdown. Uses an FNV-1a hash of the name to pick a
+ * hue; "Other" gets a fixed neutral grey (see draw_frame_budget_bar).
  */
-void draw_pie_chart(const frame_overlay_snapshot& snapshot) {
+ImU32 color_for_name(const char* name) {
+	uint32_t hash = 2166136261u; // FNV-1a
+	for (const char* p = name; *p != '\0'; ++p) {
+		hash ^= static_cast<uint8_t>(*p);
+		hash *= 16777619u;
+	}
+	const float hue = static_cast<float>(hash % 360) / 360.0f;
+	return ImGui::ColorConvertFloat4ToU32(static_cast<ImVec4>(ImColor::HSV(hue, 0.55f, 0.95f)));
+}
+
+/**
+ * Draws a single 100%-stacked horizontal "frame budget" bar: one row whose width is split into
+ * segments proportional to each category's share of the frame's traced time (top 5 contributors +
+ * "Other"), followed by a legend with matching swatches, absolute ms and percentage. Cheaper than a
+ * pie chart -- it's a handful of ImDrawList rectangles with no ImPlot plot setup.
+ */
+void draw_frame_budget_bar(const frame_overlay_snapshot& snapshot) {
 	if (snapshot.total_nanosec == 0) {
 		return;
 	}
 
-	constexpr int MAX_SLICES = 6; // top 5 contributors + "Other"
+	constexpr int MAX_SEGMENTS = 6; // top 5 contributors + "Other"
+	constexpr ImU32 OTHER_COLOR = IM_COL32(130, 130, 130, 255);
 
-	static SCP_string label_storage[MAX_SLICES];
-	static const char* labels[MAX_SLICES];
-	double pct_values[MAX_SLICES];
+	struct segment {
+		const char* name;
+		double pct;
+		float ms;
+		ImU32 color;
+	};
+
+	segment segments[MAX_SEGMENTS];
 	int count = 0;
 
-	auto add_slice = [&](const SCP_string& name, uint64_t self_nanosec) {
-		label_storage[count] = name;
-		labels[count] = label_storage[count].c_str();
-		pct_values[count] = 100.0 * static_cast<double>(self_nanosec) / static_cast<double>(snapshot.total_nanosec);
+	const double total = static_cast<double>(snapshot.total_nanosec);
+
+	auto add_segment = [&](const char* name, uint64_t self_nanosec, ImU32 color) {
+		segments[count].name = name;
+		segments[count].pct = 100.0 * static_cast<double>(self_nanosec) / total;
+		segments[count].ms = static_cast<float>(static_cast<double>(self_nanosec) / NANOSEC_PER_MS);
+		segments[count].color = color;
 		count++;
 	};
 
-	for (auto& contributor : snapshot.top_contributors) {
-		if (count >= MAX_SLICES) {
+	for (const auto& contributor : snapshot.top_contributors) {
+		if (count >= MAX_SEGMENTS) {
 			break;
 		}
-		add_slice(contributor.name, contributor.self_nanosec);
+		add_segment(contributor.name.c_str(), contributor.self_nanosec, color_for_name(contributor.name.c_str()));
 	}
-	if (snapshot.other_nanosec > 0 && count < MAX_SLICES) {
-		add_slice("Other", snapshot.other_nanosec);
+	if (snapshot.other_nanosec > 0 && count < MAX_SEGMENTS) {
+		add_segment("Other", snapshot.other_nanosec, OTHER_COLOR);
 	}
 
 	if (count == 0) {
 		return;
 	}
 
-	ImVec4 slice_colors[MAX_SLICES];
+	// The stacked bar.
+	ImDrawList* draw_list = ImGui::GetWindowDrawList();
+	const ImVec2 origin = ImGui::GetCursorScreenPos();
+	const float width = ImGui::GetContentRegionAvail().x;
+	constexpr float height = 22.0f;
 
-	ImGui::Columns(2, nullptr, false);
-	ImGui::SetColumnWidth(0, 190);
+	draw_list->AddRectFilled(origin, ImVec2(origin.x + width, origin.y + height), IM_COL32(35, 35, 35, 255), 3.0f);
 
-	if (ImPlot::BeginPlot("##frametime_pie",
-			ImVec2(180, 180),
-			ImPlotFlags_Equal | ImPlotFlags_NoMouseText | ImPlotFlags_NoLegend)) {
-		ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations);
-		ImPlot::SetupAxesLimits(0, 1, 0, 1, ImPlotCond_Always);
-
-		ImPlot::PlotPieChart(labels, pct_values, count, 0.5, 0.5, 0.4, "%.1f%%");
-
-		for (int i = 0; i < count; i++) {
-			ImPlotItem* item = ImPlot::GetItem(labels[i]);
-			slice_colors[i] = item ? ImGui::ColorConvertU32ToFloat4(item->Color) : ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
-		}
-
-		ImPlot::EndPlot();
-	}
-
-	ImGui::NextColumn();
-
+	float x = origin.x;
 	for (int i = 0; i < count; i++) {
-		ImGui::ColorButton(labels[i], slice_colors[i], ImGuiColorEditFlags_NoTooltip, ImVec2(12, 12));
-		ImGui::SameLine();
-		ImGui::Text("%s: %.1f%%", labels[i], pct_values[i]);
+		float seg_w = width * static_cast<float>(segments[i].pct / 100.0);
+		// Make sure the final segment reaches the right edge despite float rounding.
+		const float x_end = (i == count - 1) ? (origin.x + width) : (x + seg_w);
+		draw_list->AddRectFilled(ImVec2(x, origin.y), ImVec2(x_end, origin.y + height), segments[i].color);
+		x = x_end;
 	}
+	draw_list->AddRect(origin, ImVec2(origin.x + width, origin.y + height), IM_COL32(80, 80, 80, 255), 3.0f);
 
-	ImGui::Columns(1);
+	ImGui::Dummy(ImVec2(width, height));
+
+	// The legend.
+	for (int i = 0; i < count; i++) {
+		ImGui::ColorButton(segments[i].name,
+			ImGui::ColorConvertU32ToFloat4(segments[i].color),
+			ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoBorder,
+			ImVec2(12, 12));
+		ImGui::SameLine();
+		ImGui::Text("%s: %.2f ms (%.1f%%)", segments[i].name, segments[i].ms, segments[i].pct);
+	}
 }
 
 /**
@@ -228,7 +251,7 @@ void profiler_overlay_draw() {
 
 		ImGui::Separator();
 
-		draw_pie_chart(get_frame_profiler_overlay_snapshot());
+		draw_frame_budget_bar(get_frame_profiler_overlay_snapshot());
 	}
 
 	draw_graphics_debug_stats();

--- a/code/tracing/ProfilerOverlay.cpp
+++ b/code/tracing/ProfilerOverlay.cpp
@@ -18,7 +18,7 @@
 #include "implot.h"
 #include "implot_internal.h"
 #pragma pop_macro("memcpy")
-#include "backends/imgui_impl_sdl.h"
+#include "backends/imgui_impl_sdl3.h"
 
 #include <algorithm>
 #include <numeric>
@@ -206,7 +206,7 @@ void profiler_overlay_record_frame() {
 
 void profiler_overlay_draw() {
 	gr_imgui_new_frame();
-	ImGui_ImplSDL2_NewFrame(gr_screen.max_w, gr_screen.max_h);
+	ImGui_ImplSDL3_NewFrame();
 	ImGui::NewFrame();
 
 	ImGui::SetNextWindowPos(ImVec2(20, 20), ImGuiCond_FirstUseEver);

--- a/code/tracing/ProfilerOverlay.cpp
+++ b/code/tracing/ProfilerOverlay.cpp
@@ -271,7 +271,7 @@ SCP_string format_bytes(size_t bytes) {
 		snprintf(buf, sizeof(buf), SIZE_T_ARG " B", bytes);
 	}
 
-	return SCP_string(buf);
+	return { buf };
 }
 
 /**

--- a/code/tracing/ProfilerOverlay.cpp
+++ b/code/tracing/ProfilerOverlay.cpp
@@ -123,7 +123,7 @@ void draw_frame_budget_bar(const frame_overlay_snapshot& snapshot) {
 	segment segments[MAX_SEGMENTS];
 	int count = 0;
 
-	const double total = static_cast<double>(snapshot.total_nanosec);
+	const auto total = static_cast<double>(snapshot.total_nanosec);
 
 	auto add_segment = [&](const char* name, uint64_t self_nanosec, ImU32 color) {
 		segments[count].name = name;

--- a/code/tracing/ProfilerOverlay.cpp
+++ b/code/tracing/ProfilerOverlay.cpp
@@ -17,7 +17,6 @@
 #include "imgui.h"
 #include "implot.h"
 #pragma pop_macro("memcpy")
-#include "backends/imgui_impl_sdl3.h"
 
 #include <algorithm>
 #include <numeric>
@@ -218,25 +217,30 @@ void draw_graphics_debug_stats() {
 
 } // namespace
 
-void profiler_overlay_record_frame() {
-	const frame_overlay_snapshot& snapshot = get_frame_profiler_overlay_snapshot();
-	if (!snapshot.valid) {
+void profiler_overlay_frame() {
+	if (!frame_profiling_active()) {
+		History_ms.clear();
 		return;
 	}
 
-	push_history(static_cast<float>(static_cast<double>(snapshot.total_nanosec) / NANOSEC_PER_MS));
-}
+	frame_profile_process_frame();
 
-void profiler_overlay_draw() {
-	gr_imgui_new_frame();
-	ImGui_ImplSDL3_NewFrame();
-	ImGui::NewFrame();
+	const frame_overlay_snapshot& snapshot = get_frame_profiler_overlay_snapshot();
+	if (snapshot.valid) {
+		push_history(static_cast<float>(static_cast<double>(snapshot.total_nanosec) / NANOSEC_PER_MS));
+	}
+
+	gr_imgui_begin_frame();
+	if (!gr_imgui_frame_active()) {
+		// No ImGui backend on this renderer (standalone server) — nothing to draw into.
+		return;
+	}
 
 	ImGui::SetNextWindowPos(ImVec2(20, 20), ImGuiCond_FirstUseEver);
 	ImGui::SetNextWindowSize(ImVec2(380, 480), ImGuiCond_FirstUseEver);
 	ImGui::Begin("Frame Profiler", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
 
-	if (!frame_profiling_active() || History_ms.empty()) {
+	if (History_ms.empty()) {
 		ImGui::TextUnformatted("Collecting data...");
 	} else {
 		float avg_ms = history_average();
@@ -251,15 +255,12 @@ void profiler_overlay_draw() {
 
 		ImGui::Separator();
 
-		draw_frame_budget_bar(get_frame_profiler_overlay_snapshot());
+		draw_frame_budget_bar(snapshot);
 	}
 
 	draw_graphics_debug_stats();
 
 	ImGui::End();
-
-	ImGui::Render();
-	gr_imgui_render_draw_data();
 }
 
 } // namespace tracing

--- a/code/tracing/ProfilerOverlay.h
+++ b/code/tracing/ProfilerOverlay.h
@@ -7,18 +7,18 @@
 namespace tracing {
 
 /**
- * Records the current frame's total traced time (see get_frame_profiler_overlay_snapshot()) into
- * the rolling history buffer used by profiler_overlay_draw()'s graph/avg/median. Call once per
- * frame, right after frame_profile_process_frame(), while profiling is active.
+ * Per-frame entry point for the ImGui frame profiler overlay, called once from gr_flip().
+ *
+ * Drains the frame profiler (see frame_profile_process_frame()), folds the frame's total traced
+ * time into the rolling history behind the graph/avg/median, and contributes the overlay window
+ * -- avg/median frametime, a scrolling frametime graph, a stacked frame-budget bar of the top
+ * traced categories by self-time, and the -gr_debug graphics stats -- to this frame's ImGui pass,
+ * opening one via gr_imgui_begin_frame() if no other consumer already has.
+ *
+ * No-op when frame profiling is disabled. Being the single per-frame driver is what keeps the
+ * profiler's event buffer bounded in every game state, so it must stay on the common flip path
+ * rather than being called per game state.
  */
-void profiler_overlay_record_frame();
-
-/**
- * Draws the ImGui/ImPlot frame profiler overlay window: avg/median frametime, a scrolling
- * frametime graph, and a pie chart of the top-5 traced categories by self-time. Self-contained --
- * does its own ImGui::NewFrame()/Render() and submits the draw data, since mission gameplay
- * doesn't otherwise touch ImGui. Must be called before the current frame is flipped.
- */
-void profiler_overlay_draw();
+void profiler_overlay_frame();
 
 }

--- a/code/tracing/ProfilerOverlay.h
+++ b/code/tracing/ProfilerOverlay.h
@@ -1,0 +1,24 @@
+#pragma once
+
+/** @file
+ *  @ingroup tracing
+ */
+
+namespace tracing {
+
+/**
+ * Records the current frame's total traced time (see get_frame_profiler_overlay_snapshot()) into
+ * the rolling history buffer used by profiler_overlay_draw()'s graph/avg/median. Call once per
+ * frame, right after frame_profile_process_frame(), while profiling is active.
+ */
+void profiler_overlay_record_frame();
+
+/**
+ * Draws the ImGui/ImPlot frame profiler overlay window: avg/median frametime, a scrolling
+ * frametime graph, and a pie chart of the top-5 traced categories by self-time. Self-contained --
+ * does its own ImGui::NewFrame()/Render() and submits the draw data, since mission gameplay
+ * doesn't otherwise touch ImGui. Must be called before the current frame is flipped.
+ */
+void profiler_overlay_draw();
+
+}

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -5,22 +5,28 @@ namespace tracing {
 
 namespace {
 // Function-local static (Meyers singleton) to avoid any static-init-order dependency: categories
-// are themselves global statics, so this counter must be alive before the first one is constructed.
-int& category_id_counter()
+// are themselves global statics, so this registry must be alive before the first one is constructed.
+// Each Category registers itself here at construction; its index is its id.
+SCP_vector<const Category*>& category_registry()
 {
-	static int counter = 0;
-	return counter;
+	static SCP_vector<const Category*> registry;
+	return registry;
 }
 } // namespace
 
 Category::Category(const char* name, bool is_graphics)
-	: _name(name), _graphics_category(is_graphics), _id(category_id_counter()++) {
+	: _name(name), _graphics_category(is_graphics), _id(static_cast<int>(category_registry().size())) {
+	category_registry().push_back(this);
 }
 const char* Category::getName() const {
 	return _name.c_str();
 }
 int Category::getCount() {
-	return category_id_counter();
+	return static_cast<int>(category_registry().size());
+}
+const Category& Category::getById(int id) {
+	Assertion(id >= 0 && id < getCount(), "Category id %d is out of range!", id);
+	return *category_registry()[static_cast<size_t>(id)];
 }
 bool Category::usesGPUCounter() const {
 	return _graphics_category;

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -3,10 +3,24 @@
 
 namespace tracing {
 
-Category::Category(const char* name, bool is_graphics) : _name(name), _graphics_category(is_graphics) {
+namespace {
+// Function-local static (Meyers singleton) to avoid any static-init-order dependency: categories
+// are themselves global statics, so this counter must be alive before the first one is constructed.
+int& category_id_counter()
+{
+	static int counter = 0;
+	return counter;
+}
+} // namespace
+
+Category::Category(const char* name, bool is_graphics)
+	: _name(name), _graphics_category(is_graphics), _id(category_id_counter()++) {
 }
 const char* Category::getName() const {
 	return _name.c_str();
+}
+int Category::getCount() {
+	return category_id_counter();
 }
 bool Category::usesGPUCounter() const {
 	return _graphics_category;

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -39,6 +39,15 @@ class Category {
 	 * array indexed by getId().
 	 */
 	static int getCount();
+
+	/**
+	 * @brief The category with the given id, which must be in [0, getCount()).
+	 *
+	 * Lets code that accumulates per-category data keyed by getId() recover the category from an
+	 * id alone, rather than carrying a parallel id -> Category* array alongside its results.
+	 * Categories are global statics, so the reference is valid for the life of the program.
+	 */
+	static const Category& getById(int id);
 };
 
 extern Category LuaOnFrame;

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -17,12 +17,28 @@ namespace tracing {
 class Category {
 	const SCP_string _name;
 	bool _graphics_category;
+	int _id;
  public:
 	Category(const char* name, bool is_graphics);
 
 	const char* getName() const;
 
 	bool usesGPUCounter() const;
+
+	/**
+	 * @brief A stable, dense id in the range [0, getCount()) assigned at construction.
+	 *
+	 * Categories are global statics, so ids are handed out in construction order and can be used
+	 * to index a fixed-size array (see the frame profiler's per-category self-time accumulation).
+	 */
+	int getId() const { return _id; }
+
+	/**
+	 * @brief The number of Category instances constructed so far. At runtime (after static
+	 * initialization) this equals the total number of categories, so it is a safe size for an
+	 * array indexed by getId().
+	 */
+	static int getCount();
 };
 
 extern Category LuaOnFrame;

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -9,6 +9,7 @@
 #include "TraceEventWriter.h"
 #include "MainFrameTimer.h"
 #include "FrameProfiler.h"
+#include "options/Option.h"
 
 #include <cinttypes>
 #include <fstream>
@@ -116,6 +117,14 @@ bool do_trace_events = false;
 bool do_async_events = false;
 bool do_counter_events = false;
 std::int64_t main_thread_id = -1;
+
+}
+
+namespace tracing {
+bool Profiler_overlay_enabled = false;
+}
+
+namespace {
 
 int gpu_start_query = -1;
 std::uint64_t gpu_start_time = 0;
@@ -240,10 +249,10 @@ void init() {
 		mainFrameTimer.reset(new ThreadedMainFrameTimer());
 		do_async_events = true;
 	}
-	if (Cmdline_frame_profile) {
-		frameProfiler.reset(new FrameProfiler());
-		do_trace_events = true;
-	}
+	// Seed the runtime profiler-overlay toggle from -profile_frame_time (kept for backward
+	// compatibility); this also lazily constructs the FrameProfiler and folds
+	// Cmdline_json_profiling/Cmdline_frame_profile into do_trace_events.
+	set_frame_profiling_enabled(Cmdline_frame_profile);
 
 	do_gpu_queries = gr_is_capable(gr_capability::CAPABILITY_TIMESTAMP_QUERY);
 	queries_reusable = gr_is_capable(gr_capability::CAPABILITY_QUERIES_REUSABLE);
@@ -275,6 +284,40 @@ SCP_string get_frame_profile_output() {
 
 	return frameProfiler->getContent();
 }
+
+const frame_overlay_snapshot& get_frame_profiler_overlay_snapshot() {
+	Assertion(frameProfiler, "Frame profiling must be enabled for this function!");
+
+	return frameProfiler->getOverlaySnapshot();
+}
+
+bool frame_profiling_active() {
+	return Profiler_overlay_enabled;
+}
+
+void set_frame_profiling_enabled(bool enable) {
+	Profiler_overlay_enabled = enable;
+
+	if (enable && !frameProfiler) {
+		frameProfiler.reset(new FrameProfiler());
+	}
+
+	do_trace_events = Cmdline_json_profiling || Cmdline_frame_profile || Profiler_overlay_enabled;
+}
+
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
+static auto ProfilerOverlayOption = options::OptionBuilder<bool>("Game.ProfilerOverlay",
+	std::pair<const char*, int>{"Frame Profiler Overlay", 1932},
+	std::pair<const char*, int>{"Show an ImGui overlay with a frametime graph and a breakdown of what's taking up frame time", 1933})
+	.category(std::make_pair("Graphics", 1825))
+	.level(options::ExpertLevel::Advanced)
+	.default_func([]() { return Profiler_overlay_enabled; })
+	.change_listener([](const bool& val, bool) {
+		set_frame_profiling_enabled(val);
+		return true;
+	})
+	.importance(69)
+	.finish();
 
 void shutdown() {
 	if (queries_reusable) {

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -252,7 +252,12 @@ void init() {
 	// Seed the runtime profiler-overlay toggle from -profile_frame_time (kept for backward
 	// compatibility); this also lazily constructs the FrameProfiler and folds
 	// Cmdline_json_profiling/Cmdline_frame_profile into do_trace_events.
-	set_frame_profiling_enabled(Cmdline_frame_profile);
+	// OR in Profiler_overlay_enabled rather than overwriting it outright: the "Game.ProfilerOverlay"
+	// option's loadInitialValues() call (see OptionsManager) runs before tracing::init(), so by the
+	// time we get here Profiler_overlay_enabled may already reflect a persisted "on" setting that
+	// -profile_frame_time knows nothing about. Overwriting would silently disable the overlay on
+	// startup until the option was re-toggled at runtime.
+	set_frame_profiling_enabled(Cmdline_frame_profile || Profiler_overlay_enabled);
 
 	do_gpu_queries = gr_is_capable(gr_capability::CAPABILITY_TIMESTAMP_QUERY);
 	queries_reusable = gr_is_capable(gr_capability::CAPABILITY_QUERIES_REUSABLE);

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -21,18 +21,18 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-static int64_t get_tid() {
+static int64_t query_tid() {
     return (int64_t) GetCurrentThreadId();
 }
 #elif __LINUX__
 #include <sys/syscall.h>
-static int64_t get_tid() {
+static int64_t query_tid() {
 	return (int64_t) syscall(SYS_gettid);
 }
 #else
 #include <pthread.h>
 
-static int64_t get_tid() {
+static int64_t query_tid() {
 // This is not a reliable way of getting the tid but it's better than nothing
     return (int64_t) pthread_self();
 }
@@ -40,16 +40,29 @@ static int64_t get_tid() {
 
 // A function for getting the id of the current process
 #ifdef WIN32
-static int64_t get_pid() {
+static int64_t query_pid() {
     return (int64_t)GetCurrentProcessId();
 }
 #else
 #include <unistd.h>
 
-static int64_t get_pid() {
+static int64_t query_pid() {
 	return (int64_t) getpid();
 }
 #endif
+
+// Cached accessors: the thread/process id never changes for the lifetime of a thread, but the
+// underlying queries are real syscalls on Linux (SYS_gettid) and glibc (getpid, uncached since
+// 2.25). A trace event is emitted for every TRACE_SCOPE, so querying these per event dominated the
+// tracing overhead -- cache them in thread-local storage so each thread pays the syscall only once.
+static int64_t get_tid() {
+	thread_local const int64_t tid = query_tid();
+	return tid;
+}
+static int64_t get_pid() {
+	thread_local const int64_t pid = query_pid();
+	return pid;
+}
 
 namespace {
 

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -71,6 +71,12 @@ using namespace tracing;
 std::unique_ptr<ThreadedTraceEventWriter> traceEventWriter;
 std::unique_ptr<ThreadedMainFrameTimer> mainFrameTimer;
 std::unique_ptr<FrameProfiler> frameProfiler;
+// Guards frameProfiler's lifetime. submit_event() reads it from whichever thread emits a trace
+// event -- not just the main thread; e.g. the cutscene decode/audio threads (TRACE_SCOPE in
+// cutscene/player.cpp) -- while set_frame_profiling_enabled() constructs/destroys it from the main
+// thread whenever the "Frame Profiler Overlay" option is toggled at runtime. Without this, a toggle
+// mid-cutscene can free the object out from under a concurrent processEvent() call.
+std::mutex frameProfilerMutex;
 
 SCP_vector<int> query_objects;
 // Free list for backends where queries are immediately reusable (OpenGL).
@@ -153,8 +159,11 @@ void submit_event(trace_event* evt) {
 		mainFrameTimer->processEvent(evt);
 	}
 
-	if (frameProfiler) {
-		frameProfiler->processEvent(evt);
+	{
+		std::lock_guard<std::mutex> lock(frameProfilerMutex);
+		if (frameProfiler) {
+			frameProfiler->processEvent(evt);
+		}
 	}
 }
 
@@ -281,6 +290,7 @@ void process_events() {
 	}
 }
 void frame_profile_process_frame() {
+	std::lock_guard<std::mutex> lock(frameProfilerMutex);
 	if (!frameProfiler) {
 		return;
 	}
@@ -289,29 +299,34 @@ void frame_profile_process_frame() {
 }
 
 SCP_string get_frame_profile_output() {
+	std::lock_guard<std::mutex> lock(frameProfilerMutex);
 	Assertion(frameProfiler, "Frame profiling must be enabled for this function!");
 
 	return frameProfiler->getContent();
 }
 
 const frame_overlay_snapshot& get_frame_profiler_overlay_snapshot() {
+	std::lock_guard<std::mutex> lock(frameProfilerMutex);
 	Assertion(frameProfiler, "Frame profiling must be enabled for this function!");
 
 	return frameProfiler->getOverlaySnapshot();
 }
 
 bool frame_profiling_active() {
+	std::lock_guard<std::mutex> lock(frameProfilerMutex);
 	return frameProfiler != nullptr;
 }
 
 void set_frame_profiling_enabled(bool enable) {
+	std::lock_guard<std::mutex> lock(frameProfilerMutex);
+
 	// The profiler's existence is the single source of truth for "is the frame profiler
 	// collecting". submit_event() feeds it whenever it exists, and frame_profile_process_frame()
 	// (the only thing that drains its event buffer) is driven from gr_flip(), so collection and
 	// draining are gated on the same condition and cannot drift apart. Destroying it on disable
 	// is what stops collection -- leaving a live profiler behind while nothing drained it is how
 	// its buffer used to grow without bound.
-	if (enable != frame_profiling_active()) {
+	if (enable != (frameProfiler != nullptr)) {
 		if (enable) {
 			frameProfiler.reset(new FrameProfiler());
 		} else {

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -131,14 +131,6 @@ bool do_async_events = false;
 bool do_counter_events = false;
 std::int64_t main_thread_id = -1;
 
-}
-
-namespace tracing {
-bool Profiler_overlay_enabled = false;
-}
-
-namespace {
-
 int gpu_start_query = -1;
 std::uint64_t gpu_start_time = 0;
 std::uint64_t cpu_start_time = 0;
@@ -262,15 +254,12 @@ void init() {
 		mainFrameTimer.reset(new ThreadedMainFrameTimer());
 		do_async_events = true;
 	}
-	// Seed the runtime profiler-overlay toggle from -profile_frame_time (kept for backward
-	// compatibility); this also lazily constructs the FrameProfiler and folds
-	// Cmdline_json_profiling/Cmdline_frame_profile into do_trace_events.
-	// OR in Profiler_overlay_enabled rather than overwriting it outright: the "Game.ProfilerOverlay"
-	// option's loadInitialValues() call (see OptionsManager) runs before tracing::init(), so by the
-	// time we get here Profiler_overlay_enabled may already reflect a persisted "on" setting that
-	// -profile_frame_time knows nothing about. Overwriting would silently disable the overlay on
-	// startup until the option was re-toggled at runtime.
-	set_frame_profiling_enabled(Cmdline_frame_profile || Profiler_overlay_enabled);
+	// -profile_frame_time turns the profiler on for the whole session (kept for backward
+	// compatibility). OR in the current state rather than overwriting it: the
+	// "Game.ProfilerOverlay" option's loadInitialValues() call (see OptionsManager) runs before
+	// tracing::init(), so a persisted "on" setting may already have enabled the profiler by the
+	// time we get here, and -profile_frame_time knows nothing about it.
+	set_frame_profiling_enabled(Cmdline_frame_profile || frame_profiling_active());
 
 	do_gpu_queries = gr_is_capable(gr_capability::CAPABILITY_TIMESTAMP_QUERY);
 	queries_reusable = gr_is_capable(gr_capability::CAPABILITY_QUERIES_REUSABLE);
@@ -292,9 +281,11 @@ void process_events() {
 	}
 }
 void frame_profile_process_frame() {
-	Assertion(frameProfiler, "Frame profiling must be enabled for this function!");
+	if (!frameProfiler) {
+		return;
+	}
 
-	return frameProfiler->processFrame();
+	frameProfiler->processFrame();
 }
 
 SCP_string get_frame_profile_output() {
@@ -310,17 +301,27 @@ const frame_overlay_snapshot& get_frame_profiler_overlay_snapshot() {
 }
 
 bool frame_profiling_active() {
-	return Profiler_overlay_enabled;
+	return frameProfiler != nullptr;
 }
 
 void set_frame_profiling_enabled(bool enable) {
-	Profiler_overlay_enabled = enable;
-
-	if (enable && !frameProfiler) {
-		frameProfiler.reset(new FrameProfiler());
+	// The profiler's existence is the single source of truth for "is the frame profiler
+	// collecting". submit_event() feeds it whenever it exists, and frame_profile_process_frame()
+	// (the only thing that drains its event buffer) is driven from gr_flip(), so collection and
+	// draining are gated on the same condition and cannot drift apart. Destroying it on disable
+	// is what stops collection -- leaving a live profiler behind while nothing drained it is how
+	// its buffer used to grow without bound.
+	if (enable != frame_profiling_active()) {
+		if (enable) {
+			frameProfiler.reset(new FrameProfiler());
+		} else {
+			frameProfiler = nullptr;
+		}
 	}
 
-	do_trace_events = Cmdline_json_profiling || Cmdline_frame_profile || Profiler_overlay_enabled;
+	// Recomputed unconditionally, not just on a transition: init() clears do_trace_events before
+	// calling us, and the option's change listener may already have enabled the profiler by then.
+	do_trace_events = Cmdline_json_profiling || enable;
 }
 
 // coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
@@ -329,7 +330,7 @@ static auto ProfilerOverlayOption = options::OptionBuilder<bool>("Game.ProfilerO
 	std::pair<const char*, int>{"Show an ImGui overlay with a frametime graph and a breakdown of what's taking up frame time", 1933})
 	.category(std::make_pair("Graphics", 1825))
 	.level(options::ExpertLevel::Advanced)
-	.default_func([]() { return Profiler_overlay_enabled; })
+	.default_val(false)
 	.change_listener([](const bool& val, bool) {
 		set_frame_profiling_enabled(val);
 		return true;

--- a/code/tracing/tracing.h
+++ b/code/tracing/tracing.h
@@ -80,14 +80,6 @@ struct frame_overlay_snapshot {
 };
 
 /**
- * @brief Whether frame profiling data collection is currently enabled. Driven by the "Frame
- * Profiler Overlay" option (and seeded from -profile_frame_time at startup); toggling it is the
- * single thing that gates the profiler's runtime cost, so prefer set_frame_profiling_enabled()
- * over writing this directly.
- */
-extern bool Profiler_overlay_enabled;
-
-/**
  * @brief Initializes the tracing subsystem
  */
 void init();
@@ -97,6 +89,13 @@ void init();
  */
 void process_events();
 
+/**
+ * @brief Folds this frame's buffered trace events into the overlay snapshot and clears the buffer
+ *
+ * This is the only thing that drains the profiler's event buffer, so it must run once per
+ * presented frame for as long as collection is enabled — gr_flip() drives it (via
+ * profiler_overlay_frame()) for exactly that reason. No-op when profiling is off.
+ */
 void frame_profile_process_frame();
 
 /**
@@ -112,13 +111,20 @@ SCP_string get_frame_profile_output();
 const frame_overlay_snapshot& get_frame_profiler_overlay_snapshot();
 
 /**
- * @brief True if frame profiling data is currently being collected (see set_frame_profiling_enabled()).
+ * @brief True if frame profiling data is currently being collected
+ *
+ * This is the single source of truth for "is the frame profiler on" — every consumer (the
+ * overlay, the lab's text dump, osapi's ImGui input forwarding) asks here rather than
+ * re-deriving it from the command line or the options system.
  */
 bool frame_profiling_active();
 
 /**
- * @brief Enables or disables frame profiling collection at runtime (lazily constructs the profiler
- * on first enable). This is the single toggle the ImGui overlay's options-menu checkbox drives.
+ * @brief Enables or disables frame profiling collection at runtime
+ *
+ * Constructs the profiler on enable and destroys it on disable; that lifetime *is*
+ * frame_profiling_active(). Driven by the "Frame Profiler Overlay" option and seeded from
+ * -profile_frame_time at startup.
  */
 void set_frame_profiling_enabled(bool enable);
 

--- a/code/tracing/tracing.h
+++ b/code/tracing/tracing.h
@@ -66,11 +66,20 @@ struct frame_overlay_contributor {
 };
 
 /**
+ * Cap on frame_overlay_snapshot::top_contributors. The single place this is defined, so the
+ * producer (FrameProfiler::build_overlay_snapshot) and every consumer (currently the overlay's
+ * stacked frame-budget bar) can't drift apart on how many contributors get their own slot before
+ * folding into "Other".
+ */
+constexpr size_t FRAME_OVERLAY_MAX_CONTRIBUTORS = 5;
+
+/**
  * A structured, per-frame snapshot of profiling data meant for the ImGui overlay (as opposed to
- * get_frame_profile_output()'s preformatted text dump). top_contributors holds the top 5 categories
- * by self-time, sorted descending; everything else is folded into other_nanosec. total_nanosec
- * is the sum of every sample's self-time (top_contributors + other_nanosec). All times are in
- * nanoseconds, matching trace_event::timestamp/duration (timer_get_nanoseconds()).
+ * get_frame_profile_output()'s preformatted text dump). top_contributors holds up to
+ * FRAME_OVERLAY_MAX_CONTRIBUTORS categories by self-time, sorted descending; everything else is
+ * folded into other_nanosec. total_nanosec is the sum of every sample's self-time
+ * (top_contributors + other_nanosec). All times are in nanoseconds, matching
+ * trace_event::timestamp/duration (timer_get_nanoseconds()).
  */
 struct frame_overlay_snapshot {
 	bool valid = false;

--- a/code/tracing/tracing.h
+++ b/code/tracing/tracing.h
@@ -57,6 +57,37 @@ struct trace_event {
 };
 
 /**
+ * A single named contributor to a frame's total traced time, used by the ImGui frame profiler
+ * overlay's pie chart.
+ */
+struct frame_overlay_contributor {
+	SCP_string name;
+	uint64_t self_nanosec;
+};
+
+/**
+ * A structured, per-frame snapshot of profiling data meant for the ImGui overlay (as opposed to
+ * get_frame_profile_output()'s preformatted text dump). top_contributors holds the top 5 categories
+ * by self-time, sorted descending; everything else is folded into other_nanosec. total_nanosec
+ * is the sum of every sample's self-time (top_contributors + other_nanosec). All times are in
+ * nanoseconds, matching trace_event::timestamp/duration (timer_get_nanoseconds()).
+ */
+struct frame_overlay_snapshot {
+	bool valid = false;
+	uint64_t total_nanosec = 0;
+	SCP_vector<frame_overlay_contributor> top_contributors;
+	uint64_t other_nanosec = 0;
+};
+
+/**
+ * @brief Whether frame profiling data collection is currently enabled. Driven by the "Frame
+ * Profiler Overlay" option (and seeded from -profile_frame_time at startup); toggling it is the
+ * single thing that gates the profiler's runtime cost, so prefer set_frame_profiling_enabled()
+ * over writing this directly.
+ */
+extern bool Profiler_overlay_enabled;
+
+/**
  * @brief Initializes the tracing subsystem
  */
 void init();
@@ -73,6 +104,23 @@ void frame_profile_process_frame();
  * @return The frame profiler output
  */
 SCP_string get_frame_profile_output();
+
+/**
+ * @brief Gets a structured snapshot of the current frame's profiling data, for the ImGui overlay.
+ * @return The frame profiler overlay snapshot
+ */
+const frame_overlay_snapshot& get_frame_profiler_overlay_snapshot();
+
+/**
+ * @brief True if frame profiling data is currently being collected (see set_frame_profiling_enabled()).
+ */
+bool frame_profiling_active();
+
+/**
+ * @brief Enables or disables frame profiling collection at runtime (lazily constructs the profiler
+ * on first enable). This is the single toggle the ImGui overlay's options-menu checkbox drives.
+ */
+void set_frame_profiling_enabled(bool enable);
 
 /**
  * @brief Deinitializes the tracing subsystem

--- a/code/utils/HeapAllocator.cpp
+++ b/code/utils/HeapAllocator.cpp
@@ -173,6 +173,16 @@ void HeapAllocator::free(size_t offset) {
 size_t HeapAllocator::numAllocations() const {
 	return _allocatedRanges.size();
 }
+size_t HeapAllocator::usedBytes() const {
+	size_t total = 0;
+	for (const auto& range : _allocatedRanges) {
+		total += range.size;
+	}
+	return total;
+}
+size_t HeapAllocator::heapSize() const {
+	return _heapSize;
+}
 bool HeapAllocator::check_connected_range(const MemoryRange& left, const MemoryRange& right) {
 	return left.offset + left.size == right.offset;
 }

--- a/code/utils/HeapAllocator.h
+++ b/code/utils/HeapAllocator.h
@@ -69,6 +69,18 @@ class HeapAllocator {
 	 * @return The active allocations in this heap.
 	 */
 	size_t numAllocations() const;
+
+	/**
+	 * @brief Retrieves the total number of bytes currently allocated from this heap
+	 * @return The sum of the sizes of all active allocations.
+	 */
+	size_t usedBytes() const;
+
+	/**
+	 * @brief Retrieves the total size of the heap, including both allocated and free space
+	 * @return The current heap size.
+	 */
+	size_t heapSize() const;
 };
 
 }

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -196,7 +196,6 @@
 #include "stats/stats.h"
 #include "tracing/Monitor.h"
 #include "tracing/tracing.h"
-#include "tracing/ProfilerOverlay.h"
 #include "utils/Random.h"
 #include "utils/threading.h"
 #include "weapon/beam.h"
@@ -2324,10 +2323,6 @@ void game_show_framerate()
 	}
 #endif
 
-	if (tracing::Profiler_overlay_enabled) {
-		tracing::profiler_overlay_draw();
-	}
-
 	if ((Show_framerate && HUD_draw) || Cmdline_bmpman_usage) {
 
 		gr_set_color_fast(&HUD_color_debug);
@@ -4403,11 +4398,6 @@ void game_frame(bool paused)
 
 	// process lightning (nebula only)
 	nebl_process();
-
-	if (tracing::Profiler_overlay_enabled) {
-		tracing::frame_profile_process_frame();
-		tracing::profiler_overlay_record_frame();
-	}
 
 	DEBUG_GET_TIME( total_time2 )
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -196,6 +196,7 @@
 #include "stats/stats.h"
 #include "tracing/Monitor.h"
 #include "tracing/tracing.h"
+#include "tracing/ProfilerOverlay.h"
 #include "utils/Random.h"
 #include "utils/threading.h"
 #include "weapon/beam.h"
@@ -212,6 +213,7 @@
 #include <stdexcept>
 
 #include "imgui.h"
+#include "implot.h"
 
 #ifdef WIN32
 // According to AMD and NV, these _should_ force their drivers into high-performance mode
@@ -1854,6 +1856,7 @@ void game_init()
 	Random::seed(static_cast<unsigned int>(time(nullptr)));
 
 	ImGui::CreateContext();
+	ImPlot::CreateContext();
 
 	Framerate_delay = 0;
 
@@ -2321,27 +2324,13 @@ void game_show_framerate()
 	}
 #endif
 
-	if ((Show_framerate && HUD_draw) || Cmdline_frame_profile || Cmdline_bmpman_usage) {
+	if (tracing::Profiler_overlay_enabled) {
+		tracing::profiler_overlay_draw();
+	}
+
+	if ((Show_framerate && HUD_draw) || Cmdline_bmpman_usage) {
 
 		gr_set_color_fast(&HUD_color_debug);
-
-		if (Cmdline_frame_profile) {
-			// Split frame profile into two columns if necessary to avoid losing trace data
-			int fp_start_y = gr_screen.center_offset_y + 100 + line_height;
-			int fp_line_limit = (gr_screen.max_h - fp_start_y) / line_height;
-			size_t fp_column_break = 0;
-			auto fp_trace_str = tracing::get_frame_profile_output();
-
-			for (int i = 0; i < fp_line_limit && fp_column_break < fp_trace_str.length(); i++) {
-				fp_column_break = fp_trace_str.find_first_of('\n', fp_column_break+1);
-			}
-
-			gr_string(gr_screen.center_offset_x + 20, fp_start_y, fp_trace_str.substr(0,fp_column_break).c_str(), GR_RESIZE_NONE);
-
-			if (fp_column_break < fp_trace_str.length()) {
-				gr_string(gr_screen.max_w / 2, fp_start_y, fp_trace_str.substr(fp_column_break, fp_trace_str.npos).c_str(), GR_RESIZE_NONE);
-			}
-		}
 
 		if (Show_framerate) {
 			if (frametotal != 0.0f)
@@ -4415,8 +4404,9 @@ void game_frame(bool paused)
 	// process lightning (nebula only)
 	nebl_process();
 
-	if (Cmdline_frame_profile) {
+	if (tracing::Profiler_overlay_enabled) {
 		tracing::frame_profile_process_frame();
+		tracing::profiler_overlay_record_frame();
 	}
 
 	DEBUG_GET_TIME( total_time2 )
@@ -7154,6 +7144,7 @@ void game_shutdown(void)
 		std_deinit_standalone();
 	}
 
+	ImPlot::DestroyContext();
 	ImGui::DestroyContext();
 
 	os_cleanup();

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -52,6 +52,7 @@ add_subdirectory(accidental-noise)
 ADD_SUBDIRECTORY(lz4)
 
 ADD_SUBDIRECTORY(imgui)
+ADD_SUBDIRECTORY(implot)
 
 if(FSO_BUILD_WITH_OPENXR)
 	add_subdirectory(openxr EXCLUDE_FROM_ALL)

--- a/lib/implot/CMakeLists.txt
+++ b/lib/implot/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+SET(IMPLOT_SOURCES
+	implot.h
+	implot_internal.h
+	implot.cpp
+	implot_items.cpp
+)
+
+ADD_LIBRARY(implot STATIC ${IMPLOT_SOURCES})
+
+target_include_directories(implot SYSTEM PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Disable warnings if building from source
+suppress_warnings(implot)
+
+set_target_properties(implot PROPERTIES FOLDER "3rdparty")
+TARGET_LINK_LIBRARIES(implot PUBLIC imgui)

--- a/lib/implot/CMakeLists.txt
+++ b/lib/implot/CMakeLists.txt
@@ -10,6 +10,13 @@ ADD_LIBRARY(implot STATIC ${IMPLOT_SOURCES})
 
 target_include_directories(implot SYSTEM PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
+# ImPlot uses imgui's ImVec2/ImVec4 math operators, which imgui only defines when
+# IMGUI_DEFINE_MATH_OPERATORS is set before imgui.h is first included. implot_items.cpp
+# pulls in imgui.h (via implot.h) before implot_internal.h's own #ifndef guard runs, so
+# the guard loses the race -- define it on the target instead. PUBLIC so any consumer that
+# includes implot.h after imgui.h stays consistent.
+target_compile_definitions(implot PUBLIC IMGUI_DEFINE_MATH_OPERATORS)
+
 # Disable warnings if building from source
 suppress_warnings(implot)
 

--- a/lib/implot/LICENSE
+++ b/lib/implot/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Evan Pezent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/implot/README.md
+++ b/lib/implot/README.md
@@ -1,0 +1,180 @@
+# ImPlot
+ImPlot is an immediate mode, GPU accelerated plotting library for [Dear ImGui](https://github.com/ocornut/imgui). It aims to provide a first-class API that ImGui fans will love. ImPlot is well suited for visualizing program data in real-time or creating interactive plots, and requires minimal code to integrate. Just like ImGui, it does not burden the end user with GUI state management, avoids STL containers and C++ headers, and has no external dependencies except for ImGui itself.
+
+<img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/controls.gif" width="270"> <img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/dnd.gif" width="270"> <img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/pie.gif" width="270">
+
+<img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/query.gif" width="270"> <img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/bars.gif" width="270">
+<img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/rt.gif" width="270">
+
+<img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/stem.gif" width="270"> <img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/markers.gif" width="270">
+<img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/shaded.gif" width="270">
+
+<img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/candle.gif" width="270"> <img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/heat.gif" width="270">
+<img src="https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/tables.gif" width="270">
+
+## Features
+
+- GPU accelerated rendering
+- multiple plot types:
+    - line plots
+    - shaded plots
+    - scatter plots
+    - vertical/horizontal/stacked bars graphs
+    - vertical/horizontal error bars
+    - stem plots
+    - stair plots
+    - pie charts
+    - heatmap charts
+    - 1D/2D histograms
+    - images
+    - and more likely to come
+- mix/match multiple plot items on a single plot
+- configurable axes ranges and scaling (linear/log)
+- subplots
+- time formatted x-axes (US formatted or ISO 8601)
+- reversible and lockable axes
+- multiple x-axes and y-axes
+- controls for zooming, panning, box selection, and auto-fitting data
+- controls for creating persistent query ranges (see demo)
+- several plot styling options: 10 marker types, adjustable marker sizes, line weights, outline colors, fill colors, etc.
+- 16 built-in colormaps and support for and user-added colormaps
+- optional plot titles, axis labels, and grid labels
+- optional and configurable legends with toggle buttons to quickly show/hide plot items
+- default styling based on current ImGui theme, or completely custom plot styles
+- customizable data getters and data striding (just like ImGui:PlotLine)
+- accepts data as float, double, and 8, 16, 32, and 64-bit signed/unsigned integral types
+- and more! (see Announcements [2022](https://github.com/epezent/implot/discussions/370)/[2021](https://github.com/epezent/implot/issues/168)/[2020](https://github.com/epezent/implot/issues/48))
+
+## Usage
+
+The API is used just like any other ImGui `BeginX`/`EndX` pair. First, start a new plot with `ImPlot::BeginPlot()`. Next, plot as many items as you want with the provided `PlotX` functions (e.g. `PlotLine()`, `PlotBars()`, `PlotScatter()`, etc). Finally, wrap things up with a call to `ImPlot::EndPlot()`. That's it!
+
+```cpp
+int   bar_data[11] = ...;
+float x_data[1000] = ...;
+float y_data[1000] = ...;
+
+ImGui::Begin("My Window");
+if (ImPlot::BeginPlot("My Plot")) {
+    ImPlot::PlotBars("My Bar Plot", bar_data, 11);
+    ImPlot::PlotLine("My Line Plot", x_data, y_data, 1000);
+    ...
+    ImPlot::EndPlot();
+}
+ImGui::End();
+```
+
+![Usage](https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/example.PNG)
+
+
+Of course, there's much more you can do with ImPlot... 
+
+## Demos
+
+A comprehensive example of ImPlot's features can be found in `implot_demo.cpp`. Add this file to your sources and call `ImPlot::ShowDemoWindow()` somewhere in your update loop. You are encouraged to use this file as a reference when needing to implement various plot types. The demo is always updated to show new plot types and features as they are added, so check back with each release!
+
+An online version of the demo is hosted [here](https://traineq.org/implot_demo/src/implot_demo.html). You can view the plots and the source code that generated them. Note that this demo may not always be up to date and is not as performant as a desktop implementation, but it should give you a general taste of what's possible with ImPlot. Special thanks to [pthom](https://github.com/pthom) for creating and hosting this!
+
+More sophisticated demos requiring lengthier code and/or third-party libraries can be found in a separate repository: [implot_demos](https://github.com/epezent/implot_demos). Here, you will find advanced signal processing and ImPlot usage in action. Please read the `Contributing` section of that repository if you have an idea for a new demo!
+
+## Integration
+
+0) Set up an [ImGui](https://github.com/ocornut/imgui) environment if you don't already have one.
+1) Add `implot.h`, `implot_internal.h`, `implot.cpp`, `implot_items.cpp` and optionally `implot_demo.cpp` to your sources. Alternatively, you can get ImPlot using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/implot).
+2) Create and destroy an `ImPlotContext` wherever you do so for your `ImGuiContext`:
+
+```cpp
+ImGui::CreateContext();
+ImPlot::CreateContext();
+...
+ImPlot::DestroyContext();
+ImGui::DestroyContext();
+```
+
+You should be good to go!
+
+If you want to test ImPlot quickly, consider trying [mahi-gui](https://github.com/mahilab/mahi-gui), which bundles ImGui, ImPlot, and several other packages for you.
+
+## Installing ImPlot using vcpkg
+
+You can download and install ImPlot using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install implot
+```
+
+The ImPlot port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+## Extremely Important Note
+
+Dear ImGui uses **16-bit indexing by default**, so high-density ImPlot widgets like `ImPlot::PlotHeatmap()` may produce too many vertices into `ImDrawList`, which causes an assertion failure and will result in data truncation and/or visual glitches. Therefore, it is **HIGHLY** recommended that you EITHER:
+
+- **Option 1:** Enable 32-bit indices by uncommenting `#define ImDrawIdx unsigned int` in your ImGui [`imconfig.h`](https://github.com/ocornut/imgui/blob/master/imconfig.h#L89) file.
+- **Option 2:** Handle the `ImGuiBackendFlags_RendererHasVtxOffset` flag in your renderer if you must use 16-bit indices. Many of the default ImGui rendering backends already support `ImGuiBackendFlags_RendererHasVtxOffset`. Refer to [this issue](https://github.com/ocornut/imgui/issues/2591) for more information.
+
+## FAQ
+
+**Q: Why?**
+
+A: ImGui is an incredibly powerful tool for rapid prototyping and development, but provides only limited mechanisms for data visualization. Two dimensional plots are ubiquitous and useful to almost any application. Being able to visualize your data in real-time will give you insight and better understanding of your application.
+
+**Q: Is ImPlot the right plotting library for me?**
+
+A: If you're looking to generate publication quality plots and/or export plots to a file, ImPlot is NOT the library for you! ImPlot is geared toward plotting application data at realtime speeds with high levels of interactivity. ImPlot does its best to create pretty plots (indeed, there are quite a few styling options available), but it will always favor function over form.
+
+**Q: Where is the documentation?**
+
+A: The API is thoroughly commented in `implot.h`, and the demo in `implot_demo.cpp` should be more than enough to get you started. Also take a look at the [implot_demos](https://github.com/epezent/implot_demos) repository.
+
+**Q: Is ImPlot suitable for plotting large datasets?**
+
+A: Yes, within reason. You can plot tens to hundreds of thousands of points without issue, but don't expect millions to be a buttery smooth experience. That said, you can always downsample extremely large datasets by telling ImPlot to stride your data at larger intervals if needed. Also try the experimental `backends` branch which aims to provide GPU acceleration support.
+
+**Q: What data types can I plot?**
+
+A: ImPlot plotting functions accept most scalar types:
+`float`, `double`, `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`. Arrays of custom structs or classes (e.g. `Vector2f` or similar) are easily passed to ImPlot functions using the built-in striding features (see `implot.h` for documentation), and many plotters provide a "getter" overload which accepts data generating callbacks. You can fully customize the list of accepted types by defining `IMPLOT_CUSTOM_NUMERIC_TYPES` at compile time: see doc in `implot_items.cpp`.
+
+**Q: Can plot styles be modified?**
+
+A: Yes. Data colormaps and various styling colors and variables can be pushed/popped or modified permanently on startup. Three default styles are available, as well as an automatic style that attempts to match you ImGui style.
+
+**Q: Does ImPlot support logarithmic scaling or time formatting?**
+
+A: Yep! Both logscale and timescale are supported.
+
+**Q: Does ImPlot support multiple y-axes? x-axes?**
+
+A: Yes. Up to three x-axes and three y-axes can be enabled.
+
+**Q: Does ImPlot support [insert plot type]?**
+
+A: Maybe. Check the demo, gallery, or Announcements ([2020](https://github.com/epezent/implot/issues/48)/[2021](https://github.com/epezent/implot/issues/168))to see if your desired plot type is shown. If not, consider submitting an issue or better yet, a PR!
+
+**Q: Does ImPlot support 3D plots?**
+
+A: No, and likely never will since ImGui only deals in 2D rendering.
+
+**Q: My plot lines look like crap!**
+
+A: By default, no anti-aliasing is done on line plots for performance gains. If you use at least 4x MSAA, then you likely won't even notice. However, you can enable software AA per-plot with the `ImPlotFlags_AntiAliased` flag, or globally with `ImPlot::GetStyle().AntiAliasedLines = true;`.
+
+**Q: Does ImPlot provide analytic tools?**
+
+A: Not exactly, but it does give you the ability to query plot sub-ranges, with which you can process your data however you like.
+
+**Q: Can plots be exported/saved to image?**
+
+A: Not currently. Use your OS's screen capturing mechanisms if you need to capture a plot. ImPlot is not suitable for rendering publication quality plots; it is only intended to be used as a visualization tool. Post-process your data with MATLAB or matplotlib for these purposes.
+
+**Q: Can I compile ImPlot as a dynamic library?**
+
+A: Like ImGui, it is recommended that you compile and link ImPlot as a *static* library or directly as a part of your sources. However, if you must and are compiling ImPlot and ImGui as separate DLLs, make sure you set the current *ImGui* context with `ImPlot::SetImGuiContext(ImGuiContext* ctx)`. This ensures that global ImGui variables are correctly shared across the DLL boundary.
+
+**Q: Can ImPlot be used with other languages/bindings?**
+
+A: Yes, you can use the generated C binding, [cimplot](https://github.com/cimgui/cimplot) with most high level languages. [DearPyGui](https://github.com/hoffstadt/DearPyGui) provides a Python wrapper, among other things. [imgui-java](https://github.com/SpaiR/imgui-java) provides bindings for Java. A Rust binding, [implot-rs](https://github.com/4bb4/implot-rs), is currently in the works. An example using Emscripten can be found [here](https://github.com/pthom/implot_demo).

--- a/lib/implot/README.md
+++ b/lib/implot/README.md
@@ -67,13 +67,13 @@ ImGui::End();
 ![Usage](https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/example.PNG)
 
 
-Of course, there's much more you can do with ImPlot... 
+Of course, there's much more you can do with ImPlot...
 
 ## Demos
 
 A comprehensive example of ImPlot's features can be found in `implot_demo.cpp`. Add this file to your sources and call `ImPlot::ShowDemoWindow()` somewhere in your update loop. You are encouraged to use this file as a reference when needing to implement various plot types. The demo is always updated to show new plot types and features as they are added, so check back with each release!
 
-An online version of the demo is hosted [here](https://traineq.org/implot_demo/src/implot_demo.html). You can view the plots and the source code that generated them. Note that this demo may not always be up to date and is not as performant as a desktop implementation, but it should give you a general taste of what's possible with ImPlot. Special thanks to [pthom](https://github.com/pthom) for creating and hosting this!
+An online version of the demo is hosted [here](https://pthom.github.io/imgui_explorer/?lib=implot). You can view the plots and the source code that generated them. Note that this demo may not always be up to date and is not as performant as a desktop implementation, but it should give you a general taste of what's possible with ImPlot. Special thanks to [pthom](https://github.com/pthom) for creating and hosting this!
 
 More sophisticated demos requiring lengthier code and/or third-party libraries can be found in a separate repository: [implot_demos](https://github.com/epezent/implot_demos). Here, you will find advanced signal processing and ImPlot usage in action. Please read the `Contributing` section of that repository if you have an idea for a new demo!
 
@@ -92,8 +92,6 @@ ImGui::DestroyContext();
 ```
 
 You should be good to go!
-
-If you want to test ImPlot quickly, consider trying [mahi-gui](https://github.com/mahilab/mahi-gui), which bundles ImGui, ImPlot, and several other packages for you.
 
 ## Installing ImPlot using vcpkg
 
@@ -141,11 +139,11 @@ A: ImPlot plotting functions accept most scalar types:
 
 **Q: Can plot styles be modified?**
 
-A: Yes. Data colormaps and various styling colors and variables can be pushed/popped or modified permanently on startup. Three default styles are available, as well as an automatic style that attempts to match you ImGui style.
+A: Yes. Three default styles are available, as well as an automatic style that attempts to match you ImGui style. You can define any custom style as well. Plot items are generally styled for you based on the current colormap, but can be customized on an individual basis.
 
-**Q: Does ImPlot support logarithmic scaling or time formatting?**
+**Q: Does ImPlot support non-linear axis scaling? Time formatting?**
 
-A: Yep! Both logscale and timescale are supported.
+A: Yes. Logscale and symmetric logscale are provided out of the box, and you can define custom axis scales as well. Time scale with microsecond precision is also available out of the box.
 
 **Q: Does ImPlot support multiple y-axes? x-axes?**
 
@@ -153,15 +151,11 @@ A: Yes. Up to three x-axes and three y-axes can be enabled.
 
 **Q: Does ImPlot support [insert plot type]?**
 
-A: Maybe. Check the demo, gallery, or Announcements ([2020](https://github.com/epezent/implot/issues/48)/[2021](https://github.com/epezent/implot/issues/168))to see if your desired plot type is shown. If not, consider submitting an issue or better yet, a PR!
+A: Maybe. Check the demo, gallery, or Announcements ([2020](https://github.com/epezent/implot/issues/48)/[2021](https://github.com/epezent/implot/issues/168)/[2022](https://github.com/epezent/implot/discussions/370)) to see if your desired plot type is shown. If not, consider submitting an issue or better yet, a PR!
 
 **Q: Does ImPlot support 3D plots?**
 
-A: No, and likely never will since ImGui only deals in 2D rendering.
-
-**Q: My plot lines look like crap!**
-
-A: By default, no anti-aliasing is done on line plots for performance gains. If you use at least 4x MSAA, then you likely won't even notice. However, you can enable software AA per-plot with the `ImPlotFlags_AntiAliased` flag, or globally with `ImPlot::GetStyle().AntiAliasedLines = true;`.
+A: An experimental extension to ImPlot, [ImPlot3D](https://github.com/brenocq/implot3d), provides a similar API for plotting and interacting with 3D data. 
 
 **Q: Does ImPlot provide analytic tools?**
 
@@ -171,10 +165,14 @@ A: Not exactly, but it does give you the ability to query plot sub-ranges, with 
 
 A: Not currently. Use your OS's screen capturing mechanisms if you need to capture a plot. ImPlot is not suitable for rendering publication quality plots; it is only intended to be used as a visualization tool. Post-process your data with MATLAB or matplotlib for these purposes.
 
+**Q: Why are my plot lines showing aliasing?**
+
+A: You probably need to enable `ImGuiStyle::AntiAliasedLinesUseTex` (or possibly `ImGuiStyle:AntiAliasedLines`). If those settings are already enabled, then you must ensure your backend supports texture based anti-aliasing (i.e. uses bilinear sampling). Most of the default ImGui backends support this feature out of the box. Learn more [here](https://github.com/ocornut/imgui/issues/3245). Alternatively, you can enable MSAA at the application level if your hardware supports it (4x should do).
+
 **Q: Can I compile ImPlot as a dynamic library?**
 
 A: Like ImGui, it is recommended that you compile and link ImPlot as a *static* library or directly as a part of your sources. However, if you must and are compiling ImPlot and ImGui as separate DLLs, make sure you set the current *ImGui* context with `ImPlot::SetImGuiContext(ImGuiContext* ctx)`. This ensures that global ImGui variables are correctly shared across the DLL boundary.
 
 **Q: Can ImPlot be used with other languages/bindings?**
 
-A: Yes, you can use the generated C binding, [cimplot](https://github.com/cimgui/cimplot) with most high level languages. [DearPyGui](https://github.com/hoffstadt/DearPyGui) provides a Python wrapper, among other things. [imgui-java](https://github.com/SpaiR/imgui-java) provides bindings for Java. A Rust binding, [implot-rs](https://github.com/4bb4/implot-rs), is currently in the works. An example using Emscripten can be found [here](https://github.com/pthom/implot_demo).
+A: Yes, you can use the generated C binding, [cimplot](https://github.com/cimgui/cimplot) with most high level languages. [DearPyGui](https://github.com/hoffstadt/DearPyGui) provides a Python wrapper, among other things. [DearImGui/DearImPlot](https://github.com/aybe/DearImGui) provides bindings for .NET. [imgui-java](https://github.com/SpaiR/imgui-java) provides bindings for Java. [ImPlot.jl](https://github.com/wsphillips/ImPlot.jl) provides bindings for Julia. A Rust binding, [implot-rs](https://github.com/4bb4/implot-rs), is currently in the works. An example using Emscripten can be found [here](https://github.com/pthom/implot_demo).

--- a/lib/implot/TODO.md
+++ b/lib/implot/TODO.md
@@ -1,0 +1,100 @@
+The list below represents a combination of high-priority work, nice-to-have features, and random ideas. We make no guarantees that all of this work will be completed or even started. If you see something that you need or would like to have, let us know, or better yet consider submitting a PR for the feature.
+
+## API
+
+## Axes
+
+- add flag to remove weekends on Time axis
+- pixel space scale (`ImPlotTransform_Display`), normalized space scale (`ImPlotTransform_Axes`), data space scale (`ImPlotTransform_Data`)
+- make ImPlotFlags_Equal not a flag -> `SetupEqual(ImPlotAxis x, ImPlotAxis y)`
+- allow inverted arguments `SetAxes` to transpose data?
+- `SetupAxisColors()`
+- `SetupAxisHome()`
+
+## Plot Items
+
+- add `PlotBubbles` (see MATLAB bubble chart)
+- add non-zero references for `PlotBars` etc.
+- add exploding to `PlotPieChart` (on hover-highlight?)
+- fix appearance of `PlotBars` spacing
+
+## Styling
+
+- support gradient and/or colormap sampled fills (e.g. ImPlotFillStyle_)
+- API for setting different fonts for plot elements
+
+## Colormaps
+
+- gradient editing tool
+- `RemoveColormap`
+- `enum ImPlotColorRule_ { Solid, Faded, XValue, YValue, ZValue }`
+
+## Legend
+
+- `ImPlotLegendFlags_Scroll`
+- improve legend icons (e.g. adopt markers, gradients, etc)
+- make legend frame use ButtonBehavior (maybe impossible)
+
+## Tools / Misc.
+
+- add `IsPlotChanging` to detect change in limits
+- add ability to extend plot/axis context menus
+- add LTTB downsampling for lines
+- add box selection to axes
+- first frame render delay might fix "fit pop" effect
+- move some code to new `implot_tools.cpp`
+- ColormapSlider (see metrics)
+- FillAlpha should not affect markers?
+- fix mouse text for time axes
+
+## Optimizations
+
+- find faster way to buffer data into ImDrawList (very slow)
+- reduce number of calls to `PushClipRect`
+- explore SIMD operations for high density plot items
+
+## Plotter Pipeline
+
+Ideally every `PlotX` function should use our faster rendering pipeline when it is applicable.
+
+` User Data > Getter > Fitter > Renderer > RenderPrimitives`
+
+|Plotter|Getter|Fitter|Renderer|RenderPrimitives|
+|---|:-:|:-:|:-:|:-:|
+|PlotLine|Yes|Yes|Yes|Yes|
+|PlotScatter|Yes|Yes|Yes|Yes|
+|PlotStairs|Yes|Yes|Yes|Yes|
+|PlotShaded|Yes|Yes|Yes|Yes|
+|PlotBars|Yes|Yes|Yes|Yes|
+|PlotBarGroups|:|:|:|:|
+|PlotHistogram|:|:|:|:|
+|PlotErrorBars|Yes|Yes|No|No|
+|PlotStems|Yes|Yes|Yes|Yes|
+|PlotInfLines|Yes|Yes|Yes|Yes|
+|PlotPieChart|No|No|No|No|
+|PlotHeatmap|Yes|No|Yes|Mixed|
+|PlotHistogram2D|:|:|:|:|
+|PlotDigital|Yes|No|No|No|
+|PlotImage|-|-|-|-|
+|PlotText|-|-|-|-|
+|PlotDummy|-|-|-|-|
+
+## Completed
+- make BeginPlot take fewer args:
+- make query a tool -> `DragRect`
+- rework DragLine/Point to use ButtonBehavior
+- add support for multiple x-axes and don't limit count to 3
+- make axis side configurable (top/left, right/bottom) via new flag `ImPlotAxisFlags_Opposite`
+- add support for setting tick label strings via callback
+- give each axis an ID, remove ad-hoc DND solution
+- allow axis to be drag to opposite side (ala ImGui Table headers)
+- legend items can be hovered even if plot is not
+- fix frame delay on DragX tools
+- remove tag from drag line/point -> add `Tag` tool
+- add shortcut/legacy overloads for BeginPlot
+- `SetupAxisConstraints()`
+- `SetupAxisScale()`
+- add `ImPlotLineFlags`, `ImPlotBarsFlags`, etc. for each plot type
+- add `PlotBarGroups` wrapper that makes rendering groups of bars easier, with stacked bar support
+- `PlotBars` restore outlines
+- add hover/active color for plot axes

--- a/lib/implot/TODO.md
+++ b/lib/implot/TODO.md
@@ -13,9 +13,7 @@ The list below represents a combination of high-priority work, nice-to-have feat
 
 ## Plot Items
 
-- add `PlotBubbles` (see MATLAB bubble chart)
 - add non-zero references for `PlotBars` etc.
-- add exploding to `PlotPieChart` (on hover-highlight?)
 - fix appearance of `PlotBars` spacing
 
 ## Styling
@@ -31,9 +29,9 @@ The list below represents a combination of high-priority work, nice-to-have feat
 
 ## Legend
 
-- `ImPlotLegendFlags_Scroll`
 - improve legend icons (e.g. adopt markers, gradients, etc)
-- make legend frame use ButtonBehavior (maybe impossible)
+- generalize legend rendering for plots and subplots
+- add draggable scroll bar if users need it
 
 ## Tools / Misc.
 
@@ -80,6 +78,8 @@ Ideally every `PlotX` function should use our faster rendering pipeline when it 
 |PlotDummy|-|-|-|-|
 
 ## Completed
+- add `PlotBubbles` (see MATLAB bubble chart)
+- add exploding to `PlotPieChart` (on legend hover)
 - make BeginPlot take fewer args:
 - make query a tool -> `DragRect`
 - rework DragLine/Point to use ButtonBehavior
@@ -98,3 +98,5 @@ Ideally every `PlotX` function should use our faster rendering pipeline when it 
 - add `PlotBarGroups` wrapper that makes rendering groups of bars easier, with stacked bar support
 - `PlotBars` restore outlines
 - add hover/active color for plot axes
+- make legend frame use ButtonBehavior
+- `ImPlotLegendFlags_Scroll` (default behavior)

--- a/lib/implot/implot.cpp
+++ b/lib/implot/implot.cpp
@@ -1,0 +1,5723 @@
+// MIT License
+
+// Copyright (c) 2022 Evan Pezent
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ImPlot v0.14
+
+/*
+
+API BREAKING CHANGES
+====================
+Occasionally introducing changes that are breaking the API. We try to make the breakage minor and easy to fix.
+Below is a change-log of API breaking changes only. If you are using one of the functions listed, expect to have to fix some code.
+When you are not sure about a old symbol or function name, try using the Search/Find function of your IDE to look for comments or references in all implot files.
+You can read releases logs https://github.com/epezent/implot/releases for more details.
+
+- 2022/06/19 (0.14) - The signature of ColormapScale has changed to accommodate a new ImPlotColormapScaleFlags parameter
+- 2022/06/17 (0.14) - **IMPORTANT** All PlotX functions now take an ImPlotX_Flags `flags` parameter. Where applicable, it is located before the existing `offset` and `stride` parameters.
+                      If you were providing offset and stride values, you will need to update your function call to include a `flags` value. If you fail to do this, you will likely see
+                      unexpected results or crashes without a compiler warning since these three are all default args. We apologize for the inconvenience, but this was a necessary evil.
+                    - PlotBarsH has been removed; use PlotBars + ImPlotBarsFlags_Horizontal instead
+                    - PlotErrorBarsH has been removed; use PlotErrorBars + ImPlotErrorBarsFlags_Horizontal
+                    - PlotHistogram/PlotHistogram2D signatures changed; `cumulative`, `density`, and `outliers` options now specified via ImPlotHistogramFlags
+                    - PlotPieChart signature changed; `normalize` option now specified via ImPlotPieChartFlags
+                    - PlotText signature changes; `vertical` option now specified via `ImPlotTextFlags_Vertical`
+                    - `PlotVLines` and `PlotHLines` replaced with `PlotInfLines` (+ ImPlotInfLinesFlags_Horizontal )
+                    - arguments of ImPlotGetter have been reversed to be consistent with other API callbacks
+                    - SetupAxisScale + ImPlotScale have replaced ImPlotAxisFlags_LogScale and ImPlotAxisFlags_Time flags
+                    - ImPlotFormatters should now return an int indicating the size written
+                    - the signature of ImPlotGetter has been reversed so that void* user_data is the last argument and consistent with other callbacks
+- 2021/10/19 (0.13) - MAJOR API OVERHAUL! See #168 and #272
+                    - TRIVIAL RENAME:
+                      - ImPlotLimits                              -> ImPlotRect
+                      - ImPlotYAxis_                              -> ImAxis_
+                      - SetPlotYAxis                              -> SetAxis
+                      - BeginDragDropTarget                       -> BeginDragDropTargetPlot
+                      - BeginDragDropSource                       -> BeginDragDropSourcePlot
+                      - ImPlotFlags_NoMousePos                    -> ImPlotFlags_NoMouseText
+                      - SetNextPlotLimits                         -> SetNextAxesLimits
+                      - SetMouseTextLocation                      -> SetupMouseText
+                    - SIGNATURE MODIFIED:
+                      - PixelsToPlot/PlotToPixels                 -> added optional X-Axis arg
+                      - GetPlotMousePos                           -> added optional X-Axis arg
+                      - GetPlotLimits                             -> added optional X-Axis arg
+                      - GetPlotSelection                          -> added optional X-Axis arg
+                      - DragLineX/Y/DragPoint                     -> now takes int id; removed labels (render with Annotation/Tag instead)
+                    - REPLACED:
+                      - IsPlotXAxisHovered/IsPlotXYAxisHovered    -> IsAxisHovered(ImAxis)
+                      - BeginDragDropTargetX/BeginDragDropTargetY -> BeginDragDropTargetAxis(ImAxis)
+                      - BeginDragDropSourceX/BeginDragDropSourceY -> BeginDragDropSourceAxis(ImAxis)
+                      - ImPlotCol_XAxis, ImPlotCol_YAxis1, etc.   -> ImPlotCol_AxisText (push/pop this around SetupAxis to style individual axes)
+                      - ImPlotCol_XAxisGrid, ImPlotCol_Y1AxisGrid -> ImPlotCol_AxisGrid (push/pop this around SetupAxis to style individual axes)
+                      - SetNextPlotLimitsX/Y                      -> SetNextAxisLimits(ImAxis)
+                      - LinkNextPlotLimits                        -> SetNextAxisLinks(ImAxis)
+                      - FitNextPlotAxes                           -> SetNextAxisToFit(ImAxis)/SetNextAxesToFit
+                      - SetLegendLocation                         -> SetupLegend
+                      - ImPlotFlags_NoHighlight                   -> ImPlotLegendFlags_NoHighlight
+                      - ImPlotOrientation                         -> ImPlotLegendFlags_Horizontal
+                      - Annotate                                  -> Annotation
+                    - REMOVED:
+                      - GetPlotQuery, SetPlotQuery, IsPlotQueried -> use DragRect
+                      - SetNextPlotTicksX, SetNextPlotTicksY      -> use SetupAxisTicks
+                      - SetNextPlotFormatX, SetNextPlotFormatY    -> use SetupAxisFormat
+                      - AnnotateClamped                           -> use Annotation(bool clamp = true)
+                    - OBSOLETED:
+                      - BeginPlot (original signature)            -> use simplified signature + Setup API
+- 2021/07/30 (0.12) - The offset argument of `PlotXG` functions was been removed. Implement offsetting in your getter callback instead.
+- 2021/03/08 (0.9)  - SetColormap and PushColormap(ImVec4*) were removed. Use AddColormap for custom colormap support. LerpColormap was changed to SampleColormap.
+                      ShowColormapScale was changed to ColormapScale and requires additional arguments.
+- 2021/03/07 (0.9)  - The signature of ShowColormapScale was modified to accept a ImVec2 size.
+- 2021/02/28 (0.9)  - BeginLegendDragDropSource was changed to BeginDragDropSourceItem with a number of other drag and drop improvements.
+- 2021/01/18 (0.9)  - The default behavior for opening context menus was change from double right-click to single right-click. ImPlotInputMap and related functions were moved
+                      to implot_internal.h due to its immaturity.
+- 2020/10/16 (0.8)  - ImPlotStyleVar_InfoPadding was changed to ImPlotStyleVar_MousePosPadding
+- 2020/09/10 (0.8)  - The single array versions of PlotLine, PlotScatter, PlotStems, and PlotShaded were given additional arguments for x-scale and x0.
+- 2020/09/07 (0.8)  - Plotting functions which accept a custom getter function pointer have been post-fixed with a G (e.g. PlotLineG)
+- 2020/09/06 (0.7)  - Several flags under ImPlotFlags and ImPlotAxisFlags were inverted (e.g. ImPlotFlags_Legend -> ImPlotFlags_NoLegend) so that the default flagset
+                      is simply 0. This more closely matches ImGui's style and makes it easier to enable non-default but commonly used flags (e.g. ImPlotAxisFlags_Time).
+- 2020/08/28 (0.5)  - ImPlotMarker_ can no longer be combined with bitwise OR, |. This features caused unecessary slow-down, and almost no one used it.
+- 2020/08/25 (0.5)  - ImPlotAxisFlags_Scientific was removed. Logarithmic axes automatically uses scientific notation.
+- 2020/08/17 (0.5)  - PlotText was changed so that text is centered horizontally and vertically about the desired point.
+- 2020/08/16 (0.5)  - An ImPlotContext must be explicitly created and destroyed now with `CreateContext` and `DestroyContext`. Previously, the context was statically initialized in this source file.
+- 2020/06/13 (0.4)  - The flags `ImPlotAxisFlag_Adaptive` and `ImPlotFlags_Cull` were removed. Both are now done internally by default.
+- 2020/06/03 (0.3)  - The signature and behavior of PlotPieChart was changed so that data with sum less than 1 can optionally be normalized. The label format can now be specified as well.
+- 2020/06/01 (0.3)  - SetPalette was changed to `SetColormap` for consistency with other plotting libraries. `RestorePalette` was removed. Use `SetColormap(ImPlotColormap_Default)`.
+- 2020/05/31 (0.3)  - Plot functions taking custom ImVec2* getters were removed. Use the ImPlotPoint* getter versions instead.
+- 2020/05/29 (0.3)  - The signature of ImPlotLimits::Contains was changed to take two doubles instead of ImVec2
+- 2020/05/16 (0.2)  - All plotting functions were reverted to being prefixed with "Plot" to maintain a consistent VerbNoun style. `Plot` was split into `PlotLine`
+                      and `PlotScatter` (however, `PlotLine` can still be used to plot scatter points as `Plot` did before.). `Bar` is not `PlotBars`, to indicate
+                      that multiple bars will be plotted.
+- 2020/05/13 (0.2)  - `ImMarker` was change to `ImPlotMarker` and `ImAxisFlags` was changed to `ImPlotAxisFlags`.
+- 2020/05/11 (0.2)  - `ImPlotFlags_Selection` was changed to `ImPlotFlags_BoxSelect`
+- 2020/05/11 (0.2)  - The namespace ImGui:: was replaced with ImPlot::. As a result, the following additional changes were made:
+                      - Functions that were prefixed or decorated with the word "Plot" have been truncated. E.g., `ImGui::PlotBars` is now just `ImPlot::Bar`.
+                        It should be fairly obvious what was what.
+                      - Some functions have been given names that would have otherwise collided with the ImGui namespace. This has been done to maintain a consistent
+                        style with ImGui. E.g., 'ImGui::PushPlotStyleVar` is now 'ImPlot::PushStyleVar'.
+- 2020/05/10 (0.2)  - The following function/struct names were changes:
+                     - ImPlotRange       -> ImPlotLimits
+                     - GetPlotRange()    -> GetPlotLimits()
+                     - SetNextPlotRange  -> SetNextPlotLimits
+                     - SetNextPlotRangeX -> SetNextPlotLimitsX
+                     - SetNextPlotRangeY -> SetNextPlotLimitsY
+- 2020/05/10 (0.2)  - Plot queries are pixel based by default. Query rects that maintain relative plot position have been removed. This was done to support multi-y-axis.
+
+*/
+
+#include "implot.h"
+#include "implot_internal.h"
+
+#include <stdlib.h>
+
+// Support for pre-1.82 versions. Users on 1.82+ can use 0 (default) flags to mean "all corners" but in order to support older versions we are more explicit.
+#if (IMGUI_VERSION_NUM < 18102) && !defined(ImDrawFlags_RoundCornersAll)
+#define ImDrawFlags_RoundCornersAll ImDrawCornerFlags_All
+#endif
+
+// Visual Studio warnings
+#ifdef _MSC_VER
+#pragma warning (disable: 4996) // 'This function or variable may be unsafe': strcpy, strdup, sprintf, vsnprintf, sscanf, fopen
+#endif
+
+// Clang/GCC warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wformat-nonliteral"  // warning: format string is not a string literal
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"    // warning: format not a string literal, format string not checked
+#endif
+
+// Global plot context
+#ifndef GImPlot
+ImPlotContext* GImPlot = NULL;
+#endif
+
+//-----------------------------------------------------------------------------
+// Struct Implementations
+//-----------------------------------------------------------------------------
+
+ImPlotInputMap::ImPlotInputMap() {
+    ImPlot::MapInputDefault(this);
+}
+
+ImPlotStyle::ImPlotStyle() {
+
+    LineWeight         = 1;
+    Marker             = ImPlotMarker_None;
+    MarkerSize         = 4;
+    MarkerWeight       = 1;
+    FillAlpha          = 1;
+    ErrorBarSize       = 5;
+    ErrorBarWeight     = 1.5f;
+    DigitalBitHeight   = 8;
+    DigitalBitGap      = 4;
+
+    PlotBorderSize     = 1;
+    MinorAlpha         = 0.25f;
+    MajorTickLen       = ImVec2(10,10);
+    MinorTickLen       = ImVec2(5,5);
+    MajorTickSize      = ImVec2(1,1);
+    MinorTickSize      = ImVec2(1,1);
+    MajorGridSize      = ImVec2(1,1);
+    MinorGridSize      = ImVec2(1,1);
+    PlotPadding        = ImVec2(10,10);
+    LabelPadding       = ImVec2(5,5);
+    LegendPadding      = ImVec2(10,10);
+    LegendInnerPadding = ImVec2(5,5);
+    LegendSpacing      = ImVec2(5,0);
+    MousePosPadding    = ImVec2(10,10);
+    AnnotationPadding  = ImVec2(2,2);
+    FitPadding         = ImVec2(0,0);
+    PlotDefaultSize    = ImVec2(400,300);
+    PlotMinSize        = ImVec2(200,150);
+
+    ImPlot::StyleColorsAuto(this);
+
+    Colormap = ImPlotColormap_Deep;
+
+    UseLocalTime     = false;
+    Use24HourClock   = false;
+    UseISO8601       = false;
+}
+
+//-----------------------------------------------------------------------------
+// Style
+//-----------------------------------------------------------------------------
+
+namespace ImPlot {
+
+const char* GetStyleColorName(ImPlotCol col) {
+    static const char* col_names[ImPlotCol_COUNT] = {
+        "Line",
+        "Fill",
+        "MarkerOutline",
+        "MarkerFill",
+        "ErrorBar",
+        "FrameBg",
+        "PlotBg",
+        "PlotBorder",
+        "LegendBg",
+        "LegendBorder",
+        "LegendText",
+        "TitleText",
+        "InlayText",
+        "AxisText",
+        "AxisGrid",
+        "AxisTick",
+        "AxisBg",
+        "AxisBgHovered",
+        "AxisBgActive",
+        "Selection",
+        "Crosshairs"
+    };
+    return col_names[col];
+}
+
+const char* GetMarkerName(ImPlotMarker marker) {
+    switch (marker) {
+        case ImPlotMarker_None:     return "None";
+        case ImPlotMarker_Circle:   return "Circle";
+        case ImPlotMarker_Square:   return "Square";
+        case ImPlotMarker_Diamond:  return "Diamond";
+        case ImPlotMarker_Up:       return "Up";
+        case ImPlotMarker_Down:     return "Down";
+        case ImPlotMarker_Left:     return "Left";
+        case ImPlotMarker_Right:    return "Right";
+        case ImPlotMarker_Cross:    return "Cross";
+        case ImPlotMarker_Plus:     return "Plus";
+        case ImPlotMarker_Asterisk: return "Asterisk";
+        default:                    return "";
+    }
+}
+
+ImVec4 GetAutoColor(ImPlotCol idx) {
+    ImVec4 col(0,0,0,1);
+    switch(idx) {
+        case ImPlotCol_Line:          return col; // these are plot dependent!
+        case ImPlotCol_Fill:          return col; // these are plot dependent!
+        case ImPlotCol_MarkerOutline: return col; // these are plot dependent!
+        case ImPlotCol_MarkerFill:    return col; // these are plot dependent!
+        case ImPlotCol_ErrorBar:      return ImGui::GetStyleColorVec4(ImGuiCol_Text);
+        case ImPlotCol_FrameBg:       return ImGui::GetStyleColorVec4(ImGuiCol_FrameBg);
+        case ImPlotCol_PlotBg:        return ImGui::GetStyleColorVec4(ImGuiCol_WindowBg);
+        case ImPlotCol_PlotBorder:    return ImGui::GetStyleColorVec4(ImGuiCol_Border);
+        case ImPlotCol_LegendBg:      return ImGui::GetStyleColorVec4(ImGuiCol_PopupBg);
+        case ImPlotCol_LegendBorder:  return GetStyleColorVec4(ImPlotCol_PlotBorder);
+        case ImPlotCol_LegendText:    return GetStyleColorVec4(ImPlotCol_InlayText);
+        case ImPlotCol_TitleText:     return ImGui::GetStyleColorVec4(ImGuiCol_Text);
+        case ImPlotCol_InlayText:     return ImGui::GetStyleColorVec4(ImGuiCol_Text);
+        case ImPlotCol_AxisText:      return ImGui::GetStyleColorVec4(ImGuiCol_Text);
+        case ImPlotCol_AxisGrid:      return GetStyleColorVec4(ImPlotCol_AxisText) * ImVec4(1,1,1,0.25f);
+        case ImPlotCol_AxisTick:      return GetStyleColorVec4(ImPlotCol_AxisGrid);
+        case ImPlotCol_AxisBg:        return ImVec4(0,0,0,0);
+        case ImPlotCol_AxisBgHovered: return ImGui::GetStyleColorVec4(ImGuiCol_ButtonHovered);
+        case ImPlotCol_AxisBgActive:  return ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
+        case ImPlotCol_Selection:     return ImVec4(1,1,0,1);
+        case ImPlotCol_Crosshairs:    return GetStyleColorVec4(ImPlotCol_PlotBorder);
+        default: return col;
+    }
+}
+
+struct ImPlotStyleVarInfo {
+    ImGuiDataType   Type;
+    ImU32           Count;
+    ImU32           Offset;
+    void*           GetVarPtr(ImPlotStyle* style) const { return (void*)((unsigned char*)style + Offset); }
+};
+
+static const ImPlotStyleVarInfo GPlotStyleVarInfo[] =
+{
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, LineWeight)         }, // ImPlotStyleVar_LineWeight
+    { ImGuiDataType_S32,   1, (ImU32)IM_OFFSETOF(ImPlotStyle, Marker)             }, // ImPlotStyleVar_Marker
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, MarkerSize)         }, // ImPlotStyleVar_MarkerSize
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, MarkerWeight)       }, // ImPlotStyleVar_MarkerWeight
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, FillAlpha)          }, // ImPlotStyleVar_FillAlpha
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, ErrorBarSize)       }, // ImPlotStyleVar_ErrorBarSize
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, ErrorBarWeight)     }, // ImPlotStyleVar_ErrorBarWeight
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, DigitalBitHeight)   }, // ImPlotStyleVar_DigitalBitHeight
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, DigitalBitGap)      }, // ImPlotStyleVar_DigitalBitGap
+
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, PlotBorderSize)     }, // ImPlotStyleVar_PlotBorderSize
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, MinorAlpha)         }, // ImPlotStyleVar_MinorAlpha
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MajorTickLen)       }, // ImPlotStyleVar_MajorTickLen
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MinorTickLen)       }, // ImPlotStyleVar_MinorTickLen
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MajorTickSize)      }, // ImPlotStyleVar_MajorTickSize
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MinorTickSize)      }, // ImPlotStyleVar_MinorTickSize
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MajorGridSize)      }, // ImPlotStyleVar_MajorGridSize
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MinorGridSize)      }, // ImPlotStyleVar_MinorGridSize
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, PlotPadding)        }, // ImPlotStyleVar_PlotPadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, LabelPadding)       }, // ImPlotStyleVar_LabelPaddine
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, LegendPadding)      }, // ImPlotStyleVar_LegendPadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, LegendInnerPadding) }, // ImPlotStyleVar_LegendInnerPadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, LegendSpacing)      }, // ImPlotStyleVar_LegendSpacing
+
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MousePosPadding)    }, // ImPlotStyleVar_MousePosPadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, AnnotationPadding)  }, // ImPlotStyleVar_AnnotationPadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, FitPadding)         }, // ImPlotStyleVar_FitPadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, PlotDefaultSize)    }, // ImPlotStyleVar_PlotDefaultSize
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, PlotMinSize)        }  // ImPlotStyleVar_PlotMinSize
+};
+
+static const ImPlotStyleVarInfo* GetPlotStyleVarInfo(ImPlotStyleVar idx) {
+    IM_ASSERT(idx >= 0 && idx < ImPlotStyleVar_COUNT);
+    IM_ASSERT(IM_ARRAYSIZE(GPlotStyleVarInfo) == ImPlotStyleVar_COUNT);
+    return &GPlotStyleVarInfo[idx];
+}
+
+//-----------------------------------------------------------------------------
+// Generic Helpers
+//-----------------------------------------------------------------------------
+
+void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char *text_begin, const char* text_end) {
+    // the code below is based loosely on ImFont::RenderText
+    if (!text_end)
+        text_end = text_begin + strlen(text_begin);
+    ImGuiContext& g = *GImGui;
+    ImFont* font = g.Font;
+    // Align to be pixel perfect
+    pos.x = IM_FLOOR(pos.x);
+    pos.y = IM_FLOOR(pos.y);
+    const float scale = g.FontSize / font->FontSize;
+    const char* s = text_begin;
+    int chars_exp = (int)(text_end - s);
+    int chars_rnd = 0;
+    const int vtx_count_max = chars_exp * 4;
+    const int idx_count_max = chars_exp * 6;
+    DrawList->PrimReserve(idx_count_max, vtx_count_max);
+    while (s < text_end) {
+        unsigned int c = (unsigned int)*s;
+        if (c < 0x80) {
+            s += 1;
+        }
+        else {
+            s += ImTextCharFromUtf8(&c, s, text_end);
+            if (c == 0) // Malformed UTF-8?
+                break;
+        }
+        const ImFontGlyph * glyph = font->FindGlyph((ImWchar)c);
+        if (glyph == NULL) {
+            continue;
+        }
+        DrawList->PrimQuadUV(pos + ImVec2(glyph->Y0, -glyph->X0) * scale, pos + ImVec2(glyph->Y0, -glyph->X1) * scale,
+                             pos + ImVec2(glyph->Y1, -glyph->X1) * scale, pos + ImVec2(glyph->Y1, -glyph->X0) * scale,
+                             ImVec2(glyph->U0, glyph->V0), ImVec2(glyph->U1, glyph->V0),
+                             ImVec2(glyph->U1, glyph->V1), ImVec2(glyph->U0, glyph->V1),
+                             col);
+        pos.y -= glyph->AdvanceX * scale;
+        chars_rnd++;
+    }
+    // Give back unused vertices
+    int chars_skp = chars_exp-chars_rnd;
+    DrawList->PrimUnreserve(chars_skp*6, chars_skp*4);
+}
+
+void AddTextCentered(ImDrawList* DrawList, ImVec2 top_center, ImU32 col, const char* text_begin, const char* text_end) {
+    float txt_ht = ImGui::GetTextLineHeight();
+    const char* title_end = ImGui::FindRenderedTextEnd(text_begin, text_end);
+    ImVec2 text_size;
+    float  y = 0;
+    while (const char* tmp = (const char*)memchr(text_begin, '\n', title_end-text_begin)) {
+        text_size = ImGui::CalcTextSize(text_begin,tmp,true);
+        DrawList->AddText(ImVec2(top_center.x - text_size.x * 0.5f, top_center.y+y),col,text_begin,tmp);
+        text_begin = tmp + 1;
+        y += txt_ht;
+    }
+    text_size = ImGui::CalcTextSize(text_begin,title_end,true);
+    DrawList->AddText(ImVec2(top_center.x - text_size.x * 0.5f, top_center.y+y),col,text_begin,title_end);
+}
+
+double NiceNum(double x, bool round) {
+    double f;
+    double nf;
+    int expv = (int)floor(ImLog10(x));
+    f = x / ImPow(10.0, (double)expv);
+    if (round)
+        if (f < 1.5)
+            nf = 1;
+        else if (f < 3)
+            nf = 2;
+        else if (f < 7)
+            nf = 5;
+        else
+            nf = 10;
+    else if (f <= 1)
+        nf = 1;
+    else if (f <= 2)
+        nf = 2;
+    else if (f <= 5)
+        nf = 5;
+    else
+        nf = 10;
+    return nf * ImPow(10.0, expv);
+}
+
+//-----------------------------------------------------------------------------
+// Context Utils
+//-----------------------------------------------------------------------------
+
+void SetImGuiContext(ImGuiContext* ctx) {
+    ImGui::SetCurrentContext(ctx);
+}
+
+ImPlotContext* CreateContext() {
+    ImPlotContext* ctx = IM_NEW(ImPlotContext)();
+    Initialize(ctx);
+    if (GImPlot == NULL)
+        SetCurrentContext(ctx);
+    return ctx;
+}
+
+void DestroyContext(ImPlotContext* ctx) {
+    if (ctx == NULL)
+        ctx = GImPlot;
+    if (GImPlot == ctx)
+        SetCurrentContext(NULL);
+    IM_DELETE(ctx);
+}
+
+ImPlotContext* GetCurrentContext() {
+    return GImPlot;
+}
+
+void SetCurrentContext(ImPlotContext* ctx) {
+    GImPlot = ctx;
+}
+
+#define IMPLOT_APPEND_CMAP(name, qual) ctx->ColormapData.Append(#name, name, sizeof(name)/sizeof(ImU32), qual)
+#define IM_RGB(r,g,b) IM_COL32(r,g,b,255)
+
+void Initialize(ImPlotContext* ctx) {
+    ResetCtxForNextPlot(ctx);
+    ResetCtxForNextAlignedPlots(ctx);
+    ResetCtxForNextSubplot(ctx);
+
+    const ImU32 Deep[]     = {4289753676, 4283598045, 4285048917, 4283584196, 4289950337, 4284512403, 4291005402, 4287401100, 4285839820, 4291671396                        };
+    const ImU32 Dark[]     = {4280031972, 4290281015, 4283084621, 4288892568, 4278222847, 4281597951, 4280833702, 4290740727, 4288256409                                    };
+    const ImU32 Pastel[]   = {4289639675, 4293119411, 4291161036, 4293184478, 4289124862, 4291624959, 4290631909, 4293712637, 4294111986                                    };
+    const ImU32 Paired[]   = {4293119554, 4290017311, 4287291314, 4281114675, 4288256763, 4280031971, 4285513725, 4278222847, 4292260554, 4288298346, 4288282623, 4280834481};
+    const ImU32 Viridis[]  = {4283695428, 4285867080, 4287054913, 4287455029, 4287526954, 4287402273, 4286883874, 4285579076, 4283552122, 4280737725, 4280674301            };
+    const ImU32 Plasma[]   = {4287039501, 4288480321, 4289200234, 4288941455, 4287638193, 4286072780, 4284638433, 4283139314, 4281771772, 4280667900, 4280416752            };
+    const ImU32 Hot[]      = {4278190144, 4278190208, 4278190271, 4278190335, 4278206719, 4278223103, 4278239231, 4278255615, 4283826175, 4289396735, 4294967295            };
+    const ImU32 Cool[]     = {4294967040, 4294960666, 4294954035, 4294947661, 4294941030, 4294934656, 4294928025, 4294921651, 4294915020, 4294908646, 4294902015            };
+    const ImU32 Pink[]     = {4278190154, 4282532475, 4284308894, 4285690554, 4286879686, 4287870160, 4288794330, 4289651940, 4291685869, 4293392118, 4294967295            };
+    const ImU32 Jet[]      = {4289331200, 4294901760, 4294923520, 4294945280, 4294967040, 4289396565, 4283826090, 4278255615, 4278233855, 4278212095, 4278190335            };
+    const ImU32 Twilight[] = {IM_RGB(226,217,226),IM_RGB(166,191,202),IM_RGB(109,144,192),IM_RGB(95,88,176),IM_RGB(83,30,124),IM_RGB(47,20,54),IM_RGB(100,25,75),IM_RGB(159,60,80),IM_RGB(192,117,94),IM_RGB(208,179,158),IM_RGB(226,217,226)};
+    const ImU32 RdBu[]     = {IM_RGB(103,0,31),IM_RGB(178,24,43),IM_RGB(214,96,77),IM_RGB(244,165,130),IM_RGB(253,219,199),IM_RGB(247,247,247),IM_RGB(209,229,240),IM_RGB(146,197,222),IM_RGB(67,147,195),IM_RGB(33,102,172),IM_RGB(5,48,97)};
+    const ImU32 BrBG[]     = {IM_RGB(84,48,5),IM_RGB(140,81,10),IM_RGB(191,129,45),IM_RGB(223,194,125),IM_RGB(246,232,195),IM_RGB(245,245,245),IM_RGB(199,234,229),IM_RGB(128,205,193),IM_RGB(53,151,143),IM_RGB(1,102,94),IM_RGB(0,60,48)};
+    const ImU32 PiYG[]     = {IM_RGB(142,1,82),IM_RGB(197,27,125),IM_RGB(222,119,174),IM_RGB(241,182,218),IM_RGB(253,224,239),IM_RGB(247,247,247),IM_RGB(230,245,208),IM_RGB(184,225,134),IM_RGB(127,188,65),IM_RGB(77,146,33),IM_RGB(39,100,25)};
+    const ImU32 Spectral[] = {IM_RGB(158,1,66),IM_RGB(213,62,79),IM_RGB(244,109,67),IM_RGB(253,174,97),IM_RGB(254,224,139),IM_RGB(255,255,191),IM_RGB(230,245,152),IM_RGB(171,221,164),IM_RGB(102,194,165),IM_RGB(50,136,189),IM_RGB(94,79,162)};
+    const ImU32 Greys[]    = {IM_COL32_WHITE, IM_COL32_BLACK                                                                                                                };
+
+    IMPLOT_APPEND_CMAP(Deep, true);
+    IMPLOT_APPEND_CMAP(Dark, true);
+    IMPLOT_APPEND_CMAP(Pastel, true);
+    IMPLOT_APPEND_CMAP(Paired, true);
+    IMPLOT_APPEND_CMAP(Viridis, false);
+    IMPLOT_APPEND_CMAP(Plasma, false);
+    IMPLOT_APPEND_CMAP(Hot, false);
+    IMPLOT_APPEND_CMAP(Cool, false);
+    IMPLOT_APPEND_CMAP(Pink, false);
+    IMPLOT_APPEND_CMAP(Jet, false);
+    IMPLOT_APPEND_CMAP(Twilight, false);
+    IMPLOT_APPEND_CMAP(RdBu, false);
+    IMPLOT_APPEND_CMAP(BrBG, false);
+    IMPLOT_APPEND_CMAP(PiYG, false);
+    IMPLOT_APPEND_CMAP(Spectral, false);
+    IMPLOT_APPEND_CMAP(Greys, false);
+}
+
+void ResetCtxForNextPlot(ImPlotContext* ctx) {
+    // end child window if it was made
+    if (ctx->ChildWindowMade)
+        ImGui::EndChild();
+    ctx->ChildWindowMade = false;
+    // reset the next plot/item data
+    ctx->NextPlotData.Reset();
+    ctx->NextItemData.Reset();
+    // reset labels
+    ctx->Annotations.Reset();
+    ctx->Tags.Reset();
+    // reset extents/fit
+    ctx->OpenContextThisFrame = false;
+    // reset digital plot items count
+    ctx->DigitalPlotItemCnt = 0;
+    ctx->DigitalPlotOffset = 0;
+    // nullify plot
+    ctx->CurrentPlot  = NULL;
+    ctx->CurrentItem  = NULL;
+    ctx->PreviousItem = NULL;
+}
+
+void ResetCtxForNextAlignedPlots(ImPlotContext* ctx) {
+    ctx->CurrentAlignmentH = NULL;
+    ctx->CurrentAlignmentV = NULL;
+}
+
+void ResetCtxForNextSubplot(ImPlotContext* ctx) {
+    ctx->CurrentSubplot      = NULL;
+    ctx->CurrentAlignmentH   = NULL;
+    ctx->CurrentAlignmentV   = NULL;
+}
+
+//-----------------------------------------------------------------------------
+// Plot Utils
+//-----------------------------------------------------------------------------
+
+ImPlotPlot* GetPlot(const char* title) {
+    ImGuiWindow*   Window = GImGui->CurrentWindow;
+    const ImGuiID  ID     = Window->GetID(title);
+    return GImPlot->Plots.GetByKey(ID);
+}
+
+ImPlotPlot* GetCurrentPlot() {
+    return GImPlot->CurrentPlot;
+}
+
+void BustPlotCache() {
+    GImPlot->Plots.Clear();
+    GImPlot->Subplots.Clear();
+}
+
+//-----------------------------------------------------------------------------
+// Legend Utils
+//-----------------------------------------------------------------------------
+
+ImVec2 GetLocationPos(const ImRect& outer_rect, const ImVec2& inner_size, ImPlotLocation loc, const ImVec2& pad) {
+    ImVec2 pos;
+    if (ImHasFlag(loc, ImPlotLocation_West) && !ImHasFlag(loc, ImPlotLocation_East))
+        pos.x = outer_rect.Min.x + pad.x;
+    else if (!ImHasFlag(loc, ImPlotLocation_West) && ImHasFlag(loc, ImPlotLocation_East))
+        pos.x = outer_rect.Max.x - pad.x - inner_size.x;
+    else
+        pos.x = outer_rect.GetCenter().x - inner_size.x * 0.5f;
+    // legend reference point y
+    if (ImHasFlag(loc, ImPlotLocation_North) && !ImHasFlag(loc, ImPlotLocation_South))
+        pos.y = outer_rect.Min.y + pad.y;
+    else if (!ImHasFlag(loc, ImPlotLocation_North) && ImHasFlag(loc, ImPlotLocation_South))
+        pos.y = outer_rect.Max.y - pad.y - inner_size.y;
+    else
+        pos.y = outer_rect.GetCenter().y - inner_size.y * 0.5f;
+    pos.x = IM_ROUND(pos.x);
+    pos.y = IM_ROUND(pos.y);
+    return pos;
+}
+
+ImVec2 CalcLegendSize(ImPlotItemGroup& items, const ImVec2& pad, const ImVec2& spacing, bool vertical) {
+    // vars
+    const int   nItems      = items.GetLegendCount();
+    const float txt_ht      = ImGui::GetTextLineHeight();
+    const float icon_size   = txt_ht;
+    // get label max width
+    float max_label_width = 0;
+    float sum_label_width = 0;
+    for (int i = 0; i < nItems; ++i) {
+        const char* label       = items.GetLegendLabel(i);
+        const float label_width = ImGui::CalcTextSize(label, NULL, true).x;
+        max_label_width         = label_width > max_label_width ? label_width : max_label_width;
+        sum_label_width        += label_width;
+    }
+    // calc legend size
+    const ImVec2 legend_size = vertical ?
+                               ImVec2(pad.x * 2 + icon_size + max_label_width, pad.y * 2 + nItems * txt_ht + (nItems - 1) * spacing.y) :
+                               ImVec2(pad.x * 2 + icon_size * nItems + sum_label_width + (nItems - 1) * spacing.x, pad.y * 2 + txt_ht);
+    return legend_size;
+}
+
+int LegendSortingComp(const void* _a, const void* _b) {
+    ImPlotItemGroup* items = GImPlot->SortItems;
+    const int a = *(const int*)_a;
+    const int b = *(const int*)_b;
+    const char* label_a = items->GetLegendLabel(a);
+    const char* label_b = items->GetLegendLabel(b);
+    return strcmp(label_a,label_b);
+}
+
+bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hovered, const ImVec2& pad, const ImVec2& spacing, bool vertical, ImDrawList& DrawList) {
+    // vars
+    const float txt_ht      = ImGui::GetTextLineHeight();
+    const float icon_size   = txt_ht;
+    const float icon_shrink = 2;
+    ImU32 col_txt           = GetStyleColorU32(ImPlotCol_LegendText);
+    ImU32  col_txt_dis      = ImAlphaU32(col_txt, 0.25f);
+    // render each legend item
+    float sum_label_width = 0;
+    bool any_item_hovered = false;
+
+    const int num_items = items.GetLegendCount();
+    if (num_items < 1)
+        return hovered;
+    // build render order
+    ImVector<int>& indices = GImPlot->TempInt1;
+    indices.resize(num_items);
+    for (int i = 0; i < num_items; ++i)
+        indices[i] = i;
+    if (ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_Sort) && num_items > 1) {
+        GImPlot->SortItems = &items;
+        qsort(indices.Data, num_items, sizeof(int), LegendSortingComp);
+    }
+    // render
+    for (int i = 0; i < num_items; ++i) {
+        const int idx           = indices[i];
+        ImPlotItem* item        = items.GetLegendItem(idx);
+        const char* label       = items.GetLegendLabel(idx);
+        const float label_width = ImGui::CalcTextSize(label, NULL, true).x;
+        const ImVec2 top_left   = vertical ?
+                                  legend_bb.Min + pad + ImVec2(0, i * (txt_ht + spacing.y)) :
+                                  legend_bb.Min + pad + ImVec2(i * (icon_size + spacing.x) + sum_label_width, 0);
+        sum_label_width        += label_width;
+        ImRect icon_bb;
+        icon_bb.Min = top_left + ImVec2(icon_shrink,icon_shrink);
+        icon_bb.Max = top_left + ImVec2(icon_size - icon_shrink, icon_size - icon_shrink);
+        ImRect label_bb;
+        label_bb.Min = top_left;
+        label_bb.Max = top_left + ImVec2(label_width + icon_size, icon_size);
+        ImU32 col_txt_hl;
+        ImU32 col_item = ImAlphaU32(item->Color,1);
+
+        ImRect button_bb(icon_bb.Min, label_bb.Max);
+
+        ImGui::KeepAliveID(item->ID);
+
+        bool item_hov = false;
+        bool item_hld = false;
+        bool item_clk = ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_NoButtons)
+                      ? false
+                      : ImGui::ButtonBehavior(button_bb, item->ID, &item_hov, &item_hld);
+
+        if (item_clk)
+            item->Show = !item->Show;
+
+
+        const bool can_hover = (item_hov)
+                             && (!ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_NoHighlightItem)
+                             || !ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_NoHighlightAxis));
+
+        if (can_hover) {
+            item->LegendHoverRect.Min = icon_bb.Min;
+            item->LegendHoverRect.Max = label_bb.Max;
+            item->LegendHovered = true;
+            col_txt_hl = ImMixU32(col_txt, col_item, 64);
+            any_item_hovered = true;
+        }
+        else {
+            col_txt_hl = ImGui::GetColorU32(col_txt);
+        }
+        ImU32 col_icon;
+        if (item_hld)
+            col_icon = item->Show ? ImAlphaU32(col_item,0.5f) : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.5f);
+        else if (item_hov)
+            col_icon = item->Show ? ImAlphaU32(col_item,0.75f) : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.75f);
+        else
+            col_icon = item->Show ? col_item : col_txt_dis;
+
+        DrawList.AddRectFilled(icon_bb.Min, icon_bb.Max, col_icon);
+        const char* text_display_end = ImGui::FindRenderedTextEnd(label, NULL);
+        if (label != text_display_end)
+            DrawList.AddText(top_left + ImVec2(icon_size, 0), item->Show ? col_txt_hl  : col_txt_dis, label, text_display_end);
+    }
+    return hovered && !any_item_hovered;
+}
+
+//-----------------------------------------------------------------------------
+// Locators
+//-----------------------------------------------------------------------------
+
+static const float TICK_FILL_X = 0.8f;
+static const float TICK_FILL_Y = 1.0f;
+
+void Locator_Default(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data) {
+    if (range.Min == range.Max)
+        return;
+    const int nMinor        = 10;
+    const int nMajor        = ImMax(2, (int)IM_ROUND(pixels / (vertical ? 300.0f : 400.0f)));
+    const double nice_range = NiceNum(range.Size() * 0.99, false);
+    const double interval   = NiceNum(nice_range / (nMajor - 1), true);
+    const double graphmin   = floor(range.Min / interval) * interval;
+    const double graphmax   = ceil(range.Max / interval) * interval;
+    bool first_major_set    = false;
+    int  first_major_idx    = 0;
+    const int idx0 = ticker.TickCount(); // ticker may have user custom ticks
+    ImVec2 total_size(0,0);
+    for (double major = graphmin; major < graphmax + 0.5 * interval; major += interval) {
+        // is this zero? combat zero formatting issues
+        if (major-interval < 0 && major+interval > 0)
+            major = 0;
+        if (range.Contains(major)) {
+            if (!first_major_set) {
+                first_major_idx = ticker.TickCount();
+                first_major_set = true;
+            }
+            total_size += ticker.AddTick(major, true, 0, true, formatter, formatter_data).LabelSize;
+        }
+        for (int i = 1; i < nMinor; ++i) {
+            double minor = major + i * interval / nMinor;
+            if (range.Contains(minor)) {
+                total_size += ticker.AddTick(minor, false, 0, true, formatter, formatter_data).LabelSize;
+            }
+        }
+    }
+    // prune if necessary
+    if ((!vertical && total_size.x > pixels*TICK_FILL_X) || (vertical && total_size.y > pixels*TICK_FILL_Y)) {
+        for (int i = first_major_idx-1; i >= idx0; i -= 2)
+            ticker.Ticks[i].ShowLabel = false;
+        for (int i = first_major_idx+1; i < ticker.TickCount(); i += 2)
+            ticker.Ticks[i].ShowLabel = false;
+    }
+}
+
+bool CalcLogarithmicExponents(const ImPlotRange& range, float pix, bool vertical, int& exp_min, int& exp_max, int& exp_step) {
+    if (range.Min * range.Max > 0) {
+        const int nMajor = vertical ? ImMax(2, (int)IM_ROUND(pix * 0.02f)) : ImMax(2, (int)IM_ROUND(pix * 0.01f)); // TODO: magic numbers
+        double log_min = ImLog10(ImAbs(range.Min));
+        double log_max = ImLog10(ImAbs(range.Max));
+        double log_a = ImMin(log_min,log_max);
+        double log_b = ImMax(log_min,log_max);
+        exp_step  = ImMax(1,(int)(log_b - log_a) / nMajor);
+        exp_min   = (int)log_a;
+        exp_max   = (int)log_b;
+        if (exp_step != 1) {
+            while(exp_step % 3 != 0)       exp_step++; // make step size multiple of three
+            while(exp_min % exp_step != 0) exp_min--;  // decrease exp_min until exp_min + N * exp_step will be 0
+        }
+        return true;
+    }
+    return false;
+}
+
+void AddTicksLogarithmic(const ImPlotRange& range, int exp_min, int exp_max, int exp_step, ImPlotTicker& ticker, ImPlotFormatter formatter, void* data) {
+    const double sign = ImSign(range.Max);
+    for (int e = exp_min - exp_step; e < (exp_max + exp_step); e += exp_step) {
+        double major1 = sign*ImPow(10, (double)(e));
+        double major2 = sign*ImPow(10, (double)(e + 1));
+        double interval = (major2 - major1) / 9;
+        if (major1 >= (range.Min - DBL_EPSILON) && major1 <= (range.Max + DBL_EPSILON))
+            ticker.AddTick(major1, true, 0, true, formatter, data);
+        for (int j = 0; j < exp_step; ++j) {
+            major1 = sign*ImPow(10, (double)(e+j));
+            major2 = sign*ImPow(10, (double)(e+j+1));
+            interval = (major2 - major1) / 9;
+            for (int i = 1; i < (9 + (int)(j < (exp_step - 1))); ++i) {
+                double minor = major1 + i * interval;
+                if (minor >= (range.Min - DBL_EPSILON) && minor <= (range.Max + DBL_EPSILON))
+                    ticker.AddTick(minor, false, 0, false, formatter, data);
+            }
+        }
+    }
+}
+
+void Locator_Log10(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data) {
+    int exp_min, exp_max, exp_step;
+    if (CalcLogarithmicExponents(range, pixels, vertical, exp_min, exp_max, exp_step))
+        AddTicksLogarithmic(range, exp_min, exp_max, exp_step, ticker, formatter, formatter_data);
+}
+
+float CalcSymLogPixel(double plt, const ImPlotRange& range, float pixels) {
+    double scaleToPixels = pixels / range.Size();
+    double scaleMin      = TransformForward_SymLog(range.Min,NULL);
+    double scaleMax      = TransformForward_SymLog(range.Max,NULL);
+    double s             = TransformForward_SymLog(plt, NULL);
+    double t             = (s - scaleMin) / (scaleMax - scaleMin);
+    plt                  = range.Min + range.Size() * t;
+
+    return (float)(0 + scaleToPixels * (plt - range.Min));
+}
+
+void Locator_SymLog(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data) {
+    if (range.Min >= -1 && range.Max <= 1) {
+        Locator_Default(ticker, range, pixels, vertical, formatter, formatter_data);
+    }
+    else if (range.Min * range.Max < 0) { // cross zero
+        const float pix_min = 0;
+        const float pix_max = pixels;
+        const float pix_p1  = CalcSymLogPixel(1, range, pixels);
+        const float pix_n1  = CalcSymLogPixel(-1, range, pixels);
+        int exp_min_p, exp_max_p, exp_step_p;
+        int exp_min_n, exp_max_n, exp_step_n;
+        CalcLogarithmicExponents(ImPlotRange(1,range.Max), ImAbs(pix_max-pix_p1),vertical,exp_min_p,exp_max_p,exp_step_p);
+        CalcLogarithmicExponents(ImPlotRange(range.Min,-1),ImAbs(pix_n1-pix_min),vertical,exp_min_n,exp_max_n,exp_step_n);
+        int exp_step = ImMax(exp_step_n, exp_step_p);
+        ticker.AddTick(0,true,0,true,formatter,formatter_data);
+        AddTicksLogarithmic(ImPlotRange(1,range.Max), exp_min_p,exp_max_p,exp_step,ticker,formatter,formatter_data);
+        AddTicksLogarithmic(ImPlotRange(range.Min,-1),exp_min_n,exp_max_n,exp_step,ticker,formatter,formatter_data);
+    }
+    else {
+        Locator_Log10(ticker, range, pixels, vertical, formatter, formatter_data);
+    }
+}
+
+void AddTicksCustom(const double* values, const char* const labels[], int n, ImPlotTicker& ticker, ImPlotFormatter formatter, void* data) {
+    for (int i = 0; i < n; ++i) {
+        if (labels != NULL)
+            ticker.AddTick(values[i], false, 0, true, labels[i]);
+        else
+            ticker.AddTick(values[i], false, 0, true, formatter, data);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Time Ticks and Utils
+//-----------------------------------------------------------------------------
+
+// this may not be thread safe?
+static const double TimeUnitSpans[ImPlotTimeUnit_COUNT] = {
+    0.000001,
+    0.001,
+    1,
+    60,
+    3600,
+    86400,
+    2629800,
+    31557600
+};
+
+inline ImPlotTimeUnit GetUnitForRange(double range) {
+    static double cutoffs[ImPlotTimeUnit_COUNT] = {0.001, 1, 60, 3600, 86400, 2629800, 31557600, IMPLOT_MAX_TIME};
+    for (int i = 0; i < ImPlotTimeUnit_COUNT; ++i) {
+        if (range <= cutoffs[i])
+            return (ImPlotTimeUnit)i;
+    }
+    return ImPlotTimeUnit_Yr;
+}
+
+inline int LowerBoundStep(int max_divs, const int* divs, const int* step, int size) {
+    if (max_divs < divs[0])
+        return 0;
+    for (int i = 1; i < size; ++i) {
+        if (max_divs < divs[i])
+            return step[i-1];
+    }
+    return step[size-1];
+}
+
+inline int GetTimeStep(int max_divs, ImPlotTimeUnit unit) {
+    if (unit == ImPlotTimeUnit_Ms || unit == ImPlotTimeUnit_Us) {
+        static const int step[] = {500,250,200,100,50,25,20,10,5,2,1};
+        static const int divs[] = {2,4,5,10,20,40,50,100,200,500,1000};
+        return LowerBoundStep(max_divs, divs, step, 11);
+    }
+    if (unit == ImPlotTimeUnit_S || unit == ImPlotTimeUnit_Min) {
+        static const int step[] = {30,15,10,5,1};
+        static const int divs[] = {2,4,6,12,60};
+        return LowerBoundStep(max_divs, divs, step, 5);
+    }
+    else if (unit == ImPlotTimeUnit_Hr) {
+        static const int step[] = {12,6,3,2,1};
+        static const int divs[] = {2,4,8,12,24};
+        return LowerBoundStep(max_divs, divs, step, 5);
+    }
+    else if (unit == ImPlotTimeUnit_Day) {
+        static const int step[] = {14,7,2,1};
+        static const int divs[] = {2,4,14,28};
+        return LowerBoundStep(max_divs, divs, step, 4);
+    }
+    else if (unit == ImPlotTimeUnit_Mo) {
+        static const int step[] = {6,3,2,1};
+        static const int divs[] = {2,4,6,12};
+        return LowerBoundStep(max_divs, divs, step, 4);
+    }
+    return 0;
+}
+
+ImPlotTime MkGmtTime(struct tm *ptm) {
+    ImPlotTime t;
+#ifdef _WIN32
+    t.S = _mkgmtime(ptm);
+#else
+    t.S = timegm(ptm);
+#endif
+    if (t.S < 0)
+        t.S = 0;
+    return t;
+}
+
+tm* GetGmtTime(const ImPlotTime& t, tm* ptm)
+{
+#ifdef _WIN32
+  if (gmtime_s(ptm, &t.S) == 0)
+    return ptm;
+  else
+    return NULL;
+#else
+  return gmtime_r(&t.S, ptm);
+#endif
+}
+
+ImPlotTime MkLocTime(struct tm *ptm) {
+    ImPlotTime t;
+    t.S = mktime(ptm);
+    if (t.S < 0)
+        t.S = 0;
+    return t;
+}
+
+tm* GetLocTime(const ImPlotTime& t, tm* ptm) {
+#ifdef _WIN32
+  if (localtime_s(ptm, &t.S) == 0)
+    return ptm;
+  else
+    return NULL;
+#else
+    return localtime_r(&t.S, ptm);
+#endif
+}
+
+inline ImPlotTime MkTime(struct tm *ptm) {
+    if (GetStyle().UseLocalTime)
+        return MkLocTime(ptm);
+    else
+        return MkGmtTime(ptm);
+}
+
+inline tm* GetTime(const ImPlotTime& t, tm* ptm) {
+    if (GetStyle().UseLocalTime)
+        return GetLocTime(t,ptm);
+    else
+        return GetGmtTime(t,ptm);
+}
+
+ImPlotTime MakeTime(int year, int month, int day, int hour, int min, int sec, int us) {
+    tm& Tm = GImPlot->Tm;
+
+    int yr = year - 1900;
+    if (yr < 0)
+        yr = 0;
+
+    sec  = sec + us / 1000000;
+    us   = us % 1000000;
+
+    Tm.tm_sec  = sec;
+    Tm.tm_min  = min;
+    Tm.tm_hour = hour;
+    Tm.tm_mday = day;
+    Tm.tm_mon  = month;
+    Tm.tm_year = yr;
+
+    ImPlotTime t = MkTime(&Tm);
+
+    t.Us = us;
+    return t;
+}
+
+int GetYear(const ImPlotTime& t) {
+    tm& Tm = GImPlot->Tm;
+    GetTime(t, &Tm);
+    return Tm.tm_year + 1900;
+}
+
+ImPlotTime AddTime(const ImPlotTime& t, ImPlotTimeUnit unit, int count) {
+    tm& Tm = GImPlot->Tm;
+    ImPlotTime t_out = t;
+    switch(unit) {
+        case ImPlotTimeUnit_Us:  t_out.Us += count;         break;
+        case ImPlotTimeUnit_Ms:  t_out.Us += count * 1000;  break;
+        case ImPlotTimeUnit_S:   t_out.S  += count;         break;
+        case ImPlotTimeUnit_Min: t_out.S  += count * 60;    break;
+        case ImPlotTimeUnit_Hr:  t_out.S  += count * 3600;  break;
+        case ImPlotTimeUnit_Day: t_out.S  += count * 86400; break;
+        case ImPlotTimeUnit_Mo:  for (int i = 0; i < abs(count); ++i) {
+                                     GetTime(t_out, &Tm);
+                                     if (count > 0)
+                                        t_out.S += 86400 * GetDaysInMonth(Tm.tm_year + 1900, Tm.tm_mon);
+                                     else if (count < 0)
+                                        t_out.S -= 86400 * GetDaysInMonth(Tm.tm_year + 1900 - (Tm.tm_mon == 0 ? 1 : 0), Tm.tm_mon == 0 ? 11 : Tm.tm_mon - 1); // NOT WORKING
+                                 }
+                                 break;
+        case ImPlotTimeUnit_Yr:  for (int i = 0; i < abs(count); ++i) {
+                                    if (count > 0)
+                                        t_out.S += 86400 * (365 + (int)IsLeapYear(GetYear(t_out)));
+                                    else if (count < 0)
+                                        t_out.S -= 86400 * (365 + (int)IsLeapYear(GetYear(t_out) - 1));
+                                    // this is incorrect if leap year and we are past Feb 28
+                                 }
+                                 break;
+        default:                 break;
+    }
+    t_out.RollOver();
+    return t_out;
+}
+
+ImPlotTime FloorTime(const ImPlotTime& t, ImPlotTimeUnit unit) {
+    GetTime(t, &GImPlot->Tm);
+    switch (unit) {
+        case ImPlotTimeUnit_S:   return ImPlotTime(t.S, 0);
+        case ImPlotTimeUnit_Ms:  return ImPlotTime(t.S, (t.Us / 1000) * 1000);
+        case ImPlotTimeUnit_Us:  return t;
+        case ImPlotTimeUnit_Yr:  GImPlot->Tm.tm_mon  = 0; // fall-through
+        case ImPlotTimeUnit_Mo:  GImPlot->Tm.tm_mday = 1; // fall-through
+        case ImPlotTimeUnit_Day: GImPlot->Tm.tm_hour = 0; // fall-through
+        case ImPlotTimeUnit_Hr:  GImPlot->Tm.tm_min  = 0; // fall-through
+        case ImPlotTimeUnit_Min: GImPlot->Tm.tm_sec  = 0; break;
+        default:                 return t;
+    }
+    return MkTime(&GImPlot->Tm);
+}
+
+ImPlotTime CeilTime(const ImPlotTime& t, ImPlotTimeUnit unit) {
+    return AddTime(FloorTime(t, unit), unit, 1);
+}
+
+ImPlotTime RoundTime(const ImPlotTime& t, ImPlotTimeUnit unit) {
+    ImPlotTime t1 = FloorTime(t, unit);
+    ImPlotTime t2 = AddTime(t1,unit,1);
+    if (t1.S == t2.S)
+        return t.Us - t1.Us < t2.Us - t.Us ? t1 : t2;
+    return t.S - t1.S < t2.S - t.S ? t1 : t2;
+}
+
+ImPlotTime CombineDateTime(const ImPlotTime& date_part, const ImPlotTime& tod_part) {
+    tm& Tm = GImPlot->Tm;
+    GetTime(date_part, &GImPlot->Tm);
+    int y = Tm.tm_year;
+    int m = Tm.tm_mon;
+    int d = Tm.tm_mday;
+    GetTime(tod_part, &GImPlot->Tm);
+    Tm.tm_year = y;
+    Tm.tm_mon  = m;
+    Tm.tm_mday = d;
+    ImPlotTime t = MkTime(&Tm);
+    t.Us = tod_part.Us;
+    return t;
+}
+
+// TODO: allow users to define these
+static const char* MONTH_NAMES[]  = {"January","February","March","April","May","June","July","August","September","October","November","December"};
+static const char* WD_ABRVS[]     = {"Su","Mo","Tu","We","Th","Fr","Sa"};
+static const char* MONTH_ABRVS[]  = {"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"};
+
+int FormatTime(const ImPlotTime& t, char* buffer, int size, ImPlotTimeFmt fmt, bool use_24_hr_clk) {
+    tm& Tm = GImPlot->Tm;
+    GetTime(t, &Tm);
+    const int us   = t.Us % 1000;
+    const int ms   = t.Us / 1000;
+    const int sec  = Tm.tm_sec;
+    const int min  = Tm.tm_min;
+    if (use_24_hr_clk) {
+        const int hr   = Tm.tm_hour;
+        switch(fmt) {
+            case ImPlotTimeFmt_Us:        return ImFormatString(buffer, size, ".%03d %03d", ms, us);
+            case ImPlotTimeFmt_SUs:       return ImFormatString(buffer, size, ":%02d.%03d %03d", sec, ms, us);
+            case ImPlotTimeFmt_SMs:       return ImFormatString(buffer, size, ":%02d.%03d", sec, ms);
+            case ImPlotTimeFmt_S:         return ImFormatString(buffer, size, ":%02d", sec);
+            case ImPlotTimeFmt_MinSMs:    return ImFormatString(buffer, size, ":%02d:%02d.%03d", min, sec, ms);
+            case ImPlotTimeFmt_HrMinSMs:  return ImFormatString(buffer, size, "%02d:%02d:%02d.%03d", hr, min, sec, ms);
+            case ImPlotTimeFmt_HrMinS:    return ImFormatString(buffer, size, "%02d:%02d:%02d", hr, min, sec);
+            case ImPlotTimeFmt_HrMin:     return ImFormatString(buffer, size, "%02d:%02d", hr, min);
+            case ImPlotTimeFmt_Hr:        return ImFormatString(buffer, size, "%02d:00", hr);
+            default:                      return 0;
+        }
+    }
+    else {
+        const char* ap = Tm.tm_hour < 12 ? "am" : "pm";
+        const int hr   = (Tm.tm_hour == 0 || Tm.tm_hour == 12) ? 12 : Tm.tm_hour % 12;
+        switch(fmt) {
+            case ImPlotTimeFmt_Us:        return ImFormatString(buffer, size, ".%03d %03d", ms, us);
+            case ImPlotTimeFmt_SUs:       return ImFormatString(buffer, size, ":%02d.%03d %03d", sec, ms, us);
+            case ImPlotTimeFmt_SMs:       return ImFormatString(buffer, size, ":%02d.%03d", sec, ms);
+            case ImPlotTimeFmt_S:         return ImFormatString(buffer, size, ":%02d", sec);
+            case ImPlotTimeFmt_MinSMs:    return ImFormatString(buffer, size, ":%02d:%02d.%03d", min, sec, ms);
+            case ImPlotTimeFmt_HrMinSMs:  return ImFormatString(buffer, size, "%d:%02d:%02d.%03d%s", hr, min, sec, ms, ap);
+            case ImPlotTimeFmt_HrMinS:    return ImFormatString(buffer, size, "%d:%02d:%02d%s", hr, min, sec, ap);
+            case ImPlotTimeFmt_HrMin:     return ImFormatString(buffer, size, "%d:%02d%s", hr, min, ap);
+            case ImPlotTimeFmt_Hr:        return ImFormatString(buffer, size, "%d%s", hr, ap);
+            default:                      return 0;
+        }
+    }
+}
+
+int FormatDate(const ImPlotTime& t, char* buffer, int size, ImPlotDateFmt fmt, bool use_iso_8601) {
+    tm& Tm = GImPlot->Tm;
+    GetTime(t, &Tm);
+    const int day  = Tm.tm_mday;
+    const int mon  = Tm.tm_mon + 1;
+    const int year = Tm.tm_year + 1900;
+    const int yr   = year % 100;
+    if (use_iso_8601) {
+        switch (fmt) {
+            case ImPlotDateFmt_DayMo:   return ImFormatString(buffer, size, "--%02d-%02d", mon, day);
+            case ImPlotDateFmt_DayMoYr: return ImFormatString(buffer, size, "%d-%02d-%02d", year, mon, day);
+            case ImPlotDateFmt_MoYr:    return ImFormatString(buffer, size, "%d-%02d", year, mon);
+            case ImPlotDateFmt_Mo:      return ImFormatString(buffer, size, "--%02d", mon);
+            case ImPlotDateFmt_Yr:      return ImFormatString(buffer, size, "%d", year);
+            default:                    return 0;
+        }
+    }
+    else {
+        switch (fmt) {
+            case ImPlotDateFmt_DayMo:   return ImFormatString(buffer, size, "%d/%d", mon, day);
+            case ImPlotDateFmt_DayMoYr: return ImFormatString(buffer, size, "%d/%d/%02d", mon, day, yr);
+            case ImPlotDateFmt_MoYr:    return ImFormatString(buffer, size, "%s %d", MONTH_ABRVS[Tm.tm_mon], year);
+            case ImPlotDateFmt_Mo:      return ImFormatString(buffer, size, "%s", MONTH_ABRVS[Tm.tm_mon]);
+            case ImPlotDateFmt_Yr:      return ImFormatString(buffer, size, "%d", year);
+            default:                    return 0;
+        }
+    }
+ }
+
+int FormatDateTime(const ImPlotTime& t, char* buffer, int size, ImPlotDateTimeSpec fmt) {
+    int written = 0;
+    if (fmt.Date != ImPlotDateFmt_None)
+        written += FormatDate(t, buffer, size, fmt.Date, fmt.UseISO8601);
+    if (fmt.Time != ImPlotTimeFmt_None) {
+        if (fmt.Date != ImPlotDateFmt_None)
+            buffer[written++] = ' ';
+        written += FormatTime(t, &buffer[written], size - written, fmt.Time, fmt.Use24HourClock);
+    }
+    return written;
+}
+
+inline float GetDateTimeWidth(ImPlotDateTimeSpec fmt) {
+    static const ImPlotTime t_max_width = MakeTime(2888, 12, 22, 12, 58, 58, 888888); // best guess at time that maximizes pixel width
+    char buffer[32];
+    FormatDateTime(t_max_width, buffer, 32, fmt);
+    return ImGui::CalcTextSize(buffer).x;
+}
+
+inline bool TimeLabelSame(const char* l1, const char* l2) {
+    size_t len1 = strlen(l1);
+    size_t len2 = strlen(l2);
+    size_t n  = len1 < len2 ? len1 : len2;
+    return strcmp(l1 + len1 - n, l2 + len2 - n) == 0;
+}
+
+static const ImPlotDateTimeSpec TimeFormatLevel0[ImPlotTimeUnit_COUNT] = {
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,  ImPlotTimeFmt_Us),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,  ImPlotTimeFmt_SMs),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,  ImPlotTimeFmt_S),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,  ImPlotTimeFmt_HrMin),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,  ImPlotTimeFmt_Hr),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMo, ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_Mo,    ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_Yr,    ImPlotTimeFmt_None)
+};
+
+static const ImPlotDateTimeSpec TimeFormatLevel1[ImPlotTimeUnit_COUNT] = {
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,    ImPlotTimeFmt_HrMin),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,    ImPlotTimeFmt_HrMinS),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,    ImPlotTimeFmt_HrMin),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,    ImPlotTimeFmt_HrMin),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr, ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr, ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_Yr,      ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_Yr,      ImPlotTimeFmt_None)
+};
+
+static const ImPlotDateTimeSpec TimeFormatLevel1First[ImPlotTimeUnit_COUNT] = {
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr, ImPlotTimeFmt_HrMinS),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr, ImPlotTimeFmt_HrMinS),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr, ImPlotTimeFmt_HrMin),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr, ImPlotTimeFmt_HrMin),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr, ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr, ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_Yr,      ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_Yr,      ImPlotTimeFmt_None)
+};
+
+static const ImPlotDateTimeSpec TimeFormatMouseCursor[ImPlotTimeUnit_COUNT] = {
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,     ImPlotTimeFmt_Us),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,     ImPlotTimeFmt_SUs),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,     ImPlotTimeFmt_SMs),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,     ImPlotTimeFmt_HrMinS),
+    ImPlotDateTimeSpec(ImPlotDateFmt_None,     ImPlotTimeFmt_HrMin),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMo,    ImPlotTimeFmt_Hr),
+    ImPlotDateTimeSpec(ImPlotDateFmt_DayMoYr,  ImPlotTimeFmt_None),
+    ImPlotDateTimeSpec(ImPlotDateFmt_MoYr,     ImPlotTimeFmt_None)
+};
+
+inline ImPlotDateTimeSpec GetDateTimeFmt(const ImPlotDateTimeSpec* ctx, ImPlotTimeUnit idx) {
+    ImPlotStyle& style     = GetStyle();
+    ImPlotDateTimeSpec fmt  = ctx[idx];
+    fmt.UseISO8601         = style.UseISO8601;
+    fmt.Use24HourClock     = style.Use24HourClock;
+    return fmt;
+}
+
+void Locator_Time(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data) {
+    IM_ASSERT_USER_ERROR(vertical == false, "Cannot locate Time ticks on vertical axis!");
+    (void)vertical;
+    // get units for level 0 and level 1 labels
+    const ImPlotTimeUnit unit0 = GetUnitForRange(range.Size() / (pixels / 100)); // level = 0 (top)
+    const ImPlotTimeUnit unit1 = ImClamp(unit0 + 1, 0, ImPlotTimeUnit_COUNT-1);  // level = 1 (bottom)
+    // get time format specs
+    const ImPlotDateTimeSpec fmt0 = GetDateTimeFmt(TimeFormatLevel0, unit0);
+    const ImPlotDateTimeSpec fmt1 = GetDateTimeFmt(TimeFormatLevel1, unit1);
+    const ImPlotDateTimeSpec fmtf = GetDateTimeFmt(TimeFormatLevel1First, unit1);
+    // min max times
+    const ImPlotTime t_min = ImPlotTime::FromDouble(range.Min);
+    const ImPlotTime t_max = ImPlotTime::FromDouble(range.Max);
+    // maximum allowable density of labels
+    const float max_density = 0.5f;
+    // book keeping
+    int last_major_offset = -1;
+    // formatter data
+    Formatter_Time_Data ftd;
+    ftd.UserFormatter = formatter;
+    ftd.UserFormatterData = formatter_data;
+    if (unit0 != ImPlotTimeUnit_Yr) {
+        // pixels per major (level 1) division
+        const float pix_per_major_div = pixels / (float)(range.Size() / TimeUnitSpans[unit1]);
+        // nominal pixels taken up by labels
+        const float fmt0_width = GetDateTimeWidth(fmt0);
+        const float fmt1_width = GetDateTimeWidth(fmt1);
+        const float fmtf_width = GetDateTimeWidth(fmtf);
+        // the maximum number of minor (level 0) labels that can fit between major (level 1) divisions
+        const int   minor_per_major   = (int)(max_density * pix_per_major_div / fmt0_width);
+        // the minor step size (level 0)
+        const int step = GetTimeStep(minor_per_major, unit0);
+        // generate ticks
+        ImPlotTime t1 = FloorTime(ImPlotTime::FromDouble(range.Min), unit1);
+        while (t1 < t_max) {
+            // get next major
+            const ImPlotTime t2 = AddTime(t1, unit1, 1);
+            // add major tick
+            if (t1 >= t_min && t1 <= t_max) {
+                // minor level 0 tick
+                ftd.Time = t1; ftd.Spec = fmt0;
+                ticker.AddTick(t1.ToDouble(), true, 0, true, Formatter_Time, &ftd);
+                // major level 1 tick
+                ftd.Time = t1; ftd.Spec = last_major_offset < 0 ? fmtf : fmt1;
+                ImPlotTick& tick_maj = ticker.AddTick(t1.ToDouble(), true, 1, true, Formatter_Time, &ftd);
+                const char* this_major = ticker.GetText(tick_maj);
+                if (last_major_offset >= 0 && TimeLabelSame(ticker.TextBuffer.Buf.Data + last_major_offset, this_major))
+                    tick_maj.ShowLabel = false;
+                last_major_offset = tick_maj.TextOffset;
+            }
+            // add minor ticks up until next major
+            if (minor_per_major > 1 && (t_min <= t2 && t1 <= t_max)) {
+                ImPlotTime t12 = AddTime(t1, unit0, step);
+                while (t12 < t2) {
+                    float px_to_t2 = (float)((t2 - t12).ToDouble()/range.Size()) * pixels;
+                    if (t12 >= t_min && t12 <= t_max) {
+                        ftd.Time = t12; ftd.Spec = fmt0;
+                        ticker.AddTick(t12.ToDouble(), false, 0, px_to_t2 >= fmt0_width, Formatter_Time, &ftd);
+                        if (last_major_offset < 0 && px_to_t2 >= fmt0_width && px_to_t2 >= (fmt1_width + fmtf_width) / 2) {
+                            ftd.Time = t12; ftd.Spec = fmtf;
+                            ImPlotTick& tick_maj = ticker.AddTick(t12.ToDouble(), true, 1, true, Formatter_Time, &ftd);
+                            last_major_offset = tick_maj.TextOffset;
+                        }
+                    }
+                    t12 = AddTime(t12, unit0, step);
+                }
+            }
+            t1 = t2;
+        }
+    }
+    else {
+        const ImPlotDateTimeSpec fmty = GetDateTimeFmt(TimeFormatLevel0, ImPlotTimeUnit_Yr);
+        const float label_width = GetDateTimeWidth(fmty);
+        const int   max_labels  = (int)(max_density * pixels / label_width);
+        const int year_min      = GetYear(t_min);
+        const int year_max      = GetYear(CeilTime(t_max, ImPlotTimeUnit_Yr));
+        const double nice_range = NiceNum((year_max - year_min)*0.99,false);
+        const double interval   = NiceNum(nice_range / (max_labels - 1), true);
+        const int graphmin      = (int)(floor(year_min / interval) * interval);
+        const int graphmax      = (int)(ceil(year_max  / interval) * interval);
+        const int step          = (int)interval <= 0 ? 1 : (int)interval;
+
+        for (int y = graphmin; y < graphmax; y += step) {
+            ImPlotTime t = MakeTime(y);
+            if (t >= t_min && t <= t_max) {
+                ftd.Time = t; ftd.Spec = fmty;
+                ticker.AddTick(t.ToDouble(), true, 0, true, Formatter_Time, &ftd);
+            }
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Context Menu
+//-----------------------------------------------------------------------------
+
+template <typename F>
+bool DragFloat(const char*, F*, float, F, F) {
+    return false;
+}
+
+template <>
+bool DragFloat<double>(const char* label, double* v, float v_speed, double v_min, double v_max) {
+    return ImGui::DragScalar(label, ImGuiDataType_Double, v, v_speed, &v_min, &v_max, "%.3f", 1);
+}
+
+template <>
+bool DragFloat<float>(const char* label, float* v, float v_speed, float v_min, float v_max) {
+    return ImGui::DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, "%.3f", 1);
+}
+
+inline void BeginDisabledControls(bool cond) {
+    if (cond) {
+        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+        ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.25f);
+    }
+}
+
+inline void EndDisabledControls(bool cond) {
+    if (cond) {
+        ImGui::PopItemFlag();
+        ImGui::PopStyleVar();
+    }
+}
+
+void ShowAxisContextMenu(ImPlotAxis& axis, ImPlotAxis* equal_axis, bool /*time_allowed*/) {
+
+    ImGui::PushItemWidth(75);
+    bool always_locked   = axis.IsRangeLocked() || axis.IsAutoFitting();
+    bool label           = axis.HasLabel();
+    bool grid            = axis.HasGridLines();
+    bool ticks           = axis.HasTickMarks();
+    bool labels          = axis.HasTickLabels();
+    double drag_speed    = (axis.Range.Size() <= DBL_EPSILON) ? DBL_EPSILON * 1.0e+13 : 0.01 * axis.Range.Size(); // recover from almost equal axis limits.
+
+    if (axis.Scale == ImPlotScale_Time) {
+        ImPlotTime tmin = ImPlotTime::FromDouble(axis.Range.Min);
+        ImPlotTime tmax = ImPlotTime::FromDouble(axis.Range.Max);
+
+        BeginDisabledControls(always_locked);
+        ImGui::CheckboxFlags("##LockMin", (unsigned int*)&axis.Flags, ImPlotAxisFlags_LockMin);
+        EndDisabledControls(always_locked);
+        ImGui::SameLine();
+        BeginDisabledControls(axis.IsLockedMin() || always_locked);
+        if (ImGui::BeginMenu("Min Time")) {
+            if (ShowTimePicker("mintime", &tmin)) {
+                if (tmin >= tmax)
+                    tmax = AddTime(tmin, ImPlotTimeUnit_S, 1);
+                axis.SetRange(tmin.ToDouble(),tmax.ToDouble());
+            }
+            ImGui::Separator();
+            if (ShowDatePicker("mindate",&axis.PickerLevel,&axis.PickerTimeMin,&tmin,&tmax)) {
+                tmin = CombineDateTime(axis.PickerTimeMin, tmin);
+                if (tmin >= tmax)
+                    tmax = AddTime(tmin, ImPlotTimeUnit_S, 1);
+                axis.SetRange(tmin.ToDouble(), tmax.ToDouble());
+            }
+            ImGui::EndMenu();
+        }
+        EndDisabledControls(axis.IsLockedMin() || always_locked);
+
+        BeginDisabledControls(always_locked);
+        ImGui::CheckboxFlags("##LockMax", (unsigned int*)&axis.Flags, ImPlotAxisFlags_LockMax);
+        EndDisabledControls(always_locked);
+        ImGui::SameLine();
+        BeginDisabledControls(axis.IsLockedMax() || always_locked);
+        if (ImGui::BeginMenu("Max Time")) {
+            if (ShowTimePicker("maxtime", &tmax)) {
+                if (tmax <= tmin)
+                    tmin = AddTime(tmax, ImPlotTimeUnit_S, -1);
+                axis.SetRange(tmin.ToDouble(),tmax.ToDouble());
+            }
+            ImGui::Separator();
+            if (ShowDatePicker("maxdate",&axis.PickerLevel,&axis.PickerTimeMax,&tmin,&tmax)) {
+                tmax = CombineDateTime(axis.PickerTimeMax, tmax);
+                if (tmax <= tmin)
+                    tmin = AddTime(tmax, ImPlotTimeUnit_S, -1);
+                axis.SetRange(tmin.ToDouble(), tmax.ToDouble());
+            }
+            ImGui::EndMenu();
+        }
+        EndDisabledControls(axis.IsLockedMax() || always_locked);
+    }
+    else {
+        BeginDisabledControls(always_locked);
+        ImGui::CheckboxFlags("##LockMin", (unsigned int*)&axis.Flags, ImPlotAxisFlags_LockMin);
+        EndDisabledControls(always_locked);
+        ImGui::SameLine();
+        BeginDisabledControls(axis.IsLockedMin() || always_locked);
+        double temp_min = axis.Range.Min;
+        if (DragFloat("Min", &temp_min, (float)drag_speed, -HUGE_VAL, axis.Range.Max - DBL_EPSILON)) {
+            axis.SetMin(temp_min,true);
+            if (equal_axis != NULL)
+                equal_axis->SetAspect(axis.GetAspect());
+        }
+        EndDisabledControls(axis.IsLockedMin() || always_locked);
+
+        BeginDisabledControls(always_locked);
+        ImGui::CheckboxFlags("##LockMax", (unsigned int*)&axis.Flags, ImPlotAxisFlags_LockMax);
+        EndDisabledControls(always_locked);
+        ImGui::SameLine();
+        BeginDisabledControls(axis.IsLockedMax() || always_locked);
+        double temp_max = axis.Range.Max;
+        if (DragFloat("Max", &temp_max, (float)drag_speed, axis.Range.Min + DBL_EPSILON, HUGE_VAL)) {
+            axis.SetMax(temp_max,true);
+            if (equal_axis != NULL)
+                equal_axis->SetAspect(axis.GetAspect());
+        }
+        EndDisabledControls(axis.IsLockedMax() || always_locked);
+    }
+
+    ImGui::Separator();
+
+    ImGui::CheckboxFlags("Auto-Fit",(unsigned int*)&axis.Flags, ImPlotAxisFlags_AutoFit);
+    // TODO
+    // BeginDisabledControls(axis.IsTime() && time_allowed);
+    // ImGui::CheckboxFlags("Log Scale",(unsigned int*)&axis.Flags, ImPlotAxisFlags_LogScale);
+    // EndDisabledControls(axis.IsTime() && time_allowed);
+    // if (time_allowed) {
+    //     BeginDisabledControls(axis.IsLog() || axis.IsSymLog());
+    //     ImGui::CheckboxFlags("Time",(unsigned int*)&axis.Flags, ImPlotAxisFlags_Time);
+    //     EndDisabledControls(axis.IsLog() || axis.IsSymLog());
+    // }
+    ImGui::Separator();
+    ImGui::CheckboxFlags("Invert",(unsigned int*)&axis.Flags, ImPlotAxisFlags_Invert);
+    ImGui::CheckboxFlags("Opposite",(unsigned int*)&axis.Flags, ImPlotAxisFlags_Opposite);
+    ImGui::Separator();
+    BeginDisabledControls(axis.LabelOffset == -1);
+    if (ImGui::Checkbox("Label", &label))
+        ImFlipFlag(axis.Flags, ImPlotAxisFlags_NoLabel);
+    EndDisabledControls(axis.LabelOffset == -1);
+    if (ImGui::Checkbox("Grid Lines", &grid))
+        ImFlipFlag(axis.Flags, ImPlotAxisFlags_NoGridLines);
+    if (ImGui::Checkbox("Tick Marks", &ticks))
+        ImFlipFlag(axis.Flags, ImPlotAxisFlags_NoTickMarks);
+    if (ImGui::Checkbox("Tick Labels", &labels))
+        ImFlipFlag(axis.Flags, ImPlotAxisFlags_NoTickLabels);
+
+}
+
+bool ShowLegendContextMenu(ImPlotLegend& legend, bool visible) {
+    const float s = ImGui::GetFrameHeight();
+    bool ret = false;
+    if (ImGui::Checkbox("Show",&visible))
+        ret = true;
+    if (legend.CanGoInside)
+        ImGui::CheckboxFlags("Outside",(unsigned int*)&legend.Flags, ImPlotLegendFlags_Outside);
+    if (ImGui::RadioButton("H", ImHasFlag(legend.Flags, ImPlotLegendFlags_Horizontal)))
+        legend.Flags |= ImPlotLegendFlags_Horizontal;
+    ImGui::SameLine();
+    if (ImGui::RadioButton("V", !ImHasFlag(legend.Flags, ImPlotLegendFlags_Horizontal)))
+        legend.Flags &= ~ImPlotLegendFlags_Horizontal;
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(2,2));
+    if (ImGui::Button("NW",ImVec2(1.5f*s,s))) { legend.Location = ImPlotLocation_NorthWest; } ImGui::SameLine();
+    if (ImGui::Button("N", ImVec2(1.5f*s,s))) { legend.Location = ImPlotLocation_North;     } ImGui::SameLine();
+    if (ImGui::Button("NE",ImVec2(1.5f*s,s))) { legend.Location = ImPlotLocation_NorthEast; }
+    if (ImGui::Button("W", ImVec2(1.5f*s,s))) { legend.Location = ImPlotLocation_West;      } ImGui::SameLine();
+    if (ImGui::InvisibleButton("C", ImVec2(1.5f*s,s))) {     } ImGui::SameLine();
+    if (ImGui::Button("E", ImVec2(1.5f*s,s))) { legend.Location = ImPlotLocation_East;      }
+    if (ImGui::Button("SW",ImVec2(1.5f*s,s))) { legend.Location = ImPlotLocation_SouthWest; } ImGui::SameLine();
+    if (ImGui::Button("S", ImVec2(1.5f*s,s))) { legend.Location = ImPlotLocation_South;     } ImGui::SameLine();
+    if (ImGui::Button("SE",ImVec2(1.5f*s,s))) { legend.Location = ImPlotLocation_SouthEast; }
+    ImGui::PopStyleVar();
+    return ret;
+}
+
+void ShowSubplotsContextMenu(ImPlotSubplot& subplot) {
+    if ((ImGui::BeginMenu("Linking"))) {
+        if (ImGui::MenuItem("Link Rows",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows)))
+            ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows);
+        if (ImGui::MenuItem("Link Cols",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkCols)))
+            ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkCols);
+        if (ImGui::MenuItem("Link All X",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllX)))
+            ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllX);
+        if (ImGui::MenuItem("Link All Y",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY)))
+            ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY);
+        ImGui::EndMenu();
+    }
+    if ((ImGui::BeginMenu("Settings"))) {
+        BeginDisabledControls(!subplot.HasTitle);
+        if (ImGui::MenuItem("Title",NULL,subplot.HasTitle && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle)))
+            ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle);
+        EndDisabledControls(!subplot.HasTitle);
+        if (ImGui::MenuItem("Resizable",NULL,!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoResize)))
+            ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_NoResize);
+        if (ImGui::MenuItem("Align",NULL,!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoAlign)))
+            ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_NoAlign);
+        if (ImGui::MenuItem("Share Items",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems)))
+            ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems);
+        ImGui::EndMenu();
+    }
+}
+
+void ShowPlotContextMenu(ImPlotPlot& plot) {
+    const bool owns_legend = GImPlot->CurrentItems == &plot.Items;
+    const bool equal = ImHasFlag(plot.Flags, ImPlotFlags_Equal);
+
+    char buf[16] = {};
+
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+        ImPlotAxis& x_axis = plot.XAxis(i);
+        if (!x_axis.Enabled || !x_axis.HasMenus())
+            continue;
+        ImGui::PushID(i);
+        ImFormatString(buf, sizeof(buf) - 1, i == 0 ? "X-Axis" : "X-Axis %d", i + 1);
+        if (ImGui::BeginMenu(x_axis.HasLabel() ? plot.GetAxisLabel(x_axis) : buf)) {
+            ShowAxisContextMenu(x_axis, equal ? x_axis.OrthoAxis : NULL, false);
+            ImGui::EndMenu();
+        }
+        ImGui::PopID();
+    }
+
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+        ImPlotAxis& y_axis = plot.YAxis(i);
+        if (!y_axis.Enabled || !y_axis.HasMenus())
+            continue;
+        ImGui::PushID(i);
+        ImFormatString(buf, sizeof(buf) - 1, i == 0 ? "Y-Axis" : "Y-Axis %d", i + 1);
+        if (ImGui::BeginMenu(y_axis.HasLabel() ? plot.GetAxisLabel(y_axis) : buf)) {
+            ShowAxisContextMenu(y_axis, equal ? y_axis.OrthoAxis : NULL, false);
+            ImGui::EndMenu();
+        }
+        ImGui::PopID();
+    }
+
+    ImGui::Separator();
+    if (!ImHasFlag(GImPlot->CurrentItems->Legend.Flags, ImPlotLegendFlags_NoMenus)) {
+        if ((ImGui::BeginMenu("Legend"))) {
+            if (owns_legend) {
+                if (ShowLegendContextMenu(plot.Items.Legend, !ImHasFlag(plot.Flags, ImPlotFlags_NoLegend)))
+                    ImFlipFlag(plot.Flags, ImPlotFlags_NoLegend);
+            }
+            else if (GImPlot->CurrentSubplot != NULL) {
+                if (ShowLegendContextMenu(GImPlot->CurrentSubplot->Items.Legend, !ImHasFlag(GImPlot->CurrentSubplot->Flags, ImPlotSubplotFlags_NoLegend)))
+                    ImFlipFlag(GImPlot->CurrentSubplot->Flags, ImPlotSubplotFlags_NoLegend);
+            }
+            ImGui::EndMenu();
+        }
+    }
+    if ((ImGui::BeginMenu("Settings"))) {
+        if (ImGui::MenuItem("Equal", NULL, ImHasFlag(plot.Flags, ImPlotFlags_Equal)))
+            ImFlipFlag(plot.Flags, ImPlotFlags_Equal);
+        if (ImGui::MenuItem("Box Select",NULL,!ImHasFlag(plot.Flags, ImPlotFlags_NoBoxSelect)))
+            ImFlipFlag(plot.Flags, ImPlotFlags_NoBoxSelect);
+        BeginDisabledControls(plot.TitleOffset == -1);
+        if (ImGui::MenuItem("Title",NULL,plot.HasTitle()))
+            ImFlipFlag(plot.Flags, ImPlotFlags_NoTitle);
+        EndDisabledControls(plot.TitleOffset == -1);
+        if (ImGui::MenuItem("Mouse Position",NULL,!ImHasFlag(plot.Flags, ImPlotFlags_NoMouseText)))
+            ImFlipFlag(plot.Flags, ImPlotFlags_NoMouseText);
+        if (ImGui::MenuItem("Crosshairs",NULL,ImHasFlag(plot.Flags, ImPlotFlags_Crosshairs)))
+            ImFlipFlag(plot.Flags, ImPlotFlags_Crosshairs);
+        ImGui::EndMenu();
+    }
+    if (GImPlot->CurrentSubplot != NULL && !ImHasFlag(GImPlot->CurrentPlot->Flags, ImPlotSubplotFlags_NoMenus)) {
+        ImGui::Separator();
+        if ((ImGui::BeginMenu("Subplots"))) {
+            ShowSubplotsContextMenu(*GImPlot->CurrentSubplot);
+            ImGui::EndMenu();
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Axis Utils
+//-----------------------------------------------------------------------------
+
+static inline int AxisPrecision(const ImPlotAxis& axis) {
+    const double range = axis.Ticker.TickCount() > 1 ? (axis.Ticker.Ticks[1].PlotPos - axis.Ticker.Ticks[0].PlotPos) : axis.Range.Size();
+    return Precision(range);
+}
+
+static inline double RoundAxisValue(const ImPlotAxis& axis, double value) {
+    return RoundTo(value, AxisPrecision(axis));
+}
+
+void LabelAxisValue(const ImPlotAxis& axis, double value, char* buff, int size, bool round) {
+    ImPlotContext& gp = *GImPlot;
+    // TODO: We shouldn't explicitly check that the axis is Time here. Ideally,
+    // Formatter_Time would handle the formatting for us, but the code below
+    // needs additional arguments which are not currently available in ImPlotFormatter
+    if (axis.Locator == Locator_Time) {
+        ImPlotTimeUnit unit = axis.Vertical
+                            ? GetUnitForRange(axis.Range.Size() / (gp.CurrentPlot->PlotRect.GetHeight() / 100)) // TODO: magic value!
+                            : GetUnitForRange(axis.Range.Size() / (gp.CurrentPlot->PlotRect.GetWidth() / 100)); // TODO: magic value!
+        FormatDateTime(ImPlotTime::FromDouble(value), buff, size, GetDateTimeFmt(TimeFormatMouseCursor, unit));
+    }
+    else {
+        if (round)
+            value = RoundAxisValue(axis, value);
+        axis.Formatter(value, buff, size, axis.FormatterData);
+    }
+}
+
+void UpdateAxisColors(ImPlotAxis& axis) {
+    const ImVec4 col_grid = GetStyleColorVec4(ImPlotCol_AxisGrid);
+    axis.ColorMaj         = ImGui::GetColorU32(col_grid);
+    axis.ColorMin         = ImGui::GetColorU32(col_grid*ImVec4(1,1,1,GImPlot->Style.MinorAlpha));
+    axis.ColorTick        = GetStyleColorU32(ImPlotCol_AxisTick);
+    axis.ColorTxt         = GetStyleColorU32(ImPlotCol_AxisText);
+    axis.ColorBg          = GetStyleColorU32(ImPlotCol_AxisBg);
+    axis.ColorHov         = GetStyleColorU32(ImPlotCol_AxisBgHovered);
+    axis.ColorAct         = GetStyleColorU32(ImPlotCol_AxisBgActive);
+    // axis.ColorHiLi     = IM_COL32_BLACK_TRANS;
+}
+
+void PadAndDatumAxesX(ImPlotPlot& plot, float& pad_T, float& pad_B, ImPlotAlignmentData* align) {
+
+    ImPlotContext& gp = *GImPlot;
+
+    const float T = ImGui::GetTextLineHeight();
+    const float P = gp.Style.LabelPadding.y;
+    const float K = gp.Style.MinorTickLen.x;
+
+    int   count_T = 0;
+    int   count_B = 0;
+    float last_T  = plot.AxesRect.Min.y;
+    float last_B  = plot.AxesRect.Max.y;
+
+    for (int i = IMPLOT_NUM_X_AXES; i-- > 0;) { // FYI: can iterate forward
+        ImPlotAxis& axis = plot.XAxis(i);
+        if (!axis.Enabled)
+            continue;
+        const bool label = axis.HasLabel();
+        const bool ticks = axis.HasTickLabels();
+        const bool opp   = axis.IsOpposite();
+        const bool time  = axis.Scale == ImPlotScale_Time;
+        if (opp) {
+            if (count_T++ > 0)
+                pad_T += K + P;
+            if (label)
+                pad_T += T + P;
+            if (ticks)
+                pad_T += ImMax(T, axis.Ticker.MaxSize.y) + P + (time ? T + P : 0);
+            axis.Datum1 = plot.CanvasRect.Min.y + pad_T;
+            axis.Datum2 = last_T;
+            last_T = axis.Datum1;
+        }
+        else {
+            if (count_B++ > 0)
+                pad_B += K + P;
+            if (label)
+                pad_B += T + P;
+            if (ticks)
+                pad_B += ImMax(T, axis.Ticker.MaxSize.y) + P + (time ? T + P : 0);
+            axis.Datum1 = plot.CanvasRect.Max.y - pad_B;
+            axis.Datum2 = last_B;
+            last_B = axis.Datum1;
+        }
+    }
+
+    if (align) {
+        count_T = count_B = 0;
+        float delta_T, delta_B;
+        align->Update(pad_T,pad_B,delta_T,delta_B);
+        for (int i = IMPLOT_NUM_X_AXES; i-- > 0;) {
+            ImPlotAxis& axis = plot.XAxis(i);
+            if (!axis.Enabled)
+                continue;
+            if (axis.IsOpposite()) {
+                axis.Datum1 += delta_T;
+                axis.Datum2 += count_T++ > 1 ? delta_T : 0;
+            }
+            else {
+                axis.Datum1 -= delta_B;
+                axis.Datum2 -= count_B++ > 1 ? delta_B : 0;
+            }
+        }
+    }
+}
+
+void PadAndDatumAxesY(ImPlotPlot& plot, float& pad_L, float& pad_R, ImPlotAlignmentData* align) {
+
+    //   [   pad_L   ]                 [   pad_R   ]
+    //   .................CanvasRect................
+    //   :TPWPK.PTPWP _____PlotRect____ PWPTP.KPWPT:
+    //   :A # |- A # |-               -| # A -| # A:
+    //   :X   |  X   |                 |   X  |   x:
+    //   :I # |- I # |-               -| # I -| # I:
+    //   :S   |  S   |                 |   S  |   S:
+    //   :3 # |- 0 # |-_______________-| # 1 -| # 2:
+    //   :.........................................:
+    //
+    //   T = text height
+    //   P = label padding
+    //   K = minor tick length
+    //   W = label width
+
+    ImPlotContext& gp = *GImPlot;
+
+    const float T = ImGui::GetTextLineHeight();
+    const float P = gp.Style.LabelPadding.x;
+    const float K = gp.Style.MinorTickLen.y;
+
+    int   count_L = 0;
+    int   count_R = 0;
+    float last_L  = plot.AxesRect.Min.x;
+    float last_R  = plot.AxesRect.Max.x;
+
+    for (int i = IMPLOT_NUM_Y_AXES; i-- > 0;) { // FYI: can iterate forward
+        ImPlotAxis& axis = plot.YAxis(i);
+        if (!axis.Enabled)
+            continue;
+        const bool label = axis.HasLabel();
+        const bool ticks = axis.HasTickLabels();
+        const bool opp   = axis.IsOpposite();
+        if (opp) {
+            if (count_R++ > 0)
+                pad_R += K + P;
+            if (label)
+                pad_R += T + P;
+            if (ticks)
+                pad_R += axis.Ticker.MaxSize.x + P;
+            axis.Datum1 = plot.CanvasRect.Max.x - pad_R;
+            axis.Datum2 = last_R;
+            last_R = axis.Datum1;
+        }
+        else {
+            if (count_L++ > 0)
+                pad_L += K + P;
+            if (label)
+                pad_L += T + P;
+            if (ticks)
+                pad_L += axis.Ticker.MaxSize.x + P;
+            axis.Datum1 = plot.CanvasRect.Min.x + pad_L;
+            axis.Datum2 = last_L;
+            last_L = axis.Datum1;
+        }
+    }
+
+    plot.PlotRect.Min.x = plot.CanvasRect.Min.x + pad_L;
+    plot.PlotRect.Max.x = plot.CanvasRect.Max.x - pad_R;
+
+    if (align) {
+        count_L = count_R = 0;
+        float delta_L, delta_R;
+        align->Update(pad_L,pad_R,delta_L,delta_R);
+        for (int i = IMPLOT_NUM_Y_AXES; i-- > 0;) {
+            ImPlotAxis& axis = plot.YAxis(i);
+            if (!axis.Enabled)
+                continue;
+            if (axis.IsOpposite()) {
+                axis.Datum1 -= delta_R;
+                axis.Datum2 -= count_R++ > 1 ? delta_R : 0;
+            }
+            else {
+                axis.Datum1 += delta_L;
+                axis.Datum2 += count_L++ > 1 ? delta_L : 0;
+            }
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// RENDERING
+//-----------------------------------------------------------------------------
+
+static inline void RenderGridLinesX(ImDrawList& DrawList, const ImPlotTicker& ticker, const ImRect& rect, ImU32 col_maj, ImU32 col_min, float size_maj, float size_min) {
+    const float density   = ticker.TickCount() / rect.GetWidth();
+    ImVec4 col_min4  = ImGui::ColorConvertU32ToFloat4(col_min);
+    col_min4.w      *= ImClamp(ImRemap(density, 0.1f, 0.2f, 1.0f, 0.0f), 0.0f, 1.0f);
+    col_min = ImGui::ColorConvertFloat4ToU32(col_min4);
+    for (int t = 0; t < ticker.TickCount(); t++) {
+        const ImPlotTick& xt = ticker.Ticks[t];
+        if (xt.PixelPos < rect.Min.x || xt.PixelPos > rect.Max.x)
+            continue;
+        if (xt.Level == 0) {
+            if (xt.Major)
+                DrawList.AddLine(ImVec2(xt.PixelPos, rect.Min.y), ImVec2(xt.PixelPos, rect.Max.y), col_maj, size_maj);
+            else if (density < 0.2f)
+                DrawList.AddLine(ImVec2(xt.PixelPos, rect.Min.y), ImVec2(xt.PixelPos, rect.Max.y), col_min, size_min);
+        }
+    }
+}
+
+static inline void RenderGridLinesY(ImDrawList& DrawList, const ImPlotTicker& ticker, const ImRect& rect, ImU32 col_maj, ImU32 col_min, float size_maj, float size_min) {
+    const float density   = ticker.TickCount() / rect.GetHeight();
+    ImVec4 col_min4  = ImGui::ColorConvertU32ToFloat4(col_min);
+    col_min4.w      *= ImClamp(ImRemap(density, 0.1f, 0.2f, 1.0f, 0.0f), 0.0f, 1.0f);
+    col_min = ImGui::ColorConvertFloat4ToU32(col_min4);
+    for (int t = 0; t < ticker.TickCount(); t++) {
+        const ImPlotTick& yt = ticker.Ticks[t];
+        if (yt.PixelPos < rect.Min.y || yt.PixelPos > rect.Max.y)
+            continue;
+        if (yt.Major)
+            DrawList.AddLine(ImVec2(rect.Min.x, yt.PixelPos), ImVec2(rect.Max.x, yt.PixelPos), col_maj, size_maj);
+        else if (density < 0.2f)
+            DrawList.AddLine(ImVec2(rect.Min.x, yt.PixelPos), ImVec2(rect.Max.x, yt.PixelPos), col_min, size_min);
+    }
+}
+
+static inline void RenderSelectionRect(ImDrawList& DrawList, const ImVec2& p_min, const ImVec2& p_max, const ImVec4& col) {
+    const ImU32 col_bg = ImGui::GetColorU32(col * ImVec4(1,1,1,0.25f));
+    const ImU32 col_bd = ImGui::GetColorU32(col);
+    DrawList.AddRectFilled(p_min, p_max, col_bg);
+    DrawList.AddRect(p_min, p_max, col_bd);
+}
+
+//-----------------------------------------------------------------------------
+// Input Handling
+//-----------------------------------------------------------------------------
+
+static const float MOUSE_CURSOR_DRAG_THRESHOLD = 5.0f;
+static const float BOX_SELECT_DRAG_THRESHOLD   = 4.0f;
+
+bool UpdateInput(ImPlotPlot& plot) {
+
+    bool changed = false;
+
+    ImPlotContext& gp = *GImPlot;
+    ImGuiIO& IO = ImGui::GetIO();
+
+    // BUTTON STATE -----------------------------------------------------------
+
+    const ImGuiButtonFlags plot_button_flags = ImGuiButtonFlags_AllowItemOverlap
+                                             | ImGuiButtonFlags_PressedOnClick
+                                             | ImGuiButtonFlags_PressedOnDoubleClick
+                                             | ImGuiButtonFlags_MouseButtonLeft
+                                             | ImGuiButtonFlags_MouseButtonRight
+                                             | ImGuiButtonFlags_MouseButtonMiddle;
+    const ImGuiButtonFlags axis_button_flags = ImGuiButtonFlags_FlattenChildren
+                                             | plot_button_flags;
+
+    const bool plot_clicked = ImGui::ButtonBehavior(plot.PlotRect,plot.ID,&plot.Hovered,&plot.Held,plot_button_flags);
+    ImGui::SetItemAllowOverlap();
+
+    if (plot_clicked) {
+        if (!ImHasFlag(plot.Flags, ImPlotFlags_NoBoxSelect) && IO.MouseClicked[gp.InputMap.Select] && ImHasFlag(IO.KeyMods, gp.InputMap.SelectMod)) {
+            plot.Selecting   = true;
+            plot.SelectStart = IO.MousePos;
+            plot.SelectRect  = ImRect(0,0,0,0);
+        }
+        if (IO.MouseDoubleClicked[gp.InputMap.Fit]) {
+            plot.FitThisFrame = true;
+            for (int i = 0; i < ImAxis_COUNT; ++i)
+                plot.Axes[i].FitThisFrame = true;
+        }
+    }
+
+    const bool can_pan = IO.MouseDown[gp.InputMap.Pan] && ImHasFlag(IO.KeyMods, gp.InputMap.PanMod);
+
+    plot.Held = plot.Held && can_pan;
+
+    bool x_click[IMPLOT_NUM_X_AXES] = {false};
+    bool x_held[IMPLOT_NUM_X_AXES]  = {false};
+    bool x_hov[IMPLOT_NUM_X_AXES]   = {false};
+
+    bool y_click[IMPLOT_NUM_Y_AXES] = {false};
+    bool y_held[IMPLOT_NUM_Y_AXES]  = {false};
+    bool y_hov[IMPLOT_NUM_Y_AXES]   = {false};
+
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i) {
+        ImPlotAxis& xax = plot.XAxis(i);
+        if (xax.Enabled) {
+            ImGui::KeepAliveID(xax.ID);
+            x_click[i]  = ImGui::ButtonBehavior(xax.HoverRect,xax.ID,&xax.Hovered,&xax.Held,axis_button_flags);
+            if (x_click[i] && IO.MouseDoubleClicked[gp.InputMap.Fit])
+                plot.FitThisFrame = xax.FitThisFrame = true;
+            xax.Held  = xax.Held && can_pan;
+            x_hov[i]  = xax.Hovered || plot.Hovered;
+            x_held[i] = xax.Held    || plot.Held;
+        }
+    }
+
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; ++i) {
+        ImPlotAxis& yax = plot.YAxis(i);
+        if (yax.Enabled) {
+            ImGui::KeepAliveID(yax.ID);
+            y_click[i]  = ImGui::ButtonBehavior(yax.HoverRect,yax.ID,&yax.Hovered,&yax.Held,axis_button_flags);
+            if (y_click[i] && IO.MouseDoubleClicked[gp.InputMap.Fit])
+                plot.FitThisFrame = yax.FitThisFrame = true;
+            yax.Held  = yax.Held && can_pan;
+            y_hov[i]  = yax.Hovered || plot.Hovered;
+            y_held[i] = yax.Held    || plot.Held;
+        }
+    }
+
+    // cancel due to DND activity
+    if (GImGui->DragDropActive || (IO.KeyMods == gp.InputMap.OverrideMod && gp.InputMap.OverrideMod != 0))
+        return false;
+
+    // STATE -------------------------------------------------------------------
+
+    const bool axis_equal      = ImHasFlag(plot.Flags, ImPlotFlags_Equal);
+
+    const bool any_x_hov       = plot.Hovered || AnyAxesHovered(&plot.Axes[ImAxis_X1], IMPLOT_NUM_X_AXES);
+    const bool any_x_held      = plot.Held    || AnyAxesHeld(&plot.Axes[ImAxis_X1], IMPLOT_NUM_X_AXES);
+    const bool any_y_hov       = plot.Hovered || AnyAxesHovered(&plot.Axes[ImAxis_Y1], IMPLOT_NUM_Y_AXES);
+    const bool any_y_held      = plot.Held    || AnyAxesHeld(&plot.Axes[ImAxis_Y1], IMPLOT_NUM_Y_AXES);
+    const bool any_hov         = any_x_hov    || any_y_hov;
+    const bool any_held        = any_x_held   || any_y_held;
+
+    const ImVec2 select_drag   = ImGui::GetMouseDragDelta(gp.InputMap.Select);
+    const ImVec2 pan_drag      = ImGui::GetMouseDragDelta(gp.InputMap.Pan);
+    const float select_drag_sq = ImLengthSqr(select_drag);
+    const float pan_drag_sq    = ImLengthSqr(pan_drag);
+    const bool selecting       = plot.Selecting && select_drag_sq > MOUSE_CURSOR_DRAG_THRESHOLD;
+    const bool panning         = any_held       && pan_drag_sq    > MOUSE_CURSOR_DRAG_THRESHOLD;
+
+    // CONTEXT MENU -----------------------------------------------------------
+
+    if (IO.MouseReleased[gp.InputMap.Menu] && !plot.ContextLocked)
+        gp.OpenContextThisFrame = true;
+
+    if (selecting || panning)
+        plot.ContextLocked = true;
+    else if (!(IO.MouseDown[gp.InputMap.Menu] || IO.MouseReleased[gp.InputMap.Menu]))
+        plot.ContextLocked = false;
+
+    // DRAG INPUT -------------------------------------------------------------
+
+    if (any_held && !plot.Selecting) {
+        int drag_direction = 0;
+        for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+            ImPlotAxis& x_axis = plot.XAxis(i);
+            if (x_held[i] && !x_axis.IsInputLocked()) {
+                drag_direction |= (1 << 1);
+                bool increasing = x_axis.IsInverted() ? IO.MouseDelta.x > 0 : IO.MouseDelta.x < 0;
+                if (IO.MouseDelta.x != 0 && !x_axis.IsPanLocked(increasing)) {
+                    const double plot_l = x_axis.PixelsToPlot(plot.PlotRect.Min.x - IO.MouseDelta.x);
+                    const double plot_r = x_axis.PixelsToPlot(plot.PlotRect.Max.x - IO.MouseDelta.x);
+                    x_axis.SetMin(x_axis.IsInverted() ? plot_r : plot_l);
+                    x_axis.SetMax(x_axis.IsInverted() ? plot_l : plot_r);
+                    if (axis_equal && x_axis.OrthoAxis != NULL)
+                        x_axis.OrthoAxis->SetAspect(x_axis.GetAspect());
+                    changed = true;
+                }
+            }
+        }
+        for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+            ImPlotAxis& y_axis = plot.YAxis(i);
+            if (y_held[i] && !y_axis.IsInputLocked()) {
+                drag_direction |= (1 << 2);
+                bool increasing = y_axis.IsInverted() ? IO.MouseDelta.y < 0 : IO.MouseDelta.y > 0;
+                if (IO.MouseDelta.y != 0 && !y_axis.IsPanLocked(increasing)) {
+                    const double plot_t = y_axis.PixelsToPlot(plot.PlotRect.Min.y - IO.MouseDelta.y);
+                    const double plot_b = y_axis.PixelsToPlot(plot.PlotRect.Max.y - IO.MouseDelta.y);
+                    y_axis.SetMin(y_axis.IsInverted() ? plot_t : plot_b);
+                    y_axis.SetMax(y_axis.IsInverted() ? plot_b : plot_t);
+                    if (axis_equal && y_axis.OrthoAxis != NULL)
+                        y_axis.OrthoAxis->SetAspect(y_axis.GetAspect());
+                    changed = true;
+                }
+            }
+        }
+        if (IO.MouseDragMaxDistanceSqr[gp.InputMap.Pan] > MOUSE_CURSOR_DRAG_THRESHOLD) {
+            switch (drag_direction) {
+                case 0        : ImGui::SetMouseCursor(ImGuiMouseCursor_NotAllowed); break;
+                case (1 << 1) : ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);   break;
+                case (1 << 2) : ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);   break;
+                default       : ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);  break;
+            }
+        }
+    }
+
+    // SCROLL INPUT -----------------------------------------------------------
+
+    if (any_hov && IO.MouseWheel != 0 && ImHasFlag(IO.KeyMods, gp.InputMap.ZoomMod)) {
+
+        float zoom_rate = gp.InputMap.ZoomRate;
+        if (IO.MouseWheel > 0)
+            zoom_rate = (-zoom_rate) / (1.0f + (2.0f * zoom_rate));
+        ImVec2 rect_size = plot.PlotRect.GetSize();
+        float tx = ImRemap(IO.MousePos.x, plot.PlotRect.Min.x, plot.PlotRect.Max.x, 0.0f, 1.0f);
+        float ty = ImRemap(IO.MousePos.y, plot.PlotRect.Min.y, plot.PlotRect.Max.y, 0.0f, 1.0f);
+
+        for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+            ImPlotAxis& x_axis = plot.XAxis(i);
+            const bool equal_zoom   = axis_equal && x_axis.OrthoAxis != NULL;
+            const bool equal_locked = (equal_zoom != false) && x_axis.OrthoAxis->IsInputLocked();
+            if (x_hov[i] && !x_axis.IsInputLocked() && !equal_locked) {
+                float correction = (plot.Hovered && equal_zoom) ? 0.5f : 1.0f;
+                const double plot_l = x_axis.PixelsToPlot(plot.PlotRect.Min.x - rect_size.x * tx * zoom_rate * correction);
+                const double plot_r = x_axis.PixelsToPlot(plot.PlotRect.Max.x + rect_size.x * (1 - tx) * zoom_rate * correction);
+                x_axis.SetMin(x_axis.IsInverted() ? plot_r : plot_l);
+                x_axis.SetMax(x_axis.IsInverted() ? plot_l : plot_r);
+                if (axis_equal && x_axis.OrthoAxis != NULL)
+                    x_axis.OrthoAxis->SetAspect(x_axis.GetAspect());
+                changed = true;
+            }
+        }
+        for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+            ImPlotAxis& y_axis = plot.YAxis(i);
+            const bool equal_zoom   = axis_equal && y_axis.OrthoAxis != NULL;
+            const bool equal_locked = equal_zoom && y_axis.OrthoAxis->IsInputLocked();
+            if (y_hov[i] && !y_axis.IsInputLocked() && !equal_locked) {
+                float correction = (plot.Hovered && equal_zoom) ? 0.5f : 1.0f;
+                const double plot_t = y_axis.PixelsToPlot(plot.PlotRect.Min.y - rect_size.y * ty * zoom_rate * correction);
+                const double plot_b = y_axis.PixelsToPlot(plot.PlotRect.Max.y + rect_size.y * (1 - ty) * zoom_rate * correction);
+                y_axis.SetMin(y_axis.IsInverted() ? plot_t : plot_b);
+                y_axis.SetMax(y_axis.IsInverted() ? plot_b : plot_t);
+                if (axis_equal && y_axis.OrthoAxis != NULL)
+                    y_axis.OrthoAxis->SetAspect(y_axis.GetAspect());
+                changed = true;
+            }
+        }
+    }
+
+    // BOX-SELECTION ----------------------------------------------------------
+
+    if (plot.Selecting) {
+        const ImVec2 d = plot.SelectStart - IO.MousePos;
+        const bool x_can_change = !ImHasFlag(IO.KeyMods,gp.InputMap.SelectHorzMod) && ImFabs(d.x) > 2;
+        const bool y_can_change = !ImHasFlag(IO.KeyMods,gp.InputMap.SelectVertMod) && ImFabs(d.y) > 2;
+        // confirm
+        if (IO.MouseReleased[gp.InputMap.Select]) {
+            for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+                ImPlotAxis& x_axis = plot.XAxis(i);
+                if (!x_axis.IsInputLocked() && x_can_change) {
+                    const double p1 = x_axis.PixelsToPlot(plot.SelectStart.x);
+                    const double p2 = x_axis.PixelsToPlot(IO.MousePos.x);
+                    x_axis.SetMin(ImMin(p1, p2));
+                    x_axis.SetMax(ImMax(p1, p2));
+                    changed = true;
+                }
+            }
+            for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+                ImPlotAxis& y_axis = plot.YAxis(i);
+                if (!y_axis.IsInputLocked() && y_can_change) {
+                    const double p1 = y_axis.PixelsToPlot(plot.SelectStart.y);
+                    const double p2 = y_axis.PixelsToPlot(IO.MousePos.y);
+                    y_axis.SetMin(ImMin(p1, p2));
+                    y_axis.SetMax(ImMax(p1, p2));
+                    changed = true;
+                }
+            }
+            if (x_can_change || y_can_change || (ImHasFlag(IO.KeyMods,gp.InputMap.SelectHorzMod) && ImHasFlag(IO.KeyMods,gp.InputMap.SelectVertMod)))
+                gp.OpenContextThisFrame = false;
+            plot.Selected = plot.Selecting = false;
+        }
+        // cancel
+        else if (IO.MouseReleased[gp.InputMap.SelectCancel]) {
+            plot.Selected = plot.Selecting = false;
+            gp.OpenContextThisFrame = false;
+        }
+        else if (ImLengthSqr(d) > BOX_SELECT_DRAG_THRESHOLD) {
+            // bad selection
+            if (plot.IsInputLocked()) {
+                ImGui::SetMouseCursor(ImGuiMouseCursor_NotAllowed);
+                gp.OpenContextThisFrame = false;
+                plot.Selected      = false;
+            }
+            else {
+                // TODO: Handle only min or max locked cases
+                const bool full_width  = ImHasFlag(IO.KeyMods, gp.InputMap.SelectHorzMod) || AllAxesInputLocked(&plot.Axes[ImAxis_X1], IMPLOT_NUM_X_AXES);
+                const bool full_height = ImHasFlag(IO.KeyMods, gp.InputMap.SelectVertMod) || AllAxesInputLocked(&plot.Axes[ImAxis_Y1], IMPLOT_NUM_Y_AXES);
+                plot.SelectRect.Min.x = full_width  ? plot.PlotRect.Min.x : ImMin(plot.SelectStart.x, IO.MousePos.x);
+                plot.SelectRect.Max.x = full_width  ? plot.PlotRect.Max.x : ImMax(plot.SelectStart.x, IO.MousePos.x);
+                plot.SelectRect.Min.y = full_height ? plot.PlotRect.Min.y : ImMin(plot.SelectStart.y, IO.MousePos.y);
+                plot.SelectRect.Max.y = full_height ? plot.PlotRect.Max.y : ImMax(plot.SelectStart.y, IO.MousePos.y);
+                plot.SelectRect.Min  -= plot.PlotRect.Min;
+                plot.SelectRect.Max  -= plot.PlotRect.Min;
+                plot.Selected = true;
+            }
+        }
+        else {
+            plot.Selected = false;
+        }
+    }
+    return changed;
+}
+
+//-----------------------------------------------------------------------------
+// Next Plot Data (Legacy)
+//-----------------------------------------------------------------------------
+
+void ApplyNextPlotData(ImAxis idx) {
+    ImPlotContext& gp = *GImPlot;
+    ImPlotPlot& plot  = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis  = plot.Axes[idx];
+    if (!axis.Enabled)
+        return;
+    double*     npd_lmin = gp.NextPlotData.LinkedMin[idx];
+    double*     npd_lmax = gp.NextPlotData.LinkedMax[idx];
+    bool        npd_rngh = gp.NextPlotData.HasRange[idx];
+    ImPlotCond  npd_rngc = gp.NextPlotData.RangeCond[idx];
+    ImPlotRange     npd_rngv = gp.NextPlotData.Range[idx];
+    axis.LinkedMin = npd_lmin;
+    axis.LinkedMax = npd_lmax;
+    axis.PullLinks();
+    if (npd_rngh) {
+        if (!plot.Initialized || npd_rngc == ImPlotCond_Always)
+            axis.SetRange(npd_rngv);
+    }
+    axis.HasRange         = npd_rngh;
+    axis.RangeCond        = npd_rngc;
+}
+
+//-----------------------------------------------------------------------------
+// Setup
+//-----------------------------------------------------------------------------
+
+void SetupAxis(ImAxis idx, const char* label, ImPlotAxisFlags flags) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    // get plot and axis
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    // set ID
+    axis.ID = plot.ID + idx + 1;
+    // check and set flags
+    if (plot.JustCreated || flags != axis.PreviousFlags)
+        axis.Flags = flags;
+    axis.PreviousFlags = flags;
+    // enable axis
+    axis.Enabled = true;
+    // set label
+    plot.SetAxisLabel(axis,label);
+    // cache colors
+    UpdateAxisColors(axis);
+}
+
+void SetupAxisLimits(ImAxis idx, double min_lim, double max_lim, ImPlotCond cond) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");    // get plot and axis
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    if (!plot.Initialized || cond == ImPlotCond_Always)
+        axis.SetRange(min_lim, max_lim);
+    axis.HasRange  = true;
+    axis.RangeCond = cond;
+}
+
+void SetupAxisFormat(ImAxis idx, const char* fmt) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    axis.HasFormatSpec = fmt != NULL;
+    if (fmt != NULL)
+        ImStrncpy(axis.FormatSpec,fmt,sizeof(axis.FormatSpec));
+}
+
+void SetupAxisLinks(ImAxis idx, double* min_lnk, double* max_lnk) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    axis.LinkedMin = min_lnk;
+    axis.LinkedMax = max_lnk;
+    axis.PullLinks();
+}
+
+void SetupAxisFormat(ImAxis idx, ImPlotFormatter formatter, void* data) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    axis.Formatter = formatter;
+    axis.FormatterData = data;
+}
+
+void SetupAxisTicks(ImAxis idx, const double* values, int n_ticks, const char* const labels[], bool show_default) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                        "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    axis.ShowDefaultTicks = show_default;
+    AddTicksCustom(values,
+                  labels,
+                  n_ticks,
+                  axis.Ticker,
+                  axis.Formatter ? axis.Formatter : Formatter_Default,
+                  (axis.Formatter && axis.FormatterData) ? axis.FormatterData : axis.HasFormatSpec ? axis.FormatSpec : (void*)IMPLOT_LABEL_FORMAT);
+}
+
+void SetupAxisTicks(ImAxis idx, double v_min, double v_max, int n_ticks, const char* const labels[], bool show_default) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    n_ticks = n_ticks < 2 ? 2 : n_ticks;
+    FillRange(GImPlot->TempDouble1, n_ticks, v_min, v_max);
+    SetupAxisTicks(idx, GImPlot->TempDouble1.Data, n_ticks, labels, show_default);
+}
+
+void SetupAxisScale(ImAxis idx, ImPlotScale scale) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                        "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    axis.Scale = scale;
+    switch (scale)
+    {
+    case ImPlotScale_Time:
+        axis.TransformForward = NULL;
+        axis.TransformInverse = NULL;
+        axis.TransformData    = NULL;
+        axis.Locator          = Locator_Time;
+        axis.ConstraintRange  = ImPlotRange(IMPLOT_MIN_TIME, IMPLOT_MAX_TIME);
+        axis.Ticker.Levels    = 2;
+        break;
+    case ImPlotScale_Log10:
+        axis.TransformForward = TransformForward_Log10;
+        axis.TransformInverse = TransformInverse_Log10;
+        axis.TransformData    = NULL;
+        axis.Locator          = Locator_Log10;
+        axis.ConstraintRange  = ImPlotRange(DBL_MIN, INFINITY);
+        break;
+    case ImPlotScale_SymLog:
+        axis.TransformForward = TransformForward_SymLog;
+        axis.TransformInverse = TransformInverse_SymLog;
+        axis.TransformData    = NULL;
+        axis.Locator          = Locator_SymLog;
+        axis.ConstraintRange  = ImPlotRange(-INFINITY, INFINITY);
+        break;
+    default:
+        axis.TransformForward = NULL;
+        axis.TransformInverse = NULL;
+        axis.TransformData    = NULL;
+        axis.Locator          = NULL;
+        axis.ConstraintRange  = ImPlotRange(-INFINITY, INFINITY);
+        break;
+    }
+}
+
+void SetupAxisScale(ImAxis idx, ImPlotTransform fwd, ImPlotTransform inv, void* data) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                        "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    axis.Scale = IMPLOT_AUTO;
+    axis.TransformForward = fwd;
+    axis.TransformInverse = inv;
+    axis.TransformData = data;
+}
+
+void SetupAxisLimitsConstraints(ImAxis idx, double v_min, double v_max) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                        "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    axis.ConstraintRange.Min = v_min;
+    axis.ConstraintRange.Max = v_max;
+}
+
+void SetupAxisZoomConstraints(ImAxis idx, double z_min, double z_max) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                        "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& axis = plot.Axes[idx];
+    IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    axis.ConstraintZoom.Min = z_min;
+    axis.ConstraintZoom.Max = z_max;
+}
+
+void SetupAxes(const char* x_label, const char* y_label, ImPlotAxisFlags x_flags, ImPlotAxisFlags y_flags) {
+    SetupAxis(ImAxis_X1, x_label, x_flags);
+    SetupAxis(ImAxis_Y1, y_label, y_flags);
+}
+
+void SetupAxesLimits(double x_min, double x_max, double y_min, double y_max, ImPlotCond cond) {
+    SetupAxisLimits(ImAxis_X1, x_min, x_max, cond);
+    SetupAxisLimits(ImAxis_Y1, y_min, y_max, cond);
+}
+
+void SetupLegend(ImPlotLocation location, ImPlotLegendFlags flags) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentItems != NULL,
+                         "SetupLegend() needs to be called within an itemized context!");
+    ImPlotLegend& legend = GImPlot->CurrentItems->Legend;
+    // check and set location
+    if (location != legend.PreviousLocation)
+        legend.Location = location;
+    legend.PreviousLocation = location;
+    // check and set flags
+    if (flags != legend.PreviousFlags)
+        legend.Flags = flags;
+    legend.PreviousFlags = flags;
+}
+
+void SetupMouseText(ImPlotLocation location, ImPlotMouseTextFlags flags) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    GImPlot->CurrentPlot->MouseTextLocation = location;
+    GImPlot->CurrentPlot->MouseTextFlags = flags;
+}
+
+//-----------------------------------------------------------------------------
+// SetNext
+//-----------------------------------------------------------------------------
+
+void SetNextAxisLimits(ImAxis axis, double v_min, double v_max, ImPlotCond cond) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot == NULL, "SetNextAxisLimits() needs to be called before BeginPlot()!");
+    IM_ASSERT(cond == 0 || ImIsPowerOfTwo(cond)); // Make sure the user doesn't attempt to combine multiple condition flags.
+    gp.NextPlotData.HasRange[axis]  = true;
+    gp.NextPlotData.RangeCond[axis] = cond;
+    gp.NextPlotData.Range[axis].Min = v_min;
+    gp.NextPlotData.Range[axis].Max = v_max;
+}
+
+void SetNextAxisLinks(ImAxis axis, double* link_min, double* link_max) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot == NULL, "SetNextAxisLinks() needs to be called before BeginPlot()!");
+    gp.NextPlotData.LinkedMin[axis] = link_min;
+    gp.NextPlotData.LinkedMax[axis] = link_max;
+}
+
+void SetNextAxisToFit(ImAxis axis) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot == NULL, "SetNextAxisToFit() needs to be called before BeginPlot()!");
+    gp.NextPlotData.Fit[axis] = true;
+}
+
+void SetNextAxesLimits(double x_min, double x_max, double y_min, double y_max, ImPlotCond cond) {
+    SetNextAxisLimits(ImAxis_X1, x_min, x_max, cond);
+    SetNextAxisLimits(ImAxis_Y1, y_min, y_max, cond);
+}
+
+void SetNextAxesToFit() {
+    for (int i = 0; i < ImAxis_COUNT; ++i)
+        SetNextAxisToFit(i);
+}
+
+//-----------------------------------------------------------------------------
+// BeginPlot
+//-----------------------------------------------------------------------------
+
+bool BeginPlot(const char* title_id, const ImVec2& size, ImPlotFlags flags) {
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot == NULL, "Mismatched BeginPlot()/EndPlot()!");
+
+    // FRONT MATTER -----------------------------------------------------------
+
+    if (GImPlot->CurrentSubplot != NULL)
+        ImGui::PushID(GImPlot->CurrentSubplot->CurrentIdx);
+
+    // get globals
+    ImPlotContext& gp        = *GImPlot;
+    ImGuiContext &G          = *GImGui;
+    ImGuiWindow* Window      = G.CurrentWindow;
+
+    // skip if needed
+    if (Window->SkipItems && !gp.CurrentSubplot) {
+        ResetCtxForNextPlot(GImPlot);
+        return false;
+    }
+
+    // ID and age (TODO: keep track of plot age in frames)
+    const ImGuiID ID         = Window->GetID(title_id);
+    const bool just_created  = gp.Plots.GetByKey(ID) == NULL;
+    gp.CurrentPlot           = gp.Plots.GetOrAddByKey(ID);
+
+    ImPlotPlot &plot         = *gp.CurrentPlot;
+    plot.ID                  = ID;
+    plot.Items.ID            = ID - 1;
+    plot.JustCreated         = just_created;
+    plot.SetupLocked         = false;
+
+    // check flags
+    if (plot.JustCreated)
+        plot.Flags = flags;
+    else if (flags != plot.PreviousFlags)
+        plot.Flags = flags;
+    plot.PreviousFlags = flags;
+
+    // setup default axes
+    if (plot.JustCreated) {
+        SetupAxis(ImAxis_X1);
+        SetupAxis(ImAxis_Y1);
+    }
+
+    // reset axes
+    for (int i = 0; i < ImAxis_COUNT; ++i) {
+        plot.Axes[i].Reset();
+        UpdateAxisColors(plot.Axes[i]);
+    }
+    // ensure first axes enabled
+    plot.Axes[ImAxis_X1].Enabled = true;
+    plot.Axes[ImAxis_Y1].Enabled = true;
+    // set initial axes
+    plot.CurrentX = ImAxis_X1;
+    plot.CurrentY = ImAxis_Y1;
+
+    // process next plot data (legacy)
+    for (int i = 0; i < ImAxis_COUNT; ++i)
+        ApplyNextPlotData(i);
+
+    // capture scroll with a child region
+    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoChild)) {
+        ImVec2 child_size;
+        if (gp.CurrentSubplot != NULL)
+            child_size = gp.CurrentSubplot->CellSize;
+        else
+            child_size = ImVec2(size.x == 0 ? gp.Style.PlotDefaultSize.x : size.x, size.y == 0 ? gp.Style.PlotDefaultSize.y : size.y);
+        ImGui::BeginChild(title_id, child_size, false, ImGuiWindowFlags_NoScrollbar);
+        Window = ImGui::GetCurrentWindow();
+        Window->ScrollMax.y = 1.0f;
+        gp.ChildWindowMade = true;
+    }
+    else {
+        gp.ChildWindowMade = false;
+    }
+
+    // clear text buffers
+    plot.ClearTextBuffer();
+    plot.SetTitle(title_id);
+
+    // set frame size
+    ImVec2 frame_size;
+    if (gp.CurrentSubplot != NULL)
+        frame_size = gp.CurrentSubplot->CellSize;
+    else
+        frame_size = ImGui::CalcItemSize(size, gp.Style.PlotDefaultSize.x, gp.Style.PlotDefaultSize.y);
+
+    if (frame_size.x < gp.Style.PlotMinSize.x && (size.x < 0.0f || gp.CurrentSubplot != NULL))
+        frame_size.x = gp.Style.PlotMinSize.x;
+    if (frame_size.y < gp.Style.PlotMinSize.y && (size.y < 0.0f || gp.CurrentSubplot != NULL))
+        frame_size.y = gp.Style.PlotMinSize.y;
+
+    plot.FrameRect = ImRect(Window->DC.CursorPos, Window->DC.CursorPos + frame_size);
+    ImGui::ItemSize(plot.FrameRect);
+    if (!ImGui::ItemAdd(plot.FrameRect, plot.ID, &plot.FrameRect) && !gp.CurrentSubplot) {
+        ResetCtxForNextPlot(GImPlot);
+        return false;
+    }
+
+    // setup items (or dont)
+    if (gp.CurrentItems == NULL)
+        gp.CurrentItems = &plot.Items;
+
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+// SetupFinish
+//-----------------------------------------------------------------------------
+
+void SetupFinish() {
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "SetupFinish needs to be called after BeginPlot!");
+
+    ImPlotContext& gp       = *GImPlot;
+    ImGuiContext& G         = *GImGui;
+    ImDrawList& DrawList    = *G.CurrentWindow->DrawList;
+    const ImGuiStyle& Style = G.Style;
+
+    ImPlotPlot &plot  = *gp.CurrentPlot;
+
+    // lock setup
+    plot.SetupLocked = true;
+
+    // finalize axes and set default formatter/locator
+    for (int i = 0; i < ImAxis_COUNT; ++i) {
+        ImPlotAxis& axis = plot.Axes[i];
+        if (axis.Enabled) {
+            axis.Constrain();
+            if (!plot.Initialized && axis.CanInitFit())
+                plot.FitThisFrame = axis.FitThisFrame = true;
+        }
+        if (axis.Formatter == NULL) {
+            axis.Formatter = Formatter_Default;
+            if (axis.HasFormatSpec)
+                axis.FormatterData = axis.FormatSpec;
+            else
+                axis.FormatterData = (void*)IMPLOT_LABEL_FORMAT;
+        }
+        if (axis.Locator == NULL) {
+            axis.Locator = Locator_Default;
+        }
+    }
+
+    // setup NULL orthogonal axes
+    const bool axis_equal = ImHasFlag(plot.Flags, ImPlotFlags_Equal);
+    for (int ix = ImAxis_X1, iy = ImAxis_Y1; ix < ImAxis_Y1 || iy < ImAxis_COUNT; ++ix, ++iy) {
+        ImPlotAxis& x_axis = plot.Axes[ix];
+        ImPlotAxis& y_axis = plot.Axes[iy];
+        if (x_axis.Enabled && y_axis.Enabled) {
+            if (x_axis.OrthoAxis == NULL)
+                x_axis.OrthoAxis = &y_axis;
+            if (y_axis.OrthoAxis == NULL)
+                y_axis.OrthoAxis = &x_axis;
+        }
+        else if (x_axis.Enabled)
+        {
+            if (x_axis.OrthoAxis == NULL && !axis_equal)
+                x_axis.OrthoAxis = &plot.Axes[ImAxis_Y1];
+        }
+        else if (y_axis.Enabled) {
+            if (y_axis.OrthoAxis == NULL && !axis_equal)
+                y_axis.OrthoAxis = &plot.Axes[ImAxis_X1];
+        }
+    }
+
+    // canvas/axes bb
+    plot.CanvasRect = ImRect(plot.FrameRect.Min + gp.Style.PlotPadding, plot.FrameRect.Max - gp.Style.PlotPadding);
+    plot.AxesRect   = plot.FrameRect;
+
+    // outside legend adjustments
+    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoLegend) && plot.Items.GetLegendCount() > 0 && ImHasFlag(plot.Items.Legend.Flags, ImPlotLegendFlags_Outside)) {
+        ImPlotLegend& legend = plot.Items.Legend;
+        const bool horz = ImHasFlag(legend.Flags, ImPlotLegendFlags_Horizontal);
+        const ImVec2 legend_size = CalcLegendSize(plot.Items, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !horz);
+        const bool west = ImHasFlag(legend.Location, ImPlotLocation_West) && !ImHasFlag(legend.Location, ImPlotLocation_East);
+        const bool east = ImHasFlag(legend.Location, ImPlotLocation_East) && !ImHasFlag(legend.Location, ImPlotLocation_West);
+        const bool north = ImHasFlag(legend.Location, ImPlotLocation_North) && !ImHasFlag(legend.Location, ImPlotLocation_South);
+        const bool south = ImHasFlag(legend.Location, ImPlotLocation_South) && !ImHasFlag(legend.Location, ImPlotLocation_North);
+        if ((west && !horz) || (west && horz && !north && !south)) {
+            plot.CanvasRect.Min.x += (legend_size.x + gp.Style.LegendPadding.x);
+            plot.AxesRect.Min.x   += (legend_size.x + gp.Style.PlotPadding.x);
+        }
+        if ((east && !horz) || (east && horz && !north && !south)) {
+            plot.CanvasRect.Max.x -= (legend_size.x + gp.Style.LegendPadding.x);
+            plot.AxesRect.Max.x   -= (legend_size.x + gp.Style.PlotPadding.x);
+        }
+        if ((north && horz) || (north && !horz && !west && !east)) {
+            plot.CanvasRect.Min.y += (legend_size.y + gp.Style.LegendPadding.y);
+            plot.AxesRect.Min.y   += (legend_size.y + gp.Style.PlotPadding.y);
+        }
+        if ((south && horz) || (south && !horz && !west && !east)) {
+            plot.CanvasRect.Max.y -= (legend_size.y + gp.Style.LegendPadding.y);
+            plot.AxesRect.Max.y   -= (legend_size.y + gp.Style.PlotPadding.y);
+        }
+    }
+
+    // plot bb
+    float pad_top = 0, pad_bot = 0, pad_left = 0, pad_right = 0;
+
+    // (0) calc top padding form title
+    ImVec2 title_size(0.0f, 0.0f);
+    if (plot.HasTitle())
+         title_size = ImGui::CalcTextSize(plot.GetTitle(), NULL, true);
+    if (title_size.x > 0) {
+        pad_top += title_size.y + gp.Style.LabelPadding.y;
+        plot.AxesRect.Min.y += gp.Style.PlotPadding.y + pad_top;
+    }
+
+    // (1) calc addition top padding and bot padding
+    PadAndDatumAxesX(plot,pad_top,pad_bot,gp.CurrentAlignmentH);
+
+    const float plot_height = plot.CanvasRect.GetHeight() - pad_top - pad_bot;
+
+    // (2) get y tick labels (needed for left/right pad)
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+        ImPlotAxis& axis = plot.YAxis(i);
+        if (axis.WillRender() && axis.ShowDefaultTicks) {
+            axis.Locator(axis.Ticker, axis.Range, plot_height, true, axis.Formatter, axis.FormatterData);
+        }
+    }
+
+    // (3) calc left/right pad
+    PadAndDatumAxesY(plot,pad_left,pad_right,gp.CurrentAlignmentV);
+
+    const float plot_width = plot.CanvasRect.GetWidth() - pad_left - pad_right;
+
+    // (4) get x ticks
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+        ImPlotAxis& axis = plot.XAxis(i);
+        if (axis.WillRender() && axis.ShowDefaultTicks) {
+            axis.Locator(axis.Ticker, axis.Range, plot_width, false, axis.Formatter, axis.FormatterData);
+        }
+    }
+
+    // (5) calc plot bb
+    plot.PlotRect = ImRect(plot.CanvasRect.Min + ImVec2(pad_left, pad_top), plot.CanvasRect.Max - ImVec2(pad_right, pad_bot));
+
+    // HOVER------------------------------------------------------------
+
+    // axes hover rect, pixel ranges
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i) {
+        ImPlotAxis& xax = plot.XAxis(i);
+        xax.HoverRect   = ImRect(ImVec2(plot.PlotRect.Min.x, ImMin(xax.Datum1,xax.Datum2)),
+                                 ImVec2(plot.PlotRect.Max.x, ImMax(xax.Datum1,xax.Datum2)));
+        xax.PixelMin    = xax.IsInverted() ? plot.PlotRect.Max.x : plot.PlotRect.Min.x;
+        xax.PixelMax    = xax.IsInverted() ? plot.PlotRect.Min.x : plot.PlotRect.Max.x;
+        xax.UpdateTransformCache();
+    }
+
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; ++i) {
+        ImPlotAxis& yax = plot.YAxis(i);
+        yax.HoverRect   = ImRect(ImVec2(ImMin(yax.Datum1,yax.Datum2),plot.PlotRect.Min.y),
+                                 ImVec2(ImMax(yax.Datum1,yax.Datum2),plot.PlotRect.Max.y));
+        yax.PixelMin    = yax.IsInverted() ? plot.PlotRect.Min.y : plot.PlotRect.Max.y;
+        yax.PixelMax    = yax.IsInverted() ? plot.PlotRect.Max.y : plot.PlotRect.Min.y;
+        yax.UpdateTransformCache();
+    }
+    // Equal axis constraint. Must happen after we set Pixels
+    // constrain equal axes for primary x and y if not approximately equal
+    // constrains x to y since x pixel size depends on y labels width, and causes feedback loops in opposite case
+    if (axis_equal) {
+        for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i) {
+            ImPlotAxis& x_axis = plot.XAxis(i);
+            if (x_axis.OrthoAxis == NULL)
+                continue;
+            double xar = x_axis.GetAspect();
+            double yar = x_axis.OrthoAxis->GetAspect();
+            // edge case: user has set x range this frame, so fit y to x so that we honor their request for x range
+            // NB: because of feedback across several frames, the user's x request may not be perfectly honored
+            if (x_axis.HasRange)
+                x_axis.OrthoAxis->SetAspect(xar);
+            else if (!ImAlmostEqual(xar,yar) && !x_axis.OrthoAxis->IsInputLocked())
+                 x_axis.SetAspect(yar);
+        }
+    }
+
+    // INPUT ------------------------------------------------------------------
+    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoInputs))
+        UpdateInput(plot);
+
+    // fit from FitNextPlotAxes or auto fit
+    for (int i = 0; i < ImAxis_COUNT; ++i) {
+        if (gp.NextPlotData.Fit[i] || plot.Axes[i].IsAutoFitting()) {
+            plot.FitThisFrame = true;
+            plot.Axes[i].FitThisFrame = true;
+        }
+    }
+
+    // RENDER -----------------------------------------------------------------
+
+    const float txt_height = ImGui::GetTextLineHeight();
+
+    // render frame
+    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoFrame))
+        ImGui::RenderFrame(plot.FrameRect.Min, plot.FrameRect.Max, GetStyleColorU32(ImPlotCol_FrameBg), true, Style.FrameRounding);
+
+    // grid bg
+    DrawList.AddRectFilled(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBg));
+
+    // transform ticks
+    for (int i = 0; i < ImAxis_COUNT; i++) {
+        ImPlotAxis& axis = plot.Axes[i];
+        if (axis.WillRender()) {
+            for (int t = 0; t < axis.Ticker.TickCount(); t++) {
+                ImPlotTick& tk = axis.Ticker.Ticks[t];
+                tk.PixelPos = IM_ROUND(axis.PlotToPixels(tk.PlotPos));
+            }
+        }
+    }
+
+    // render grid (background)
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+        ImPlotAxis& x_axis = plot.XAxis(i);
+        if (x_axis.Enabled && x_axis.HasGridLines() && !x_axis.IsForeground())
+            RenderGridLinesX(DrawList, x_axis.Ticker, plot.PlotRect, x_axis.ColorMaj, x_axis.ColorMin, gp.Style.MajorGridSize.x, gp.Style.MinorGridSize.x);
+    }
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+        ImPlotAxis& y_axis = plot.YAxis(i);
+        if (y_axis.Enabled && y_axis.HasGridLines() && !y_axis.IsForeground())
+            RenderGridLinesY(DrawList, y_axis.Ticker, plot.PlotRect,  y_axis.ColorMaj, y_axis.ColorMin, gp.Style.MajorGridSize.y, gp.Style.MinorGridSize.y);
+    }
+
+    // render x axis button, label, tick labels
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+        ImPlotAxis& ax = plot.XAxis(i);
+        if (!ax.Enabled)
+            continue;
+        if ((ax.Hovered || ax.Held) && !plot.Held && !ImHasFlag(ax.Flags, ImPlotAxisFlags_NoHighlight))
+            DrawList.AddRectFilled(ax.HoverRect.Min, ax.HoverRect.Max, ax.Held ? ax.ColorAct : ax.ColorHov);
+        else if (ax.ColorHiLi != IM_COL32_BLACK_TRANS) {
+            DrawList.AddRectFilled(ax.HoverRect.Min, ax.HoverRect.Max, ax.ColorHiLi);
+            ax.ColorHiLi = IM_COL32_BLACK_TRANS;
+        }
+        else if (ax.ColorBg != IM_COL32_BLACK_TRANS) {
+            DrawList.AddRectFilled(ax.HoverRect.Min, ax.HoverRect.Max, ax.ColorBg);
+        }
+        const ImPlotTicker& tkr = ax.Ticker;
+        const bool opp = ax.IsOpposite();
+        if (ax.HasLabel()) {
+            const char* label        = plot.GetAxisLabel(ax);
+            const ImVec2 label_size  = ImGui::CalcTextSize(label);
+            const float label_offset = (ax.HasTickLabels() ? tkr.MaxSize.y + gp.Style.LabelPadding.y : 0.0f)
+                                     + (tkr.Levels - 1) * (txt_height + gp.Style.LabelPadding.y)
+                                     + gp.Style.LabelPadding.y;
+            const ImVec2 label_pos(plot.PlotRect.GetCenter().x - label_size.x * 0.5f,
+                                   opp ? ax.Datum1 - label_offset - label_size.y : ax.Datum1 + label_offset);
+            DrawList.AddText(label_pos, ax.ColorTxt, label);
+        }
+        if (ax.HasTickLabels()) {
+            for (int j = 0; j < tkr.TickCount(); ++j) {
+                const ImPlotTick& tk = tkr.Ticks[j];
+                const float datum = ax.Datum1 + (opp ? (-gp.Style.LabelPadding.y -txt_height -tk.Level * (txt_height + gp.Style.LabelPadding.y))
+                                                     : gp.Style.LabelPadding.y + tk.Level * (txt_height + gp.Style.LabelPadding.y));
+                if (tk.ShowLabel && tk.PixelPos >= plot.PlotRect.Min.x - 1 && tk.PixelPos <= plot.PlotRect.Max.x + 1) {
+                    ImVec2 start(tk.PixelPos - 0.5f * tk.LabelSize.x, datum);
+                    DrawList.AddText(start, ax.ColorTxt, tkr.GetText(j));
+                }
+            }
+        }
+    }
+
+    // render y axis button, label, tick labels
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+        ImPlotAxis& ax = plot.YAxis(i);
+        if (!ax.Enabled)
+            continue;
+        if ((ax.Hovered || ax.Held) && !plot.Held && !ImHasFlag(ax.Flags, ImPlotAxisFlags_NoHighlight))
+            DrawList.AddRectFilled(ax.HoverRect.Min, ax.HoverRect.Max, ax.Held ? ax.ColorAct : ax.ColorHov);
+        else if (ax.ColorHiLi != IM_COL32_BLACK_TRANS) {
+            DrawList.AddRectFilled(ax.HoverRect.Min, ax.HoverRect.Max, ax.ColorHiLi);
+            ax.ColorHiLi = IM_COL32_BLACK_TRANS;
+        }
+        else if (ax.ColorBg != IM_COL32_BLACK_TRANS) {
+            DrawList.AddRectFilled(ax.HoverRect.Min, ax.HoverRect.Max, ax.ColorBg);
+        }
+        const ImPlotTicker& tkr = ax.Ticker;
+        const bool opp = ax.IsOpposite();
+        if (ax.HasLabel()) {
+            const char* label        = plot.GetAxisLabel(ax);
+            const ImVec2 label_size  = CalcTextSizeVertical(label);
+            const float label_offset = (ax.HasTickLabels() ? tkr.MaxSize.x + gp.Style.LabelPadding.x : 0.0f)
+                                     + gp.Style.LabelPadding.x;
+            const ImVec2 label_pos(opp ? ax.Datum1 + label_offset : ax.Datum1 - label_offset - label_size.x,
+                                   plot.PlotRect.GetCenter().y + label_size.y * 0.5f);
+            AddTextVertical(&DrawList, label_pos, ax.ColorTxt, label);
+        }
+        if (ax.HasTickLabels()) {
+            for (int j = 0; j < tkr.TickCount(); ++j) {
+                const ImPlotTick& tk = tkr.Ticks[j];
+                const float datum = ax.Datum1 + (opp ? gp.Style.LabelPadding.x : (-gp.Style.LabelPadding.x - tk.LabelSize.x));
+                if (tk.ShowLabel && tk.PixelPos >= plot.PlotRect.Min.y - 1 && tk.PixelPos <= plot.PlotRect.Max.y + 1) {
+                    ImVec2 start(datum, tk.PixelPos - 0.5f * tk.LabelSize.y);
+                    DrawList.AddText(start, ax.ColorTxt, tkr.GetText(j));
+                }
+            }
+        }
+    }
+
+
+    // clear legend (TODO: put elsewhere)
+    plot.Items.Legend.Reset();
+    // push ID to set item hashes (NB: !!!THIS PROBABLY NEEDS TO BE IN BEGIN PLOT!!!!)
+    ImGui::PushOverrideID(gp.CurrentItems->ID);
+}
+
+//-----------------------------------------------------------------------------
+// EndPlot()
+//-----------------------------------------------------------------------------
+
+void EndPlot() {
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "Mismatched BeginPlot()/EndPlot()!");
+
+    SetupLock();
+
+    ImPlotContext& gp     = *GImPlot;
+    ImGuiContext &G       = *GImGui;
+    ImPlotPlot &plot      = *gp.CurrentPlot;
+    ImGuiWindow * Window  = G.CurrentWindow;
+    ImDrawList & DrawList = *Window->DrawList;
+    const ImGuiIO &   IO  = ImGui::GetIO();
+
+    // FINAL RENDER -----------------------------------------------------------
+
+    const bool render_border  = gp.Style.PlotBorderSize > 0 && gp.Style.Colors[ImPlotCol_PlotBorder].w > 0;
+    const bool any_x_held = plot.Held    || AnyAxesHeld(&plot.Axes[ImAxis_X1], IMPLOT_NUM_X_AXES);
+    const bool any_y_held = plot.Held    || AnyAxesHeld(&plot.Axes[ImAxis_Y1], IMPLOT_NUM_Y_AXES);
+
+    ImGui::PushClipRect(plot.FrameRect.Min, plot.FrameRect.Max, true);
+
+    // render grid (foreground)
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+        ImPlotAxis& x_axis = plot.XAxis(i);
+        if (x_axis.Enabled && x_axis.HasGridLines() && x_axis.IsForeground())
+            RenderGridLinesX(DrawList, x_axis.Ticker, plot.PlotRect, x_axis.ColorMaj, x_axis.ColorMin, gp.Style.MajorGridSize.x, gp.Style.MinorGridSize.x);
+    }
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+        ImPlotAxis& y_axis = plot.YAxis(i);
+        if (y_axis.Enabled && y_axis.HasGridLines() && y_axis.IsForeground())
+            RenderGridLinesY(DrawList, y_axis.Ticker, plot.PlotRect,  y_axis.ColorMaj, y_axis.ColorMin, gp.Style.MajorGridSize.y, gp.Style.MinorGridSize.y);
+    }
+
+
+    // render title
+    if (plot.HasTitle()) {
+        ImU32 col = GetStyleColorU32(ImPlotCol_TitleText);
+        AddTextCentered(&DrawList,ImVec2(plot.PlotRect.GetCenter().x, plot.CanvasRect.Min.y),col,plot.GetTitle());
+    }
+
+    // render x ticks
+    int count_B = 0, count_T = 0;
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+        const ImPlotAxis& ax = plot.XAxis(i);
+        if (!ax.Enabled)
+            continue;
+        const ImPlotTicker& tkr = ax.Ticker;
+        const bool opp = ax.IsOpposite();
+        const bool aux = ((opp && count_T > 0)||(!opp && count_B > 0));
+        if (ax.HasTickMarks()) {
+            const float direction = opp ? 1.0f : -1.0f;
+            for (int j = 0; j < tkr.TickCount(); ++j) {
+                const ImPlotTick& tk = tkr.Ticks[j];
+                if (tk.Level != 0 || tk.PixelPos < plot.PlotRect.Min.x || tk.PixelPos > plot.PlotRect.Max.x)
+                    continue;
+                const ImVec2 start(tk.PixelPos, ax.Datum1);
+                const float len = (!aux && tk.Major) ? gp.Style.MajorTickLen.x  : gp.Style.MinorTickLen.x;
+                const float thk = (!aux && tk.Major) ? gp.Style.MajorTickSize.x : gp.Style.MinorTickSize.x;
+                DrawList.AddLine(start, start + ImVec2(0,direction*len), ax.ColorTick, thk);
+            }
+            if (aux || !render_border)
+                DrawList.AddLine(ImVec2(plot.PlotRect.Min.x,ax.Datum1), ImVec2(plot.PlotRect.Max.x,ax.Datum1), ax.ColorTick, gp.Style.MinorTickSize.x);
+        }
+        count_B += !opp;
+        count_T +=  opp;
+    }
+
+    // render y ticks
+    int count_L = 0, count_R = 0;
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+        const ImPlotAxis& ax = plot.YAxis(i);
+        if (!ax.Enabled)
+            continue;
+        const ImPlotTicker& tkr = ax.Ticker;
+        const bool opp = ax.IsOpposite();
+        const bool aux = ((opp && count_R > 0)||(!opp && count_L > 0));
+        if (ax.HasTickMarks()) {
+            const float direction = opp ? -1.0f : 1.0f;
+            for (int j = 0; j < tkr.TickCount(); ++j) {
+                const ImPlotTick& tk = tkr.Ticks[j];
+                if (tk.Level != 0 || tk.PixelPos < plot.PlotRect.Min.y || tk.PixelPos > plot.PlotRect.Max.y)
+                    continue;
+                const ImVec2 start(ax.Datum1, tk.PixelPos);
+                const float len = (!aux && tk.Major) ? gp.Style.MajorTickLen.y  : gp.Style.MinorTickLen.y;
+                const float thk = (!aux && tk.Major) ? gp.Style.MajorTickSize.y : gp.Style.MinorTickSize.y;
+                DrawList.AddLine(start, start + ImVec2(direction*len,0), ax.ColorTick, thk);
+            }
+            if (aux || !render_border)
+                DrawList.AddLine(ImVec2(ax.Datum1, plot.PlotRect.Min.y), ImVec2(ax.Datum1, plot.PlotRect.Max.y), ax.ColorTick, gp.Style.MinorTickSize.y);
+        }
+        count_L += !opp;
+        count_R +=  opp;
+    }
+    ImGui::PopClipRect();
+
+    // render annotations
+    PushPlotClipRect();
+    for (int i = 0; i < gp.Annotations.Size; ++i) {
+        const char* txt       = gp.Annotations.GetText(i);
+        ImPlotAnnotation& an  = gp.Annotations.Annotations[i];
+        const ImVec2 txt_size = ImGui::CalcTextSize(txt);
+        const ImVec2 size     = txt_size + gp.Style.AnnotationPadding * 2;
+        ImVec2 pos            = an.Pos;
+        if (an.Offset.x == 0)
+            pos.x -= size.x / 2;
+        else if (an.Offset.x > 0)
+            pos.x += an.Offset.x;
+        else
+            pos.x -= size.x - an.Offset.x;
+        if (an.Offset.y == 0)
+            pos.y -= size.y / 2;
+        else if (an.Offset.y > 0)
+            pos.y += an.Offset.y;
+        else
+            pos.y -= size.y - an.Offset.y;
+        if (an.Clamp)
+            pos = ClampLabelPos(pos, size, plot.PlotRect.Min, plot.PlotRect.Max);
+        ImRect rect(pos,pos+size);
+        if (an.Offset.x != 0 || an.Offset.y != 0) {
+            ImVec2 corners[4] = {rect.GetTL(), rect.GetTR(), rect.GetBR(), rect.GetBL()};
+            int min_corner = 0;
+            float min_len = FLT_MAX;
+            for (int c = 0; c < 4; ++c) {
+                float len = ImLengthSqr(an.Pos - corners[c]);
+                if (len < min_len) {
+                    min_corner = c;
+                    min_len = len;
+                }
+            }
+            DrawList.AddLine(an.Pos, corners[min_corner], an.ColorBg);
+        }
+        DrawList.AddRectFilled(rect.Min, rect.Max, an.ColorBg);
+        DrawList.AddText(pos + gp.Style.AnnotationPadding, an.ColorFg, txt);
+    }
+
+    // render selection
+    if (plot.Selected)
+        RenderSelectionRect(DrawList, plot.SelectRect.Min + plot.PlotRect.Min, plot.SelectRect.Max + plot.PlotRect.Min, GetStyleColorVec4(ImPlotCol_Selection));
+
+    // render crosshairs
+    if (ImHasFlag(plot.Flags, ImPlotFlags_Crosshairs) && plot.Hovered && !(any_x_held || any_y_held) && !plot.Selecting && !plot.Items.Legend.Hovered) {
+        ImGui::SetMouseCursor(ImGuiMouseCursor_None);
+        ImVec2 xy = IO.MousePos;
+        ImVec2 h1(plot.PlotRect.Min.x, xy.y);
+        ImVec2 h2(xy.x - 5, xy.y);
+        ImVec2 h3(xy.x + 5, xy.y);
+        ImVec2 h4(plot.PlotRect.Max.x, xy.y);
+        ImVec2 v1(xy.x, plot.PlotRect.Min.y);
+        ImVec2 v2(xy.x, xy.y - 5);
+        ImVec2 v3(xy.x, xy.y + 5);
+        ImVec2 v4(xy.x, plot.PlotRect.Max.y);
+        ImU32 col = GetStyleColorU32(ImPlotCol_Crosshairs);
+        DrawList.AddLine(h1, h2, col);
+        DrawList.AddLine(h3, h4, col);
+        DrawList.AddLine(v1, v2, col);
+        DrawList.AddLine(v3, v4, col);
+    }
+
+    // render mouse pos
+    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoMouseText) && (plot.Hovered || ImHasFlag(plot.MouseTextFlags, ImPlotMouseTextFlags_ShowAlways))) {
+
+        const bool no_aux = ImHasFlag(plot.MouseTextFlags, ImPlotMouseTextFlags_NoAuxAxes);
+        const bool no_fmt = ImHasFlag(plot.MouseTextFlags, ImPlotMouseTextFlags_NoFormat);
+
+        ImGuiTextBuffer& builder = gp.MousePosStringBuilder;
+        builder.Buf.shrink(0);
+        char buff[IMPLOT_LABEL_MAX_SIZE];
+
+        const int num_x = no_aux ? 1 : IMPLOT_NUM_X_AXES;
+        for (int i = 0; i < num_x; ++i) {
+            ImPlotAxis& x_axis = plot.XAxis(i);
+            if (!x_axis.Enabled)
+                continue;
+            if (i > 0)
+                builder.append(", (");
+            double v = x_axis.PixelsToPlot(IO.MousePos.x);
+            if (no_fmt)
+                Formatter_Default(v,buff,IMPLOT_LABEL_MAX_SIZE,(void*)IMPLOT_LABEL_FORMAT);
+            else
+                LabelAxisValue(x_axis,v,buff,IMPLOT_LABEL_MAX_SIZE,true);
+            builder.append(buff);
+            if (i > 0)
+                builder.append(")");
+        }
+        builder.append(", ");
+        const int num_y = no_aux ? 1 : IMPLOT_NUM_Y_AXES;
+        for (int i = 0; i < num_y; ++i) {
+            ImPlotAxis& y_axis = plot.YAxis(i);
+            if (!y_axis.Enabled)
+                continue;
+            if (i > 0)
+                builder.append(", (");
+            double v = y_axis.PixelsToPlot(IO.MousePos.y);
+            if (no_fmt)
+                Formatter_Default(v,buff,IMPLOT_LABEL_MAX_SIZE,(void*)IMPLOT_LABEL_FORMAT);
+            else
+                LabelAxisValue(y_axis,v,buff,IMPLOT_LABEL_MAX_SIZE,true);
+            builder.append(buff);
+            if (i > 0)
+                builder.append(")");
+        }
+
+        if (!builder.empty()) {
+            const ImVec2 size = ImGui::CalcTextSize(builder.c_str());
+            const ImVec2 pos = GetLocationPos(plot.PlotRect, size, plot.MouseTextLocation, gp.Style.MousePosPadding);
+            DrawList.AddText(pos, GetStyleColorU32(ImPlotCol_InlayText), builder.c_str());
+        }
+    }
+    PopPlotClipRect();
+
+    // axis side switch
+    if (!plot.Held) {
+        ImVec2 mouse_pos = ImGui::GetIO().MousePos;
+        ImRect trigger_rect = plot.PlotRect;
+        trigger_rect.Expand(-10);
+        for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i) {
+            ImPlotAxis& x_axis = plot.XAxis(i);
+            if (ImHasFlag(x_axis.Flags, ImPlotAxisFlags_NoSideSwitch))
+                continue;
+            if (x_axis.Held && plot.PlotRect.Contains(mouse_pos)) {
+                const bool opp = ImHasFlag(x_axis.Flags, ImPlotAxisFlags_Opposite);
+                if (!opp) {
+                    ImRect rect(plot.PlotRect.Min.x - 5, plot.PlotRect.Min.y - 5,
+                                plot.PlotRect.Max.x + 5, plot.PlotRect.Min.y + 5);
+                    if (mouse_pos.y < plot.PlotRect.Max.y - 10)
+                        DrawList.AddRectFilled(rect.Min, rect.Max, x_axis.ColorHov);
+                    if (rect.Contains(mouse_pos))
+                        x_axis.Flags |= ImPlotAxisFlags_Opposite;
+                }
+                else {
+                    ImRect rect(plot.PlotRect.Min.x - 5, plot.PlotRect.Max.y - 5,
+                                plot.PlotRect.Max.x + 5, plot.PlotRect.Max.y + 5);
+                    if (mouse_pos.y > plot.PlotRect.Min.y + 10)
+                        DrawList.AddRectFilled(rect.Min, rect.Max, x_axis.ColorHov);
+                    if (rect.Contains(mouse_pos))
+                        x_axis.Flags &= ~ImPlotAxisFlags_Opposite;
+                }
+            }
+        }
+        for (int i = 0; i < IMPLOT_NUM_Y_AXES; ++i) {
+            ImPlotAxis& y_axis = plot.YAxis(i);
+            if (ImHasFlag(y_axis.Flags, ImPlotAxisFlags_NoSideSwitch))
+                continue;
+            if (y_axis.Held && plot.PlotRect.Contains(mouse_pos)) {
+                const bool opp = ImHasFlag(y_axis.Flags, ImPlotAxisFlags_Opposite);
+                if (!opp) {
+                    ImRect rect(plot.PlotRect.Max.x - 5, plot.PlotRect.Min.y - 5,
+                                plot.PlotRect.Max.x + 5, plot.PlotRect.Max.y + 5);
+                    if (mouse_pos.x > plot.PlotRect.Min.x + 10)
+                        DrawList.AddRectFilled(rect.Min, rect.Max, y_axis.ColorHov);
+                    if (rect.Contains(mouse_pos))
+                        y_axis.Flags |= ImPlotAxisFlags_Opposite;
+                }
+                else {
+                    ImRect rect(plot.PlotRect.Min.x - 5, plot.PlotRect.Min.y - 5,
+                                plot.PlotRect.Min.x + 5, plot.PlotRect.Max.y + 5);
+                    if (mouse_pos.x < plot.PlotRect.Max.x - 10)
+                        DrawList.AddRectFilled(rect.Min, rect.Max, y_axis.ColorHov);
+                    if (rect.Contains(mouse_pos))
+                        y_axis.Flags &= ~ImPlotAxisFlags_Opposite;
+                }
+            }
+        }
+    }
+
+    // reset legend hovers
+    plot.Items.Legend.Hovered = false;
+    for (int i = 0; i < plot.Items.GetItemCount(); ++i)
+        plot.Items.GetItemByIndex(i)->LegendHovered = false;
+    // render legend
+    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoLegend) && plot.Items.GetLegendCount() > 0) {
+        ImPlotLegend& legend = plot.Items.Legend;
+        const bool   legend_out  = ImHasFlag(legend.Flags, ImPlotLegendFlags_Outside);
+        const bool   legend_horz = ImHasFlag(legend.Flags, ImPlotLegendFlags_Horizontal);
+        const ImVec2 legend_size = CalcLegendSize(plot.Items, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz);
+        const ImVec2 legend_pos  = GetLocationPos(legend_out ? plot.FrameRect : plot.PlotRect,
+                                                  legend_size,
+                                                  legend.Location,
+                                                  legend_out ? gp.Style.PlotPadding : gp.Style.LegendPadding);
+        legend.Rect = ImRect(legend_pos, legend_pos + legend_size);
+        // test hover
+        legend.Hovered = ImGui::IsWindowHovered() && legend.Rect.Contains(IO.MousePos);
+
+        if (legend_out)
+            ImGui::PushClipRect(plot.FrameRect.Min, plot.FrameRect.Max, true);
+        else
+            PushPlotClipRect();
+        ImU32  col_bg      = GetStyleColorU32(ImPlotCol_LegendBg);
+        ImU32  col_bd      = GetStyleColorU32(ImPlotCol_LegendBorder);
+        DrawList.AddRectFilled(legend.Rect.Min, legend.Rect.Max, col_bg);
+        DrawList.AddRect(legend.Rect.Min, legend.Rect.Max, col_bd);
+        bool legend_contextable = ShowLegendEntries(plot.Items, legend.Rect, legend.Hovered, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, DrawList)
+                                && !ImHasFlag(legend.Flags, ImPlotLegendFlags_NoMenus);
+
+        // main ctx menu
+        if (gp.OpenContextThisFrame && legend_contextable && !ImHasFlag(plot.Flags, ImPlotFlags_NoMenus))
+            ImGui::OpenPopup("##LegendContext");
+        ImGui::PopClipRect();
+        if (ImGui::BeginPopup("##LegendContext")) {
+            ImGui::Text("Legend"); ImGui::Separator();
+            if (ShowLegendContextMenu(legend, !ImHasFlag(plot.Flags, ImPlotFlags_NoLegend)))
+                ImFlipFlag(plot.Flags, ImPlotFlags_NoLegend);
+            ImGui::EndPopup();
+        }
+    }
+    else {
+        plot.Items.Legend.Rect = ImRect();
+    }
+
+    // render border
+    if (render_border)
+        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, ImDrawFlags_RoundCornersAll, gp.Style.PlotBorderSize);
+
+    // render tags
+    for (int i = 0; i < gp.Tags.Size; ++i) {
+        ImPlotTag& tag  = gp.Tags.Tags[i];
+        ImPlotAxis& axis = plot.Axes[tag.Axis];
+        if (!axis.Enabled || !axis.Range.Contains(tag.Value))
+            continue;
+        const char* txt = gp.Tags.GetText(i);
+        ImVec2 text_size = ImGui::CalcTextSize(txt);
+        ImVec2 size = text_size + gp.Style.AnnotationPadding * 2;
+        ImVec2 pos;
+        axis.Ticker.OverrideSizeLate(size);
+        float pix = IM_ROUND(axis.PlotToPixels(tag.Value));
+        if (axis.Vertical) {
+            if (axis.IsOpposite()) {
+                pos = ImVec2(axis.Datum1 + gp.Style.LabelPadding.x, pix - size.y * 0.5f);
+                DrawList.AddTriangleFilled(ImVec2(axis.Datum1,pix), pos, pos + ImVec2(0,size.y), tag.ColorBg);
+            }
+            else {
+                pos = ImVec2(axis.Datum1 - size.x - gp.Style.LabelPadding.x, pix - size.y * 0.5f);
+                DrawList.AddTriangleFilled(pos + ImVec2(size.x,0), ImVec2(axis.Datum1,pix), pos+size, tag.ColorBg);
+            }
+        }
+        else {
+            if (axis.IsOpposite()) {
+                pos = ImVec2(pix - size.x * 0.5f, axis.Datum1 - size.y - gp.Style.LabelPadding.y );
+                DrawList.AddTriangleFilled(pos + ImVec2(0,size.y), pos + size, ImVec2(pix,axis.Datum1), tag.ColorBg);
+            }
+            else {
+                pos = ImVec2(pix - size.x * 0.5f, axis.Datum1 + gp.Style.LabelPadding.y);
+                DrawList.AddTriangleFilled(pos, ImVec2(pix,axis.Datum1), pos + ImVec2(size.x, 0), tag.ColorBg);
+            }
+        }
+        DrawList.AddRectFilled(pos,pos+size,tag.ColorBg);
+        DrawList.AddText(pos+gp.Style.AnnotationPadding,tag.ColorFg,txt);
+    }
+
+    // FIT DATA --------------------------------------------------------------
+    const bool axis_equal = ImHasFlag(plot.Flags, ImPlotFlags_Equal);
+    if (plot.FitThisFrame) {
+        for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+            ImPlotAxis& x_axis = plot.XAxis(i);
+            if (x_axis.FitThisFrame) {
+                x_axis.ApplyFit(gp.Style.FitPadding.x);
+                if (axis_equal && x_axis.OrthoAxis != NULL) {
+                    double aspect = x_axis.GetAspect();
+                    ImPlotAxis& y_axis = *x_axis.OrthoAxis;
+                    if (y_axis.FitThisFrame) {
+                        y_axis.ApplyFit(gp.Style.FitPadding.y);
+                        y_axis.FitThisFrame = false;
+                        aspect = ImMax(aspect, y_axis.GetAspect());
+                    }
+                    x_axis.SetAspect(aspect);
+                    y_axis.SetAspect(aspect);
+                }
+            }
+        }
+        for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+            ImPlotAxis& y_axis = plot.YAxis(i);
+            if (y_axis.FitThisFrame) {
+                y_axis.ApplyFit(gp.Style.FitPadding.y);
+                if (axis_equal && y_axis.OrthoAxis != NULL) {
+                    double aspect = y_axis.GetAspect();
+                    ImPlotAxis& x_axis = *y_axis.OrthoAxis;
+                    if (x_axis.FitThisFrame) {
+                        x_axis.ApplyFit(gp.Style.FitPadding.x);
+                        x_axis.FitThisFrame = false;
+                        aspect = ImMax(x_axis.GetAspect(), aspect);
+                    }
+                    x_axis.SetAspect(aspect);
+                    y_axis.SetAspect(aspect);
+                }
+            }
+        }
+        plot.FitThisFrame = false;
+    }
+
+    // CONTEXT MENUS -----------------------------------------------------------
+
+    ImGui::PushOverrideID(plot.ID);
+
+    const bool can_ctx = gp.OpenContextThisFrame &&
+                         !ImHasFlag(plot.Flags, ImPlotFlags_NoMenus) &&
+                         !plot.Items.Legend.Hovered;
+
+
+
+    // main ctx menu
+    if (can_ctx && plot.Hovered)
+        ImGui::OpenPopup("##PlotContext");
+    if (ImGui::BeginPopup("##PlotContext")) {
+        ShowPlotContextMenu(plot);
+        ImGui::EndPopup();
+    }
+
+    // axes ctx menus
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i) {
+        ImGui::PushID(i);
+        ImPlotAxis& x_axis = plot.XAxis(i);
+        if (can_ctx && x_axis.Hovered && x_axis.HasMenus())
+            ImGui::OpenPopup("##XContext");
+        if (ImGui::BeginPopup("##XContext")) {
+            ImGui::Text(x_axis.HasLabel() ? plot.GetAxisLabel(x_axis) :  i == 0 ? "X-Axis" : "X-Axis %d", i + 1);
+            ImGui::Separator();
+            ShowAxisContextMenu(x_axis, axis_equal ? x_axis.OrthoAxis : NULL, true);
+            ImGui::EndPopup();
+        }
+        ImGui::PopID();
+    }
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; ++i) {
+        ImGui::PushID(i);
+        ImPlotAxis& y_axis = plot.YAxis(i);
+        if (can_ctx && y_axis.Hovered && y_axis.HasMenus())
+            ImGui::OpenPopup("##YContext");
+        if (ImGui::BeginPopup("##YContext")) {
+            ImGui::Text(y_axis.HasLabel() ? plot.GetAxisLabel(y_axis) : i == 0 ? "Y-Axis" : "Y-Axis %d", i + 1);
+            ImGui::Separator();
+            ShowAxisContextMenu(y_axis, axis_equal ? y_axis.OrthoAxis : NULL, false);
+            ImGui::EndPopup();
+        }
+        ImGui::PopID();
+    }
+    ImGui::PopID();
+
+    // LINKED AXES ------------------------------------------------------------
+
+    for (int i = 0; i < ImAxis_COUNT; ++i)
+        plot.Axes[i].PushLinks();
+
+
+    // CLEANUP ----------------------------------------------------------------
+
+    // remove items
+    if (gp.CurrentItems == &plot.Items)
+        gp.CurrentItems = NULL;
+    // reset the plot items for the next frame
+    for (int i = 0; i < plot.Items.GetItemCount(); ++i) {
+        plot.Items.GetItemByIndex(i)->SeenThisFrame = false;
+    }
+
+    // mark the plot as initialized, i.e. having made it through one frame completely
+    plot.Initialized = true;
+    // Pop ImGui::PushID at the end of BeginPlot
+    ImGui::PopID();
+    // Reset context for next plot
+    ResetCtxForNextPlot(GImPlot);
+
+    // setup next subplot
+    if (gp.CurrentSubplot != NULL) {
+        ImGui::PopID();
+        SubplotNextCell();
+    }
+}
+
+//-----------------------------------------------------------------------------
+// BEGIN/END SUBPLOT
+//-----------------------------------------------------------------------------
+
+static const float SUBPLOT_BORDER_SIZE             = 1.0f;
+static const float SUBPLOT_SPLITTER_HALF_THICKNESS = 4.0f;
+static const float SUBPLOT_SPLITTER_FEEDBACK_TIMER = 0.06f;
+
+void SubplotSetCell(int row, int col) {
+    ImPlotContext& gp      = *GImPlot;
+    ImPlotSubplot& subplot = *gp.CurrentSubplot;
+    if (row >= subplot.Rows || col >= subplot.Cols)
+        return;
+    float xoff = 0;
+    float yoff = 0;
+    for (int c = 0; c < col; ++c)
+        xoff += subplot.ColRatios[c];
+    for (int r = 0; r < row; ++r)
+        yoff += subplot.RowRatios[r];
+    const ImVec2 grid_size = subplot.GridRect.GetSize();
+    ImVec2 cpos            = subplot.GridRect.Min + ImVec2(xoff*grid_size.x,yoff*grid_size.y);
+    cpos.x = IM_ROUND(cpos.x);
+    cpos.y = IM_ROUND(cpos.y);
+    ImGui::GetCurrentWindow()->DC.CursorPos =  cpos;
+    // set cell size
+    subplot.CellSize.x = IM_ROUND(subplot.GridRect.GetWidth()  * subplot.ColRatios[col]);
+    subplot.CellSize.y = IM_ROUND(subplot.GridRect.GetHeight() * subplot.RowRatios[row]);
+    // setup links
+    const bool lx = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllX);
+    const bool ly = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY);
+    const bool lr = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows);
+    const bool lc = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkCols);
+
+    SetNextAxisLinks(ImAxis_X1, lx ? &subplot.ColLinkData[0].Min : lc ? &subplot.ColLinkData[col].Min : NULL,
+                                lx ? &subplot.ColLinkData[0].Max : lc ? &subplot.ColLinkData[col].Max : NULL);
+    SetNextAxisLinks(ImAxis_Y1, ly ? &subplot.RowLinkData[0].Min : lr ? &subplot.RowLinkData[row].Min : NULL,
+                                ly ? &subplot.RowLinkData[0].Max : lr ? &subplot.RowLinkData[row].Max : NULL);
+    // setup alignment
+    if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoAlign)) {
+        gp.CurrentAlignmentH = &subplot.RowAlignmentData[row];
+        gp.CurrentAlignmentV = &subplot.ColAlignmentData[col];
+    }
+    // set idx
+    if (ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ColMajor))
+        subplot.CurrentIdx = col * subplot.Rows + row;
+    else
+        subplot.CurrentIdx = row * subplot.Cols + col;
+}
+
+void SubplotSetCell(int idx) {
+    ImPlotContext& gp      = *GImPlot;
+    ImPlotSubplot& subplot = *gp.CurrentSubplot;
+    if (idx >= subplot.Rows * subplot.Cols)
+        return;
+    int row = 0, col = 0;
+    if (ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ColMajor)) {
+        row = idx % subplot.Rows;
+        col = idx / subplot.Rows;
+    }
+    else {
+        row = idx / subplot.Cols;
+        col = idx % subplot.Cols;
+    }
+    return SubplotSetCell(row, col);
+}
+
+void SubplotNextCell() {
+    ImPlotContext& gp      = *GImPlot;
+    ImPlotSubplot& subplot = *gp.CurrentSubplot;
+    SubplotSetCell(++subplot.CurrentIdx);
+}
+
+bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, ImPlotSubplotFlags flags, float* row_sizes, float* col_sizes) {
+    IM_ASSERT_USER_ERROR(rows > 0 && cols > 0, "Invalid sizing arguments!");
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentSubplot == NULL, "Mismatched BeginSubplots()/EndSubplots()!");
+    ImPlotContext& gp = *GImPlot;
+    ImGuiContext &G = *GImGui;
+    ImGuiWindow * Window = G.CurrentWindow;
+    if (Window->SkipItems)
+        return false;
+    const ImGuiID ID = Window->GetID(title);
+    bool just_created = gp.Subplots.GetByKey(ID) == NULL;
+    gp.CurrentSubplot = gp.Subplots.GetOrAddByKey(ID);
+    ImPlotSubplot& subplot = *gp.CurrentSubplot;
+    subplot.ID       = ID;
+    subplot.Items.ID = ID - 1;
+    subplot.HasTitle = ImGui::FindRenderedTextEnd(title, NULL) != title;
+    // push ID
+    ImGui::PushID(ID);
+
+    if (just_created)
+        subplot.Flags = flags;
+    else if (flags != subplot.PreviousFlags)
+        subplot.Flags = flags;
+    subplot.PreviousFlags = flags;
+
+    // check for change in rows and cols
+    if (subplot.Rows != rows || subplot.Cols != cols) {
+        subplot.RowAlignmentData.resize(rows);
+        subplot.RowLinkData.resize(rows);
+        subplot.RowRatios.resize(rows);
+        for (int r = 0; r < rows; ++r) {
+            subplot.RowAlignmentData[r].Reset();
+            subplot.RowLinkData[r] = ImPlotRange(0,1);
+            subplot.RowRatios[r] = 1.0f / rows;
+        }
+        subplot.ColAlignmentData.resize(cols);
+        subplot.ColLinkData.resize(cols);
+        subplot.ColRatios.resize(cols);
+        for (int c = 0; c < cols; ++c) {
+            subplot.ColAlignmentData[c].Reset();
+            subplot.ColLinkData[c] = ImPlotRange(0,1);
+            subplot.ColRatios[c] = 1.0f / cols;
+        }
+    }
+    // check incoming size requests
+    float row_sum = 0, col_sum = 0;
+    if (row_sizes != NULL) {
+        row_sum = ImSum(row_sizes, rows);
+        for (int r = 0; r < rows; ++r)
+            subplot.RowRatios[r] = row_sizes[r] / row_sum;
+    }
+    if (col_sizes != NULL) {
+        col_sum = ImSum(col_sizes, cols);
+        for (int c = 0; c < cols; ++c)
+            subplot.ColRatios[c] = col_sizes[c] / col_sum;
+    }
+    subplot.Rows = rows;
+    subplot.Cols = cols;
+
+    // calc plot frame sizes
+    ImVec2 title_size(0.0f, 0.0f);
+    if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle))
+         title_size = ImGui::CalcTextSize(title, NULL, true);
+    const float pad_top = title_size.x > 0.0f ? title_size.y + gp.Style.LabelPadding.y : 0;
+    const ImVec2 half_pad = gp.Style.PlotPadding/2;
+    const ImVec2 frame_size = ImGui::CalcItemSize(size, gp.Style.PlotDefaultSize.x, gp.Style.PlotDefaultSize.y);
+    subplot.FrameRect = ImRect(Window->DC.CursorPos, Window->DC.CursorPos + frame_size);
+    subplot.GridRect.Min = subplot.FrameRect.Min + half_pad + ImVec2(0,pad_top);
+    subplot.GridRect.Max = subplot.FrameRect.Max - half_pad;
+    subplot.FrameHovered = subplot.FrameRect.Contains(ImGui::GetMousePos()) && ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
+
+    // outside legend adjustments (TODO: make function)
+    const bool share_items = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems);
+    if (share_items)
+        gp.CurrentItems = &subplot.Items;
+    if (share_items && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoLegend) && subplot.Items.GetLegendCount() > 0) {
+        ImPlotLegend& legend = subplot.Items.Legend;
+        const bool horz = ImHasFlag(legend.Flags, ImPlotLegendFlags_Horizontal);
+        const ImVec2 legend_size = CalcLegendSize(subplot.Items, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !horz);
+        const bool west = ImHasFlag(legend.Location, ImPlotLocation_West) && !ImHasFlag(legend.Location, ImPlotLocation_East);
+        const bool east = ImHasFlag(legend.Location, ImPlotLocation_East) && !ImHasFlag(legend.Location, ImPlotLocation_West);
+        const bool north = ImHasFlag(legend.Location, ImPlotLocation_North) && !ImHasFlag(legend.Location, ImPlotLocation_South);
+        const bool south = ImHasFlag(legend.Location, ImPlotLocation_South) && !ImHasFlag(legend.Location, ImPlotLocation_North);
+        if ((west && !horz) || (west && horz && !north && !south))
+            subplot.GridRect.Min.x += (legend_size.x + gp.Style.LegendPadding.x);
+        if ((east && !horz) || (east && horz && !north && !south))
+            subplot.GridRect.Max.x -= (legend_size.x + gp.Style.LegendPadding.x);
+        if ((north && horz) || (north && !horz && !west && !east))
+            subplot.GridRect.Min.y += (legend_size.y + gp.Style.LegendPadding.y);
+        if ((south && horz) || (south && !horz && !west && !east))
+            subplot.GridRect.Max.y -= (legend_size.y + gp.Style.LegendPadding.y);
+    }
+
+    // render single background frame
+    ImGui::RenderFrame(subplot.FrameRect.Min, subplot.FrameRect.Max, GetStyleColorU32(ImPlotCol_FrameBg), true, ImGui::GetStyle().FrameRounding);
+    // render title
+    if (title_size.x > 0.0f && !ImHasFlag(subplot.Flags, ImPlotFlags_NoTitle)) {
+        const ImU32 col = GetStyleColorU32(ImPlotCol_TitleText);
+        AddTextCentered(ImGui::GetWindowDrawList(),ImVec2(subplot.GridRect.GetCenter().x, subplot.GridRect.Min.y - pad_top + half_pad.y),col,title);
+    }
+
+    // render splitters
+    if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoResize)) {
+        ImDrawList& DrawList = *ImGui::GetWindowDrawList();
+        const ImU32 hov_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_SeparatorHovered]);
+        const ImU32 act_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_SeparatorActive]);
+        float xpos = subplot.GridRect.Min.x;
+        float ypos = subplot.GridRect.Min.y;
+        int separator = 1;
+        // bool pass = false;
+        for (int r = 0; r < subplot.Rows-1; ++r) {
+            ypos += subplot.RowRatios[r] * subplot.GridRect.GetHeight();
+            const ImGuiID sep_id = subplot.ID + separator;
+            ImGui::KeepAliveID(sep_id);
+            const ImRect sep_bb = ImRect(subplot.GridRect.Min.x, ypos-SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Max.x, ypos+SUBPLOT_SPLITTER_HALF_THICKNESS);
+            bool sep_hov = false, sep_hld = false;
+            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+            if ((sep_hov && G.HoveredIdTimer > SUBPLOT_SPLITTER_FEEDBACK_TIMER) || sep_hld) {
+                if (sep_clk && ImGui::IsMouseDoubleClicked(0)) {
+                    float p = (subplot.RowRatios[r] + subplot.RowRatios[r+1])/2;
+                    subplot.RowRatios[r] = subplot.RowRatios[r+1] = p;
+                }
+                if (sep_clk) {
+                    subplot.TempSizes[0] = subplot.RowRatios[r];
+                    subplot.TempSizes[1] = subplot.RowRatios[r+1];
+                }
+                if (sep_hld) {
+                    float dp = ImGui::GetMouseDragDelta(0).y  / subplot.GridRect.GetHeight();
+                    if (subplot.TempSizes[0] + dp > 0.1f && subplot.TempSizes[1] - dp > 0.1f) {
+                        subplot.RowRatios[r]   = subplot.TempSizes[0] + dp;
+                        subplot.RowRatios[r+1] = subplot.TempSizes[1] - dp;
+                    }
+                }
+                DrawList.AddLine(ImVec2(IM_ROUND(subplot.GridRect.Min.x),IM_ROUND(ypos)),
+                                 ImVec2(IM_ROUND(subplot.GridRect.Max.x),IM_ROUND(ypos)),
+                                 sep_hld ? act_col : hov_col, SUBPLOT_BORDER_SIZE);
+                ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
+            }
+            separator++;
+        }
+        for (int c = 0; c < subplot.Cols-1; ++c) {
+            xpos += subplot.ColRatios[c] * subplot.GridRect.GetWidth();
+            const ImGuiID sep_id = subplot.ID + separator;
+            ImGui::KeepAliveID(sep_id);
+            const ImRect sep_bb = ImRect(xpos-SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Min.y, xpos+SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Max.y);
+            bool sep_hov = false, sep_hld = false;
+            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+            if ((sep_hov && G.HoveredIdTimer > SUBPLOT_SPLITTER_FEEDBACK_TIMER) || sep_hld) {
+                if (sep_clk && ImGui::IsMouseDoubleClicked(0)) {
+                    float p = (subplot.ColRatios[c] + subplot.ColRatios[c+1])/2;
+                    subplot.ColRatios[c] = subplot.ColRatios[c+1] = p;
+                }
+                if (sep_clk) {
+                    subplot.TempSizes[0] = subplot.ColRatios[c];
+                    subplot.TempSizes[1] = subplot.ColRatios[c+1];
+                }
+                if (sep_hld) {
+                    float dp = ImGui::GetMouseDragDelta(0).x / subplot.GridRect.GetWidth();
+                    if (subplot.TempSizes[0] + dp > 0.1f && subplot.TempSizes[1] - dp > 0.1f) {
+                        subplot.ColRatios[c]   = subplot.TempSizes[0] + dp;
+                        subplot.ColRatios[c+1] = subplot.TempSizes[1] - dp;
+                    }
+                }
+                DrawList.AddLine(ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Min.y)),
+                                 ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Max.y)),
+                                 sep_hld ? act_col : hov_col, SUBPLOT_BORDER_SIZE);
+                ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+            }
+            separator++;
+        }
+    }
+
+    // set outgoing sizes
+    if (row_sizes != NULL) {
+        for (int r = 0; r < rows; ++r)
+            row_sizes[r] = subplot.RowRatios[r] * row_sum;
+    }
+    if (col_sizes != NULL) {
+        for (int c = 0; c < cols; ++c)
+            col_sizes[c] = subplot.ColRatios[c] * col_sum;
+    }
+
+    // push styling
+    PushStyleColor(ImPlotCol_FrameBg, IM_COL32_BLACK_TRANS);
+    PushStyleVar(ImPlotStyleVar_PlotPadding, half_pad);
+    PushStyleVar(ImPlotStyleVar_PlotMinSize, ImVec2(0,0));
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize,0);
+
+    // set initial cursor pos
+    Window->DC.CursorPos = subplot.GridRect.Min;
+    // begin alignments
+    for (int r = 0; r < subplot.Rows; ++r)
+        subplot.RowAlignmentData[r].Begin();
+    for (int c = 0; c < subplot.Cols; ++c)
+        subplot.ColAlignmentData[c].Begin();
+    // clear legend data
+    subplot.Items.Legend.Reset();
+    // Setup first subplot
+    SubplotSetCell(0,0);
+    return true;
+}
+
+void EndSubplots() {
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentSubplot != NULL, "Mismatched BeginSubplots()/EndSubplots()!");
+    ImPlotContext& gp = *GImPlot;
+    ImPlotSubplot& subplot = *GImPlot->CurrentSubplot;
+    // set alignments
+    for (int r = 0; r < subplot.Rows; ++r)
+        subplot.RowAlignmentData[r].End();
+    for (int c = 0; c < subplot.Cols; ++c)
+        subplot.ColAlignmentData[c].End();
+    // pop styling
+    PopStyleColor();
+    PopStyleVar();
+    PopStyleVar();
+    ImGui::PopStyleVar();
+    // legend
+    subplot.Items.Legend.Hovered = false;
+    for (int i = 0; i < subplot.Items.GetItemCount(); ++i)
+        subplot.Items.GetItemByIndex(i)->LegendHovered = false;
+    // render legend
+    const bool share_items = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems);
+    ImDrawList& DrawList = *ImGui::GetWindowDrawList();
+    if (share_items && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoLegend) && subplot.Items.GetLegendCount() > 0) {
+        const bool   legend_horz = ImHasFlag(subplot.Items.Legend.Flags, ImPlotLegendFlags_Horizontal);
+        const ImVec2 legend_size = CalcLegendSize(subplot.Items, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz);
+        const ImVec2 legend_pos  = GetLocationPos(subplot.FrameRect, legend_size, subplot.Items.Legend.Location, gp.Style.PlotPadding);
+        subplot.Items.Legend.Rect = ImRect(legend_pos, legend_pos + legend_size);
+        subplot.Items.Legend.Hovered = subplot.FrameHovered && subplot.Items.Legend.Rect.Contains(ImGui::GetIO().MousePos);
+        ImGui::PushClipRect(subplot.FrameRect.Min, subplot.FrameRect.Max, true);
+        ImU32  col_bg      = GetStyleColorU32(ImPlotCol_LegendBg);
+        ImU32  col_bd      = GetStyleColorU32(ImPlotCol_LegendBorder);
+        DrawList.AddRectFilled(subplot.Items.Legend.Rect.Min, subplot.Items.Legend.Rect.Max, col_bg);
+        DrawList.AddRect(subplot.Items.Legend.Rect.Min, subplot.Items.Legend.Rect.Max, col_bd);
+        bool legend_contextable = ShowLegendEntries(subplot.Items, subplot.Items.Legend.Rect, subplot.Items.Legend.Hovered, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, DrawList)
+                                && !ImHasFlag(subplot.Items.Legend.Flags, ImPlotLegendFlags_NoMenus);
+        if (legend_contextable && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoMenus) && ImGui::GetIO().MouseReleased[gp.InputMap.Menu])
+            ImGui::OpenPopup("##LegendContext");
+        ImGui::PopClipRect();
+        if (ImGui::BeginPopup("##LegendContext")) {
+            ImGui::Text("Legend"); ImGui::Separator();
+            if (ShowLegendContextMenu(subplot.Items.Legend, !ImHasFlag(subplot.Flags, ImPlotFlags_NoLegend)))
+                ImFlipFlag(subplot.Flags, ImPlotFlags_NoLegend);
+            ImGui::EndPopup();
+        }
+    }
+    else {
+        subplot.Items.Legend.Rect = ImRect();
+    }
+    // remove items
+    if (gp.CurrentItems == &subplot.Items)
+        gp.CurrentItems = NULL;
+    // reset the plot items for the next frame (TODO: put this elswhere)
+    for (int i = 0; i < subplot.Items.GetItemCount(); ++i) {
+        subplot.Items.GetItemByIndex(i)->SeenThisFrame = false;
+    }
+    // pop id
+    ImGui::PopID();
+    // set DC back correctly
+    GImGui->CurrentWindow->DC.CursorPos = subplot.FrameRect.Min;
+    ImGui::Dummy(subplot.FrameRect.GetSize());
+    ResetCtxForNextSubplot(GImPlot);
+
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Plot Utils
+//-----------------------------------------------------------------------------
+
+void SetAxis(ImAxis axis) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "SetAxis() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(axis >= ImAxis_X1 && axis < ImAxis_COUNT, "Axis index out of bounds!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot->Axes[axis].Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    SetupLock();
+    if (axis < ImAxis_Y1)
+        gp.CurrentPlot->CurrentX = axis;
+    else
+        gp.CurrentPlot->CurrentY = axis;
+}
+
+void SetAxes(ImAxis x_idx, ImAxis y_idx) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "SetAxes() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(x_idx >= ImAxis_X1 && x_idx < ImAxis_Y1, "X-Axis index out of bounds!");
+    IM_ASSERT_USER_ERROR(y_idx >= ImAxis_Y1 && y_idx < ImAxis_COUNT, "Y-Axis index out of bounds!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot->Axes[x_idx].Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot->Axes[y_idx].Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
+    SetupLock();
+    gp.CurrentPlot->CurrentX = x_idx;
+    gp.CurrentPlot->CurrentY = y_idx;
+}
+
+ImPlotPoint PixelsToPlot(float x, float y, ImAxis x_idx, ImAxis y_idx) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "PixelsToPlot() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(x_idx == IMPLOT_AUTO || (x_idx >= ImAxis_X1 && x_idx < ImAxis_Y1),    "X-Axis index out of bounds!");
+    IM_ASSERT_USER_ERROR(y_idx == IMPLOT_AUTO || (y_idx >= ImAxis_Y1 && y_idx < ImAxis_COUNT), "Y-Axis index out of bounds!");
+    SetupLock();
+    ImPlotPlot& plot   = *gp.CurrentPlot;
+    ImPlotAxis& x_axis = x_idx == IMPLOT_AUTO ? plot.Axes[plot.CurrentX] : plot.Axes[x_idx];
+    ImPlotAxis& y_axis = y_idx == IMPLOT_AUTO ? plot.Axes[plot.CurrentY] : plot.Axes[y_idx];
+    return ImPlotPoint( x_axis.PixelsToPlot(x), y_axis.PixelsToPlot(y) );
+}
+
+ImPlotPoint PixelsToPlot(const ImVec2& pix, ImAxis x_idx, ImAxis y_idx) {
+    return PixelsToPlot(pix.x, pix.y, x_idx, y_idx);
+}
+
+ImVec2 PlotToPixels(double x, double y, ImAxis x_idx, ImAxis y_idx) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "PlotToPixels() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(x_idx == IMPLOT_AUTO || (x_idx >= ImAxis_X1 && x_idx < ImAxis_Y1),    "X-Axis index out of bounds!");
+    IM_ASSERT_USER_ERROR(y_idx == IMPLOT_AUTO || (y_idx >= ImAxis_Y1 && y_idx < ImAxis_COUNT), "Y-Axis index out of bounds!");
+    SetupLock();
+    ImPlotPlot& plot = *gp.CurrentPlot;
+    ImPlotAxis& x_axis = x_idx == IMPLOT_AUTO ? plot.Axes[plot.CurrentX] : plot.Axes[x_idx];
+    ImPlotAxis& y_axis = y_idx == IMPLOT_AUTO ? plot.Axes[plot.CurrentY] : plot.Axes[y_idx];
+    return ImVec2( x_axis.PlotToPixels(x), y_axis.PlotToPixels(y) );
+}
+
+ImVec2 PlotToPixels(const ImPlotPoint& plt, ImAxis x_idx, ImAxis y_idx) {
+    return PlotToPixels(plt.x, plt.y, x_idx, y_idx);
+}
+
+ImVec2 GetPlotPos() {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotPos() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    return gp.CurrentPlot->PlotRect.Min;
+}
+
+ImVec2 GetPlotSize() {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotSize() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    return gp.CurrentPlot->PlotRect.GetSize();
+}
+
+ImPlotPoint GetPlotMousePos(ImAxis x_idx, ImAxis y_idx) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "GetPlotMousePos() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    return PixelsToPlot(ImGui::GetMousePos(), x_idx, y_idx);
+}
+
+ImPlotRect GetPlotLimits(ImAxis x_idx, ImAxis y_idx) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotLimits() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(x_idx == IMPLOT_AUTO || (x_idx >= ImAxis_X1 && x_idx < ImAxis_Y1),    "X-Axis index out of bounds!");
+    IM_ASSERT_USER_ERROR(y_idx == IMPLOT_AUTO || (y_idx >= ImAxis_Y1 && y_idx < ImAxis_COUNT), "Y-Axis index out of bounds!");
+    SetupLock();
+    ImPlotPlot& plot = *gp.CurrentPlot;
+    ImPlotAxis& x_axis = x_idx == IMPLOT_AUTO ? plot.Axes[plot.CurrentX] : plot.Axes[x_idx];
+    ImPlotAxis& y_axis = y_idx == IMPLOT_AUTO ? plot.Axes[plot.CurrentY] : plot.Axes[y_idx];
+    ImPlotRect limits;
+    limits.X = x_axis.Range;
+    limits.Y = y_axis.Range;
+    return limits;
+}
+
+bool IsPlotHovered() {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "IsPlotHovered() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    return gp.CurrentPlot->Hovered;
+}
+
+bool IsAxisHovered(ImAxis axis) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "IsPlotXAxisHovered() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    return gp.CurrentPlot->Axes[axis].Hovered;
+}
+
+bool IsSubplotsHovered() {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentSubplot != NULL, "IsSubplotsHovered() needs to be called between BeginSubplots() and EndSubplots()!");
+    return gp.CurrentSubplot->FrameHovered;
+}
+
+bool IsPlotSelected() {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "IsPlotSelected() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    return gp.CurrentPlot->Selected;
+}
+
+ImPlotRect GetPlotSelection(ImAxis x_idx, ImAxis y_idx) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotSelection() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    ImPlotPlot& plot = *gp.CurrentPlot;
+    if (!plot.Selected)
+        return ImPlotRect(0,0,0,0);
+    ImPlotPoint p1 = PixelsToPlot(plot.SelectRect.Min + plot.PlotRect.Min, x_idx, y_idx);
+    ImPlotPoint p2 = PixelsToPlot(plot.SelectRect.Max + plot.PlotRect.Min, x_idx, y_idx);
+    ImPlotRect result;
+    result.X.Min = ImMin(p1.x, p2.x);
+    result.X.Max = ImMax(p1.x, p2.x);
+    result.Y.Min = ImMin(p1.y, p2.y);
+    result.Y.Max = ImMax(p1.y, p2.y);
+    return result;
+}
+
+void CancelPlotSelection() {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "CancelPlotSelection() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    ImPlotPlot& plot = *gp.CurrentPlot;
+    if (plot.Selected)
+        plot.Selected = plot.Selecting = false;
+}
+
+void HideNextItem(bool hidden, ImPlotCond cond) {
+    ImPlotContext& gp = *GImPlot;
+    gp.NextItemData.HasHidden  = true;
+    gp.NextItemData.Hidden     = hidden;
+    gp.NextItemData.HiddenCond = cond;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Plot Tools
+//-----------------------------------------------------------------------------
+
+void Annotation(double x, double y, const ImVec4& col, const ImVec2& offset, bool clamp, bool round) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "Annotation() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    char x_buff[IMPLOT_LABEL_MAX_SIZE];
+    char y_buff[IMPLOT_LABEL_MAX_SIZE];
+    ImPlotAxis& x_axis = gp.CurrentPlot->Axes[gp.CurrentPlot->CurrentX];
+    ImPlotAxis& y_axis = gp.CurrentPlot->Axes[gp.CurrentPlot->CurrentY];
+    LabelAxisValue(x_axis, x, x_buff, sizeof(x_buff), round);
+    LabelAxisValue(y_axis, y, y_buff, sizeof(y_buff), round);
+    Annotation(x,y,col,offset,clamp,"%s, %s",x_buff,y_buff);
+}
+
+void AnnotationV(double x, double y, const ImVec4& col, const ImVec2& offset, bool clamp, const char* fmt, va_list args) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "Annotation() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    ImVec2 pos = PlotToPixels(x,y,IMPLOT_AUTO,IMPLOT_AUTO);
+    ImU32  bg  = ImGui::GetColorU32(col);
+    ImU32  fg  = col.w == 0 ? GetStyleColorU32(ImPlotCol_InlayText) : CalcTextColor(col);
+    gp.Annotations.AppendV(pos, offset, bg, fg, clamp, fmt, args);
+}
+
+void Annotation(double x, double y, const ImVec4& col, const ImVec2& offset, bool clamp, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    AnnotationV(x,y,col,offset,clamp,fmt,args);
+    va_end(args);
+}
+
+void TagV(ImAxis axis, double v, const ImVec4& col, const char* fmt, va_list args) {
+    ImPlotContext& gp = *GImPlot;
+    SetupLock();
+    ImU32 bg = ImGui::GetColorU32(col);
+    ImU32 fg = col.w == 0 ? GetStyleColorU32(ImPlotCol_AxisText) : CalcTextColor(col);
+    gp.Tags.AppendV(axis,v,bg,fg,fmt,args);
+}
+
+void Tag(ImAxis axis, double v, const ImVec4& col, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    TagV(axis,v,col,fmt,args);
+    va_end(args);
+}
+
+void Tag(ImAxis axis, double v, const ImVec4& color, bool round) {
+    ImPlotContext& gp = *GImPlot;
+    SetupLock();
+    char buff[IMPLOT_LABEL_MAX_SIZE];
+    ImPlotAxis& ax = gp.CurrentPlot->Axes[axis];
+    LabelAxisValue(ax, v, buff, sizeof(buff), round);
+    Tag(axis,v,color,"%s",buff);
+}
+
+IMPLOT_API void TagX(double x, const ImVec4& color, bool round) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagX() needs to be called between BeginPlot() and EndPlot()!");
+    Tag(GImPlot->CurrentPlot->CurrentX, x, color, round);
+}
+
+IMPLOT_API void TagX(double x, const ImVec4& color, const char* fmt, ...) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagX() needs to be called between BeginPlot() and EndPlot()!");
+    va_list args;
+    va_start(args, fmt);
+    TagV(GImPlot->CurrentPlot->CurrentX,x,color,fmt,args);
+    va_end(args);
+}
+
+IMPLOT_API void TagXV(double x, const ImVec4& color, const char* fmt, va_list args) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagX() needs to be called between BeginPlot() and EndPlot()!");
+    TagV(GImPlot->CurrentPlot->CurrentX, x, color, fmt, args);
+}
+
+IMPLOT_API void TagY(double y, const ImVec4& color, bool round) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagY() needs to be called between BeginPlot() and EndPlot()!");
+    Tag(GImPlot->CurrentPlot->CurrentY, y, color, round);
+}
+
+IMPLOT_API void TagY(double y, const ImVec4& color, const char* fmt, ...) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagY() needs to be called between BeginPlot() and EndPlot()!");
+    va_list args;
+    va_start(args, fmt);
+    TagV(GImPlot->CurrentPlot->CurrentY,y,color,fmt,args);
+    va_end(args);
+}
+
+IMPLOT_API void TagYV(double y, const ImVec4& color, const char* fmt, va_list args) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagY() needs to be called between BeginPlot() and EndPlot()!");
+    TagV(GImPlot->CurrentPlot->CurrentY, y, color, fmt, args);
+}
+
+static const float DRAG_GRAB_HALF_SIZE = 4.0f;
+
+bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, ImPlotDragToolFlags flags) {
+    ImGui::PushID("#IMPLOT_DRAG_POINT");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "DragPoint() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+
+    if (!ImHasFlag(flags,ImPlotDragToolFlags_NoFit) && FitThisFrame()) {
+        FitPoint(ImPlotPoint(*x,*y));
+    }
+
+    const bool input = !ImHasFlag(flags, ImPlotDragToolFlags_NoInputs);
+    const bool show_curs = !ImHasFlag(flags, ImPlotDragToolFlags_NoCursors);
+    const bool no_delay = !ImHasFlag(flags, ImPlotDragToolFlags_Delayed);
+    const float grab_half_size = ImMax(DRAG_GRAB_HALF_SIZE, radius);
+    const ImVec4 color = IsColorAuto(col) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : col;
+    const ImU32 col32 = ImGui::ColorConvertFloat4ToU32(color);
+
+    ImVec2 pos = PlotToPixels(*x,*y,IMPLOT_AUTO,IMPLOT_AUTO);
+    const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
+    ImRect rect(pos.x-grab_half_size,pos.y-grab_half_size,pos.x+grab_half_size,pos.y+grab_half_size);
+    bool hovered = false, held = false;
+
+    ImGui::KeepAliveID(id);
+    if (input)
+        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+
+    bool dragging = false;
+    if (held && ImGui::IsMouseDragging(0)) {
+        *x = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
+        *y = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
+        dragging = true;
+    }
+
+    PushPlotClipRect();
+    ImDrawList& DrawList = *GetPlotDrawList();
+    if ((hovered || held) && show_curs)
+        ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+    if (dragging && no_delay)
+        pos = PlotToPixels(*x,*y,IMPLOT_AUTO,IMPLOT_AUTO);
+    DrawList.AddCircleFilled(pos, radius, col32);
+    PopPlotClipRect();
+
+    ImGui::PopID();
+    return dragging;
+}
+
+bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags) {
+    // ImGui::PushID("#IMPLOT_DRAG_LINE_X");
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "DragLineX() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+
+    if (!ImHasFlag(flags,ImPlotDragToolFlags_NoFit) && FitThisFrame()) {
+        FitPointX(*value);
+    }
+
+    const bool input = !ImHasFlag(flags, ImPlotDragToolFlags_NoInputs);
+    const bool show_curs = !ImHasFlag(flags, ImPlotDragToolFlags_NoCursors);
+    const bool no_delay = !ImHasFlag(flags, ImPlotDragToolFlags_Delayed);
+    const float grab_half_size = ImMax(DRAG_GRAB_HALF_SIZE, thickness/2);
+    float yt = gp.CurrentPlot->PlotRect.Min.y;
+    float yb = gp.CurrentPlot->PlotRect.Max.y;
+    float x  = IM_ROUND(PlotToPixels(*value,0,IMPLOT_AUTO,IMPLOT_AUTO).x);
+    const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
+    ImRect rect(x-grab_half_size,yt,x+grab_half_size,yb);
+    bool hovered = false, held = false;
+
+    ImGui::KeepAliveID(id);
+    if (input)
+        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+
+    if ((hovered || held) && show_curs)
+        ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+
+    float len = gp.Style.MajorTickLen.x;
+    ImVec4 color = IsColorAuto(col) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : col;
+    ImU32 col32 = ImGui::ColorConvertFloat4ToU32(color);
+
+    bool dragging = false;
+    if (held && ImGui::IsMouseDragging(0)) {
+        *value = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
+        dragging = true;
+    }
+
+    PushPlotClipRect();
+    ImDrawList& DrawList = *GetPlotDrawList();
+    if (dragging && no_delay)
+        x  = IM_ROUND(PlotToPixels(*value,0,IMPLOT_AUTO,IMPLOT_AUTO).x);
+    DrawList.AddLine(ImVec2(x,yt), ImVec2(x,yb),     col32,   thickness);
+    DrawList.AddLine(ImVec2(x,yt), ImVec2(x,yt+len), col32, 3*thickness);
+    DrawList.AddLine(ImVec2(x,yb), ImVec2(x,yb-len), col32, 3*thickness);
+    PopPlotClipRect();
+
+    // ImGui::PopID();
+    return dragging;
+}
+
+bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags) {
+    ImGui::PushID("#IMPLOT_DRAG_LINE_Y");
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "DragLineY() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+
+    if (!ImHasFlag(flags,ImPlotDragToolFlags_NoFit) && FitThisFrame()) {
+        FitPointY(*value);
+    }
+
+    const bool input = !ImHasFlag(flags, ImPlotDragToolFlags_NoInputs);
+    const bool show_curs = !ImHasFlag(flags, ImPlotDragToolFlags_NoCursors);
+    const bool no_delay = !ImHasFlag(flags, ImPlotDragToolFlags_Delayed);
+    const float grab_half_size = ImMax(DRAG_GRAB_HALF_SIZE, thickness/2);
+    float xl = gp.CurrentPlot->PlotRect.Min.x;
+    float xr = gp.CurrentPlot->PlotRect.Max.x;
+    float y  = IM_ROUND(PlotToPixels(0, *value,IMPLOT_AUTO,IMPLOT_AUTO).y);
+
+    const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
+    ImRect rect(xl,y-grab_half_size,xr,y+grab_half_size);
+    bool hovered = false, held = false;
+
+    ImGui::KeepAliveID(id);
+    if (input)
+        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+
+    if ((hovered || held) && show_curs)
+        ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
+
+    float len = gp.Style.MajorTickLen.y;
+    ImVec4 color = IsColorAuto(col) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : col;
+    ImU32 col32 = ImGui::ColorConvertFloat4ToU32(color);
+
+    bool dragging = false;
+    if (held && ImGui::IsMouseDragging(0)) {
+        *value = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
+        dragging = true;
+    }
+
+    PushPlotClipRect();
+    ImDrawList& DrawList = *GetPlotDrawList();
+    if (dragging && no_delay)
+        y  = IM_ROUND(PlotToPixels(0, *value,IMPLOT_AUTO,IMPLOT_AUTO).y);
+    DrawList.AddLine(ImVec2(xl,y), ImVec2(xr,y),     col32,   thickness);
+    DrawList.AddLine(ImVec2(xl,y), ImVec2(xl+len,y), col32, 3*thickness);
+    DrawList.AddLine(ImVec2(xr,y), ImVec2(xr-len,y), col32, 3*thickness);
+    PopPlotClipRect();
+
+    ImGui::PopID();
+    return dragging;
+}
+
+bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_max, const ImVec4& col, ImPlotDragToolFlags flags) {
+    ImGui::PushID("#IMPLOT_DRAG_RECT");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "DragRect() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+
+    if (!ImHasFlag(flags,ImPlotDragToolFlags_NoFit) && FitThisFrame()) {
+        FitPoint(ImPlotPoint(*x_min,*y_min));
+        FitPoint(ImPlotPoint(*x_max,*y_max));
+    }
+
+    const bool input = !ImHasFlag(flags, ImPlotDragToolFlags_NoInputs);
+    const bool show_curs = !ImHasFlag(flags, ImPlotDragToolFlags_NoCursors);
+    const bool no_delay = !ImHasFlag(flags, ImPlotDragToolFlags_Delayed);
+    bool    h[] = {true,false,true,false};
+    double* x[] = {x_min,x_max,x_max,x_min};
+    double* y[] = {y_min,y_min,y_max,y_max};
+    ImVec2 p[4];
+    for (int i = 0; i < 4; ++i)
+        p[i] = PlotToPixels(*x[i],*y[i],IMPLOT_AUTO,IMPLOT_AUTO);
+    ImVec2 pc = PlotToPixels((*x_min+*x_max)/2,(*y_min+*y_max)/2,IMPLOT_AUTO,IMPLOT_AUTO);
+    ImRect rect(ImMin(p[0],p[2]),ImMax(p[0],p[2]));
+    ImRect rect_grab = rect; rect_grab.Expand(DRAG_GRAB_HALF_SIZE);
+
+    ImGuiMouseCursor cur[4];
+    if (show_curs) {
+        cur[0] = (rect.Min.x == p[0].x && rect.Min.y == p[0].y) || (rect.Max.x == p[0].x && rect.Max.y == p[0].y) ? ImGuiMouseCursor_ResizeNWSE : ImGuiMouseCursor_ResizeNESW;
+        cur[1] = cur[0] == ImGuiMouseCursor_ResizeNWSE ? ImGuiMouseCursor_ResizeNESW : ImGuiMouseCursor_ResizeNWSE;
+        cur[2] = cur[1] == ImGuiMouseCursor_ResizeNWSE ? ImGuiMouseCursor_ResizeNESW : ImGuiMouseCursor_ResizeNWSE;
+        cur[3] = cur[2] == ImGuiMouseCursor_ResizeNWSE ? ImGuiMouseCursor_ResizeNESW : ImGuiMouseCursor_ResizeNWSE;
+    }
+
+    ImVec4 color = IsColorAuto(col) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : col;
+    ImU32 col32 = ImGui::ColorConvertFloat4ToU32(color);
+    color.w *= 0.25f;
+    ImU32 col32_a = ImGui::ColorConvertFloat4ToU32(color);
+    const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
+
+    bool dragging = false;
+    bool hovered = false, held = false;
+    ImRect b_rect(pc.x-DRAG_GRAB_HALF_SIZE,pc.y-DRAG_GRAB_HALF_SIZE,pc.x+DRAG_GRAB_HALF_SIZE,pc.y+DRAG_GRAB_HALF_SIZE);
+
+    ImGui::KeepAliveID(id);
+    if (input)
+        ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
+
+    if ((hovered || held) && show_curs)
+        ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
+    if (held && ImGui::IsMouseDragging(0)) {
+        for (int i = 0; i < 4; ++i) {
+            ImPlotPoint pp = PixelsToPlot(p[i] + ImGui::GetIO().MouseDelta,IMPLOT_AUTO,IMPLOT_AUTO);
+            *y[i] = pp.y;
+            *x[i] = pp.x;
+        }
+        dragging = true;
+    }
+
+    for (int i = 0; i < 4; ++i) {
+        // points
+        b_rect = ImRect(p[i].x-DRAG_GRAB_HALF_SIZE,p[i].y-DRAG_GRAB_HALF_SIZE,p[i].x+DRAG_GRAB_HALF_SIZE,p[i].y+DRAG_GRAB_HALF_SIZE);
+        ImGuiID p_id = id + i + 1;
+        ImGui::KeepAliveID(p_id);
+        if (input)
+            ImGui::ButtonBehavior(b_rect,p_id,&hovered,&held);
+        if ((hovered || held) && show_curs)
+            ImGui::SetMouseCursor(cur[i]);
+
+        if (held && ImGui::IsMouseDragging(0)) {
+            *x[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
+            *y[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
+            dragging = true;
+        }
+
+        // edges
+        ImVec2 e_min = ImMin(p[i],p[(i+1)%4]);
+        ImVec2 e_max = ImMax(p[i],p[(i+1)%4]);
+        b_rect = h[i] ? ImRect(e_min.x + DRAG_GRAB_HALF_SIZE, e_min.y - DRAG_GRAB_HALF_SIZE, e_max.x - DRAG_GRAB_HALF_SIZE, e_max.y + DRAG_GRAB_HALF_SIZE)
+                    : ImRect(e_min.x - DRAG_GRAB_HALF_SIZE, e_min.y + DRAG_GRAB_HALF_SIZE, e_max.x + DRAG_GRAB_HALF_SIZE, e_max.y - DRAG_GRAB_HALF_SIZE);
+        ImGuiID e_id = id + i + 5;
+        ImGui::KeepAliveID(e_id);
+        if (input)
+            ImGui::ButtonBehavior(b_rect,e_id,&hovered,&held);
+        if ((hovered || held) && show_curs)
+            h[i] ? ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS) : ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+        if (held && ImGui::IsMouseDragging(0)) {
+            if (h[i])
+                *y[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
+            else
+                *x[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
+            dragging = true;
+        }
+        if (hovered && ImGui::IsMouseDoubleClicked(0))
+        {
+            ImPlotRect b = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO);
+            if (h[i])
+                *y[i] = ((y[i] == y_min && *y_min < *y_max) || (y[i] == y_max && *y_max < *y_min)) ? b.Y.Min : b.Y.Max;
+            else
+                *x[i] = ((x[i] == x_min && *x_min < *x_max) || (x[i] == x_max && *x_max < *x_min)) ? b.X.Min : b.X.Max;
+            dragging = true;
+        }
+    }
+
+
+    PushPlotClipRect();
+    ImDrawList& DrawList = *GetPlotDrawList();
+    if (dragging && no_delay) {
+        for (int i = 0; i < 4; ++i)
+            p[i] = PlotToPixels(*x[i],*y[i],IMPLOT_AUTO,IMPLOT_AUTO);
+        pc = PlotToPixels((*x_min+*x_max)/2,(*y_min+*y_max)/2,IMPLOT_AUTO,IMPLOT_AUTO);
+        rect = ImRect(ImMin(p[0],p[2]),ImMax(p[0],p[2]));
+    }
+    DrawList.AddRectFilled(rect.Min, rect.Max, col32_a);
+    DrawList.AddRect(rect.Min, rect.Max, col32);
+    if (input && (dragging || rect_grab.Contains(ImGui::GetMousePos()))) {
+        DrawList.AddCircleFilled(pc,DRAG_GRAB_HALF_SIZE,col32);
+        for (int i = 0; i < 4; ++i)
+            DrawList.AddCircleFilled(p[i],DRAG_GRAB_HALF_SIZE,col32);
+    }
+    PopPlotClipRect();
+    ImGui::PopID();
+    return dragging;
+}
+
+bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags flags) {
+    return DragRect(id, &bounds->X.Min, &bounds->Y.Min,&bounds->X.Max, &bounds->Y.Max, col, flags);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Legend Utils and Tools
+//-----------------------------------------------------------------------------
+
+bool IsLegendEntryHovered(const char* label_id) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != NULL, "IsPlotItemHighlight() needs to be called within an itemized context!");
+    SetupLock();
+    ImGuiID id = ImGui::GetIDWithSeed(label_id, NULL, gp.CurrentItems->ID);
+    ImPlotItem* item = gp.CurrentItems->GetItem(id);
+    return item && item->LegendHovered;
+}
+
+bool BeginLegendPopup(const char* label_id, ImGuiMouseButton mouse_button) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != NULL, "BeginLegendPopup() needs to be called within an itemized context!");
+    SetupLock();
+    ImGuiWindow* window = GImGui->CurrentWindow;
+    if (window->SkipItems)
+        return false;
+    ImGuiID id = ImGui::GetIDWithSeed(label_id, NULL, gp.CurrentItems->ID);
+    if (ImGui::IsMouseReleased(mouse_button)) {
+        ImPlotItem* item = gp.CurrentItems->GetItem(id);
+        if (item && item->LegendHovered)
+            ImGui::OpenPopupEx(id);
+    }
+    return ImGui::BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
+}
+
+void EndLegendPopup() {
+    SetupLock();
+    ImGui::EndPopup();
+}
+
+void ShowAltLegend(const char* title_id, bool vertical, const ImVec2 size, bool interactable) {
+    ImPlotContext& gp    = *GImPlot;
+    ImGuiContext &G      = *GImGui;
+    ImGuiWindow * Window = G.CurrentWindow;
+    if (Window->SkipItems)
+        return;
+    ImDrawList &DrawList = *Window->DrawList;
+    ImPlotPlot* plot = GetPlot(title_id);
+    ImVec2 legend_size;
+    ImVec2 default_size = gp.Style.LegendPadding * 2;
+    if (plot != NULL) {
+        legend_size  = CalcLegendSize(plot->Items, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, vertical);
+        default_size = legend_size + gp.Style.LegendPadding * 2;
+    }
+    ImVec2 frame_size = ImGui::CalcItemSize(size, default_size.x, default_size.y);
+    ImRect bb_frame = ImRect(Window->DC.CursorPos, Window->DC.CursorPos + frame_size);
+    ImGui::ItemSize(bb_frame);
+    if (!ImGui::ItemAdd(bb_frame, 0, &bb_frame))
+        return;
+    ImGui::RenderFrame(bb_frame.Min, bb_frame.Max, GetStyleColorU32(ImPlotCol_FrameBg), true, G.Style.FrameRounding);
+    DrawList.PushClipRect(bb_frame.Min, bb_frame.Max, true);
+    if (plot != NULL) {
+        const ImVec2 legend_pos  = GetLocationPos(bb_frame, legend_size, 0, gp.Style.LegendPadding);
+        const ImRect legend_bb(legend_pos, legend_pos + legend_size);
+        interactable = interactable && bb_frame.Contains(ImGui::GetIO().MousePos);
+        // render legend box
+        ImU32  col_bg      = GetStyleColorU32(ImPlotCol_LegendBg);
+        ImU32  col_bd      = GetStyleColorU32(ImPlotCol_LegendBorder);
+        DrawList.AddRectFilled(legend_bb.Min, legend_bb.Max, col_bg);
+        DrawList.AddRect(legend_bb.Min, legend_bb.Max, col_bd);
+        // render entries
+        ShowLegendEntries(plot->Items, legend_bb, interactable, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, vertical, DrawList);
+    }
+    DrawList.PopClipRect();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Drag and Drop Utils
+//-----------------------------------------------------------------------------
+
+bool BeginDragDropTargetPlot() {
+    SetupLock();
+    ImRect rect = GImPlot->CurrentPlot->PlotRect;
+    return ImGui::BeginDragDropTargetCustom(rect, GImPlot->CurrentPlot->ID);
+}
+
+bool BeginDragDropTargetAxis(ImAxis axis) {
+    SetupLock();
+    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotAxis& ax = plot.Axes[axis];
+    ImRect rect = ax.HoverRect;
+    rect.Expand(-3.5f);
+    return ImGui::BeginDragDropTargetCustom(rect, ax.ID);
+}
+
+bool BeginDragDropTargetLegend() {
+    SetupLock();
+    ImPlotItemGroup& items = *GImPlot->CurrentItems;
+    ImRect rect = items.Legend.Rect;
+    return ImGui::BeginDragDropTargetCustom(rect, items.ID);
+}
+
+void EndDragDropTarget() {
+    SetupLock();
+	ImGui::EndDragDropTarget();
+}
+
+bool BeginDragDropSourcePlot(ImGuiDragDropFlags flags) {
+    SetupLock();
+    ImPlotPlot* plot = GImPlot->CurrentPlot;
+    if (GImGui->IO.KeyMods == GImPlot->InputMap.OverrideMod || GImGui->DragDropPayload.SourceId == plot->ID)
+        return ImGui::ItemAdd(plot->PlotRect, plot->ID) && ImGui::BeginDragDropSource(flags);
+    return false;
+}
+
+bool BeginDragDropSourceAxis(ImAxis idx, ImGuiDragDropFlags flags) {
+    SetupLock();
+    ImPlotAxis& axis = GImPlot->CurrentPlot->Axes[idx];
+    if (GImGui->IO.KeyMods == GImPlot->InputMap.OverrideMod || GImGui->DragDropPayload.SourceId == axis.ID)
+        return ImGui::ItemAdd(axis.HoverRect, axis.ID) && ImGui::BeginDragDropSource(flags);
+    return false;
+}
+
+bool BeginDragDropSourceItem(const char* label_id, ImGuiDragDropFlags flags) {
+    SetupLock();
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != NULL, "BeginDragDropSourceItem() needs to be called within an itemized context!");
+    ImGuiID item_id = ImGui::GetIDWithSeed(label_id, NULL, gp.CurrentItems->ID);
+    ImPlotItem* item = gp.CurrentItems->GetItem(item_id);
+    if (item != NULL) {
+        return ImGui::ItemAdd(item->LegendHoverRect, item->ID) && ImGui::BeginDragDropSource(flags);
+    }
+    return false;
+}
+
+void EndDragDropSource() {
+    SetupLock();
+    ImGui::EndDragDropSource();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Aligned Plots
+//-----------------------------------------------------------------------------
+
+bool BeginAlignedPlots(const char* group_id, bool vertical) {
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentAlignmentH == NULL && GImPlot->CurrentAlignmentV == NULL, "Mismatched BeginAlignedPlots()/EndAlignedPlots()!");
+    ImPlotContext& gp = *GImPlot;
+    ImGuiContext &G = *GImGui;
+    ImGuiWindow * Window = G.CurrentWindow;
+    if (Window->SkipItems)
+        return false;
+    const ImGuiID ID = Window->GetID(group_id);
+    ImPlotAlignmentData* alignment = gp.AlignmentData.GetOrAddByKey(ID);
+    if (vertical)
+        gp.CurrentAlignmentV = alignment;
+    else
+        gp.CurrentAlignmentH = alignment;
+    if (alignment->Vertical != vertical)
+        alignment->Reset();
+    alignment->Vertical = vertical;
+    alignment->Begin();
+    return true;
+}
+
+void EndAlignedPlots() {
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentAlignmentH != NULL || GImPlot->CurrentAlignmentV != NULL, "Mismatched BeginAlignedPlots()/EndAlignedPlots()!");
+    ImPlotContext& gp = *GImPlot;
+    ImPlotAlignmentData* alignment = gp.CurrentAlignmentH != NULL ? gp.CurrentAlignmentH : (gp.CurrentAlignmentV != NULL ? gp.CurrentAlignmentV : NULL);
+    if (alignment)
+        alignment->End();
+    ResetCtxForNextAlignedPlots(GImPlot);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Plot and Item Styling
+//-----------------------------------------------------------------------------
+
+ImPlotStyle& GetStyle() {
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    ImPlotContext& gp = *GImPlot;
+    return gp.Style;
+}
+
+void PushStyleColor(ImPlotCol idx, ImU32 col) {
+    ImPlotContext& gp = *GImPlot;
+    ImGuiColorMod backup;
+    backup.Col = idx;
+    backup.BackupValue = gp.Style.Colors[idx];
+    gp.ColorModifiers.push_back(backup);
+    gp.Style.Colors[idx] = ImGui::ColorConvertU32ToFloat4(col);
+}
+
+void PushStyleColor(ImPlotCol idx, const ImVec4& col) {
+    ImPlotContext& gp = *GImPlot;
+    ImGuiColorMod backup;
+    backup.Col = idx;
+    backup.BackupValue = gp.Style.Colors[idx];
+    gp.ColorModifiers.push_back(backup);
+    gp.Style.Colors[idx] = col;
+}
+
+void PopStyleColor(int count) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(count <= gp.ColorModifiers.Size, "You can't pop more modifiers than have been pushed!");
+    while (count > 0)
+    {
+        ImGuiColorMod& backup = gp.ColorModifiers.back();
+        gp.Style.Colors[backup.Col] = backup.BackupValue;
+        gp.ColorModifiers.pop_back();
+        count--;
+    }
+}
+
+void PushStyleVar(ImPlotStyleVar idx, float val) {
+    ImPlotContext& gp = *GImPlot;
+    const ImPlotStyleVarInfo* var_info = GetPlotStyleVarInfo(idx);
+    if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1) {
+        float* pvar = (float*)var_info->GetVarPtr(&gp.Style);
+        gp.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        *pvar = val;
+        return;
+    }
+    IM_ASSERT(0 && "Called PushStyleVar() float variant but variable is not a float!");
+}
+
+void PushStyleVar(ImPlotStyleVar idx, int val) {
+    ImPlotContext& gp = *GImPlot;
+    const ImPlotStyleVarInfo* var_info = GetPlotStyleVarInfo(idx);
+    if (var_info->Type == ImGuiDataType_S32 && var_info->Count == 1) {
+        int* pvar = (int*)var_info->GetVarPtr(&gp.Style);
+        gp.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        *pvar = val;
+        return;
+    }
+    else if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1) {
+        float* pvar = (float*)var_info->GetVarPtr(&gp.Style);
+        gp.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        *pvar = (float)val;
+        return;
+    }
+    IM_ASSERT(0 && "Called PushStyleVar() int variant but variable is not a int!");
+}
+
+void PushStyleVar(ImGuiStyleVar idx, const ImVec2& val)
+{
+    ImPlotContext& gp = *GImPlot;
+    const ImPlotStyleVarInfo* var_info = GetPlotStyleVarInfo(idx);
+    if (var_info->Type == ImGuiDataType_Float && var_info->Count == 2)
+    {
+        ImVec2* pvar = (ImVec2*)var_info->GetVarPtr(&gp.Style);
+        gp.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        *pvar = val;
+        return;
+    }
+    IM_ASSERT(0 && "Called PushStyleVar() ImVec2 variant but variable is not a ImVec2!");
+}
+
+void PopStyleVar(int count) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(count <= gp.StyleModifiers.Size, "You can't pop more modifiers than have been pushed!");
+    while (count > 0) {
+        ImGuiStyleMod& backup = gp.StyleModifiers.back();
+        const ImPlotStyleVarInfo* info = GetPlotStyleVarInfo(backup.VarIdx);
+        void* data = info->GetVarPtr(&gp.Style);
+        if (info->Type == ImGuiDataType_Float && info->Count == 1) {
+            ((float*)data)[0] = backup.BackupFloat[0];
+        }
+        else if (info->Type == ImGuiDataType_Float && info->Count == 2) {
+             ((float*)data)[0] = backup.BackupFloat[0];
+             ((float*)data)[1] = backup.BackupFloat[1];
+        }
+        else if (info->Type == ImGuiDataType_S32 && info->Count == 1) {
+            ((int*)data)[0] = backup.BackupInt[0];
+        }
+        gp.StyleModifiers.pop_back();
+        count--;
+    }
+}
+
+//------------------------------------------------------------------------------
+// [Section] Colormaps
+//------------------------------------------------------------------------------
+
+ImPlotColormap AddColormap(const char* name, const ImVec4* colormap, int size, bool qual) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(size > 1, "The colormap size must be greater than 1!");
+    IM_ASSERT_USER_ERROR(gp.ColormapData.GetIndex(name) == -1, "The colormap name has already been used!");
+    ImVector<ImU32> buffer;
+    buffer.resize(size);
+    for (int i = 0; i < size; ++i)
+        buffer[i] = ImGui::ColorConvertFloat4ToU32(colormap[i]);
+    return gp.ColormapData.Append(name, buffer.Data, size, qual);
+}
+
+ImPlotColormap AddColormap(const char* name, const ImU32*  colormap, int size, bool qual) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(size > 1, "The colormap size must be greater than 1!");
+    IM_ASSERT_USER_ERROR(gp.ColormapData.GetIndex(name) == -1, "The colormap name has already be used!");
+    return gp.ColormapData.Append(name, colormap, size, qual);
+}
+
+int GetColormapCount() {
+    ImPlotContext& gp = *GImPlot;
+    return gp.ColormapData.Count;
+}
+
+const char* GetColormapName(ImPlotColormap colormap) {
+    ImPlotContext& gp = *GImPlot;
+    return gp.ColormapData.GetName(colormap);
+}
+
+ImPlotColormap GetColormapIndex(const char* name) {
+    ImPlotContext& gp = *GImPlot;
+    return gp.ColormapData.GetIndex(name);
+}
+
+void PushColormap(ImPlotColormap colormap) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(colormap >= 0 && colormap < gp.ColormapData.Count, "The colormap index is invalid!");
+    gp.ColormapModifiers.push_back(gp.Style.Colormap);
+    gp.Style.Colormap = colormap;
+}
+
+void PushColormap(const char* name) {
+    ImPlotContext& gp = *GImPlot;
+    ImPlotColormap idx = gp.ColormapData.GetIndex(name);
+    IM_ASSERT_USER_ERROR(idx != -1, "The colormap name is invalid!");
+    PushColormap(idx);
+}
+
+void PopColormap(int count) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(count <= gp.ColormapModifiers.Size, "You can't pop more modifiers than have been pushed!");
+    while (count > 0) {
+        const ImPlotColormap& backup = gp.ColormapModifiers.back();
+        gp.Style.Colormap     = backup;
+        gp.ColormapModifiers.pop_back();
+        count--;
+    }
+}
+
+ImU32 NextColormapColorU32() {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != NULL, "NextColormapColor() needs to be called between BeginPlot() and EndPlot()!");
+    int idx = gp.CurrentItems->ColormapIdx % gp.ColormapData.GetKeyCount(gp.Style.Colormap);
+    ImU32 col  = gp.ColormapData.GetKeyColor(gp.Style.Colormap, idx);
+    gp.CurrentItems->ColormapIdx++;
+    return col;
+}
+
+ImVec4 NextColormapColor() {
+    return ImGui::ColorConvertU32ToFloat4(NextColormapColorU32());
+}
+
+int GetColormapSize(ImPlotColormap cmap) {
+    ImPlotContext& gp = *GImPlot;
+    cmap = cmap == IMPLOT_AUTO ? gp.Style.Colormap : cmap;
+    IM_ASSERT_USER_ERROR(cmap >= 0 && cmap < gp.ColormapData.Count, "Invalid colormap index!");
+    return gp.ColormapData.GetKeyCount(cmap);
+}
+
+ImU32 GetColormapColorU32(int idx, ImPlotColormap cmap) {
+    ImPlotContext& gp = *GImPlot;
+    cmap = cmap == IMPLOT_AUTO ? gp.Style.Colormap : cmap;
+    IM_ASSERT_USER_ERROR(cmap >= 0 && cmap < gp.ColormapData.Count, "Invalid colormap index!");
+    idx = idx % gp.ColormapData.GetKeyCount(cmap);
+    return gp.ColormapData.GetKeyColor(cmap, idx);
+}
+
+ImVec4 GetColormapColor(int idx, ImPlotColormap cmap) {
+    return ImGui::ColorConvertU32ToFloat4(GetColormapColorU32(idx,cmap));
+}
+
+ImU32  SampleColormapU32(float t, ImPlotColormap cmap) {
+    ImPlotContext& gp = *GImPlot;
+    cmap = cmap == IMPLOT_AUTO ? gp.Style.Colormap : cmap;
+    IM_ASSERT_USER_ERROR(cmap >= 0 && cmap < gp.ColormapData.Count, "Invalid colormap index!");
+    return gp.ColormapData.LerpTable(cmap, t);
+}
+
+ImVec4 SampleColormap(float t, ImPlotColormap cmap) {
+    return ImGui::ColorConvertU32ToFloat4(SampleColormapU32(t,cmap));
+}
+
+void RenderColorBar(const ImU32* colors, int size, ImDrawList& DrawList, const ImRect& bounds, bool vert, bool reversed, bool continuous) {
+    const int n = continuous ? size - 1 : size;
+    ImU32 col1, col2;
+    if (vert) {
+        const float step = bounds.GetHeight() / n;
+        ImRect rect(bounds.Min.x, bounds.Min.y, bounds.Max.x, bounds.Min.y + step);
+        for (int i = 0; i < n; ++i) {
+            if (reversed) {
+                col1 = colors[size-i-1];
+                col2 = continuous ? colors[size-i-2] : col1;
+            }
+            else {
+                col1 = colors[i];
+                col2 = continuous ? colors[i+1] : col1;
+            }
+            DrawList.AddRectFilledMultiColor(rect.Min, rect.Max, col1, col1, col2, col2);
+            rect.TranslateY(step);
+        }
+    }
+    else {
+        const float step = bounds.GetWidth() / n;
+        ImRect rect(bounds.Min.x, bounds.Min.y, bounds.Min.x + step, bounds.Max.y);
+        for (int i = 0; i < n; ++i) {
+            if (reversed) {
+                col1 = colors[size-i-1];
+                col2 = continuous ? colors[size-i-2] : col1;
+            }
+            else {
+                col1 = colors[i];
+                col2 = continuous ? colors[i+1] : col1;
+            }
+            DrawList.AddRectFilledMultiColor(rect.Min, rect.Max, col1, col2, col2, col1);
+            rect.TranslateX(step);
+        }
+    }
+}
+
+void ColormapScale(const char* label, double scale_min, double scale_max, const ImVec2& size, const char* format, ImPlotColormapScaleFlags flags, ImPlotColormap cmap) {
+    ImGuiContext &G      = *GImGui;
+    ImGuiWindow * Window = G.CurrentWindow;
+    if (Window->SkipItems)
+        return;
+
+    const ImGuiID ID = Window->GetID(label);
+    ImVec2 label_size(0,0);
+    if (!ImHasFlag(flags, ImPlotColormapScaleFlags_NoLabel)) {
+        label_size = ImGui::CalcTextSize(label,NULL,true);
+    }
+
+    ImPlotContext& gp = *GImPlot;
+    cmap = cmap == IMPLOT_AUTO ? gp.Style.Colormap : cmap;
+    IM_ASSERT_USER_ERROR(cmap >= 0 && cmap < gp.ColormapData.Count, "Invalid colormap index!");
+
+    ImVec2 frame_size  = ImGui::CalcItemSize(size, 0, gp.Style.PlotDefaultSize.y);
+    if (frame_size.y < gp.Style.PlotMinSize.y && size.y < 0.0f)
+        frame_size.y = gp.Style.PlotMinSize.y;
+
+    ImPlotRange range(ImMin(scale_min,scale_max), ImMax(scale_min,scale_max));
+    gp.CTicker.Reset();
+    Locator_Default(gp.CTicker, range, frame_size.y, true, Formatter_Default, (void*)format);
+
+    const bool rend_label = label_size.x > 0;
+    const float txt_off   = gp.Style.LabelPadding.x;
+    const float pad       = txt_off + gp.CTicker.MaxSize.x + (rend_label ? txt_off + label_size.y : 0);
+    float bar_w           = 20;
+    if (frame_size.x == 0)
+        frame_size.x = bar_w + pad + 2 * gp.Style.PlotPadding.x;
+    else {
+        bar_w = frame_size.x - (pad + 2 * gp.Style.PlotPadding.x);
+        if (bar_w < gp.Style.MajorTickLen.y)
+            bar_w = gp.Style.MajorTickLen.y;
+    }
+
+    ImDrawList &DrawList = *Window->DrawList;
+    ImRect bb_frame = ImRect(Window->DC.CursorPos, Window->DC.CursorPos + frame_size);
+    ImGui::ItemSize(bb_frame);
+    if (!ImGui::ItemAdd(bb_frame, ID, &bb_frame))
+        return;
+
+    ImGui::RenderFrame(bb_frame.Min, bb_frame.Max, GetStyleColorU32(ImPlotCol_FrameBg), true, G.Style.FrameRounding);
+
+    const bool opposite = ImHasFlag(flags, ImPlotColormapScaleFlags_Opposite);
+    const bool inverted = ImHasFlag(flags, ImPlotColormapScaleFlags_Invert);
+    const bool reversed = scale_min > scale_max;
+
+    float bb_grad_shift = opposite ? pad : 0;
+    ImRect bb_grad(bb_frame.Min + gp.Style.PlotPadding + ImVec2(bb_grad_shift, 0),
+                   bb_frame.Min + ImVec2(bar_w + gp.Style.PlotPadding.x + bb_grad_shift,
+                                         frame_size.y - gp.Style.PlotPadding.y));
+
+    ImGui::PushClipRect(bb_frame.Min, bb_frame.Max, true);
+    const ImU32 col_text = ImGui::GetColorU32(ImGuiCol_Text);
+
+    const bool invert_scale = inverted ? (reversed ? false : true) : (reversed ? true : false);
+    const float y_min = invert_scale ? bb_grad.Max.y : bb_grad.Min.y;
+    const float y_max = invert_scale ? bb_grad.Min.y : bb_grad.Max.y;
+
+    RenderColorBar(gp.ColormapData.GetKeys(cmap), gp.ColormapData.GetKeyCount(cmap), DrawList, bb_grad, true, !inverted, !gp.ColormapData.IsQual(cmap));
+    for (int i = 0; i < gp.CTicker.TickCount(); ++i) {
+        const double y_pos_plt = gp.CTicker.Ticks[i].PlotPos;
+        const float y_pos = ImRemap((float)y_pos_plt, (float)range.Max, (float)range.Min, y_min, y_max);
+        const float tick_width = gp.CTicker.Ticks[i].Major ? gp.Style.MajorTickLen.y : gp.Style.MinorTickLen.y;
+        const float tick_thick = gp.CTicker.Ticks[i].Major ? gp.Style.MajorTickSize.y : gp.Style.MinorTickSize.y;
+        const float tick_t     = (float)((y_pos_plt - scale_min) / (scale_max - scale_min));
+        const ImU32 tick_col = CalcTextColor(GImPlot->ColormapData.LerpTable(cmap,tick_t));
+        if (y_pos < bb_grad.Max.y - 2 && y_pos > bb_grad.Min.y + 2) {
+            DrawList.AddLine(opposite ? ImVec2(bb_grad.Min.x+1, y_pos) : ImVec2(bb_grad.Max.x-1, y_pos),
+                             opposite ? ImVec2(bb_grad.Min.x + tick_width, y_pos) : ImVec2(bb_grad.Max.x - tick_width, y_pos),
+                             tick_col,
+                             tick_thick);
+        }
+        const float txt_x = opposite ? bb_grad.Min.x - txt_off - gp.CTicker.Ticks[i].LabelSize.x : bb_grad.Max.x + txt_off;
+        const float txt_y = y_pos - gp.CTicker.Ticks[i].LabelSize.y * 0.5f;
+        DrawList.AddText(ImVec2(txt_x, txt_y), col_text, gp.CTicker.GetText(i));
+    }
+
+    if (rend_label) {
+        const float pos_x = opposite ? bb_frame.Min.x + gp.Style.PlotPadding.x : bb_grad.Max.x + 2 * txt_off + gp.CTicker.MaxSize.x;
+        const float pos_y = bb_grad.GetCenter().y + label_size.x * 0.5f;
+        const char* label_end = ImGui::FindRenderedTextEnd(label);
+        AddTextVertical(&DrawList,ImVec2(pos_x,pos_y),col_text,label,label_end);
+    }
+    DrawList.AddRect(bb_grad.Min, bb_grad.Max, GetStyleColorU32(ImPlotCol_PlotBorder));
+    ImGui::PopClipRect();
+}
+
+bool ColormapSlider(const char* label, float* t, ImVec4* out, const char* format, ImPlotColormap cmap) {
+    *t = ImClamp(*t,0.0f,1.0f);
+    ImGuiContext &G      = *GImGui;
+    ImGuiWindow * Window = G.CurrentWindow;
+    if (Window->SkipItems)
+        return false;
+    ImPlotContext& gp = *GImPlot;
+    cmap = cmap == IMPLOT_AUTO ? gp.Style.Colormap : cmap;
+    IM_ASSERT_USER_ERROR(cmap >= 0 && cmap < gp.ColormapData.Count, "Invalid colormap index!");
+    const ImU32* keys  = GImPlot->ColormapData.GetKeys(cmap);
+    const int    count = GImPlot->ColormapData.GetKeyCount(cmap);
+    const bool   qual  = GImPlot->ColormapData.IsQual(cmap);
+    const ImVec2 pos  = ImGui::GetCurrentWindow()->DC.CursorPos;
+    const float w     = ImGui::CalcItemWidth();
+    const float h     = ImGui::GetFrameHeight();
+    const ImRect rect = ImRect(pos.x,pos.y,pos.x+w,pos.y+h);
+    RenderColorBar(keys,count,*ImGui::GetWindowDrawList(),rect,false,false,!qual);
+    const ImU32 grab = CalcTextColor(GImPlot->ColormapData.LerpTable(cmap,*t));
+    // const ImU32 text = CalcTextColor(GImPlot->ColormapData.LerpTable(cmap,0.5f));
+    ImGui::PushStyleColor(ImGuiCol_FrameBg,IM_COL32_BLACK_TRANS);
+    ImGui::PushStyleColor(ImGuiCol_FrameBgActive,IM_COL32_BLACK_TRANS);
+    ImGui::PushStyleColor(ImGuiCol_FrameBgHovered,ImVec4(1,1,1,0.1f));
+    ImGui::PushStyleColor(ImGuiCol_SliderGrab,grab);
+    ImGui::PushStyleColor(ImGuiCol_SliderGrabActive, grab);
+    ImGui::PushStyleVar(ImGuiStyleVar_GrabMinSize,2);
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,0);
+    const bool changed = ImGui::SliderFloat(label,t,0,1,format);
+    ImGui::PopStyleColor(5);
+    ImGui::PopStyleVar(2);
+    if (out != NULL)
+        *out = ImGui::ColorConvertU32ToFloat4(GImPlot->ColormapData.LerpTable(cmap,*t));
+    return changed;
+}
+
+bool ColormapButton(const char* label, const ImVec2& size_arg, ImPlotColormap cmap) {
+    ImGuiContext &G      = *GImGui;
+    const ImGuiStyle& style = G.Style;
+    ImGuiWindow * Window = G.CurrentWindow;
+    if (Window->SkipItems)
+        return false;
+    ImPlotContext& gp = *GImPlot;
+    cmap = cmap == IMPLOT_AUTO ? gp.Style.Colormap : cmap;
+    IM_ASSERT_USER_ERROR(cmap >= 0 && cmap < gp.ColormapData.Count, "Invalid colormap index!");
+    const ImU32* keys  = GImPlot->ColormapData.GetKeys(cmap);
+    const int    count = GImPlot->ColormapData.GetKeyCount(cmap);
+    const bool   qual  = GImPlot->ColormapData.IsQual(cmap);
+    const ImVec2 pos  = ImGui::GetCurrentWindow()->DC.CursorPos;
+    const ImVec2 label_size = ImGui::CalcTextSize(label, NULL, true);
+    ImVec2 size = ImGui::CalcItemSize(size_arg, label_size.x + style.FramePadding.x * 2.0f, label_size.y + style.FramePadding.y * 2.0f);
+    const ImRect rect = ImRect(pos.x,pos.y,pos.x+size.x,pos.y+size.y);
+    RenderColorBar(keys,count,*ImGui::GetWindowDrawList(),rect,false,false,!qual);
+    const ImU32 text = CalcTextColor(GImPlot->ColormapData.LerpTable(cmap,G.Style.ButtonTextAlign.x));
+    ImGui::PushStyleColor(ImGuiCol_Button,IM_COL32_BLACK_TRANS);
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered,ImVec4(1,1,1,0.1f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,ImVec4(1,1,1,0.2f));
+    ImGui::PushStyleColor(ImGuiCol_Text,text);
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,0);
+    const bool pressed = ImGui::Button(label,size);
+    ImGui::PopStyleColor(4);
+    ImGui::PopStyleVar(1);
+    return pressed;
+}
+
+//-----------------------------------------------------------------------------
+// [Section] Miscellaneous
+//-----------------------------------------------------------------------------
+
+ImPlotInputMap& GetInputMap() {
+    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    ImPlotContext& gp = *GImPlot;
+    return gp.InputMap;
+}
+
+void MapInputDefault(ImPlotInputMap* dst) {
+    ImPlotInputMap& map = dst ? *dst : GetInputMap();
+    map.Pan             = ImGuiMouseButton_Left;
+    map.PanMod          = ImGuiModFlags_None;
+    map.Fit             = ImGuiMouseButton_Left;
+    map.Menu            = ImGuiMouseButton_Right;
+    map.Select          = ImGuiMouseButton_Right;
+    map.SelectMod       = ImGuiModFlags_None;
+    map.SelectCancel    = ImGuiMouseButton_Left;
+    map.SelectHorzMod   = ImGuiModFlags_Alt;
+    map.SelectVertMod   = ImGuiModFlags_Shift;
+    map.OverrideMod     = ImGuiModFlags_Ctrl;
+    map.ZoomMod         = ImGuiModFlags_None;
+    map.ZoomRate        = 0.1f;
+}
+
+void MapInputReverse(ImPlotInputMap* dst) {
+    ImPlotInputMap& map = dst ? *dst : GetInputMap();
+    map.Pan             = ImGuiMouseButton_Right;
+    map.PanMod          = ImGuiModFlags_None;
+    map.Fit             = ImGuiMouseButton_Left;
+    map.Menu            = ImGuiMouseButton_Right;
+    map.Select          = ImGuiMouseButton_Left;
+    map.SelectMod       = ImGuiModFlags_None;
+    map.SelectCancel    = ImGuiMouseButton_Right;
+    map.SelectHorzMod   = ImGuiModFlags_Alt;
+    map.SelectVertMod   = ImGuiModFlags_Shift;
+    map.OverrideMod     = ImGuiModFlags_Ctrl;
+    map.ZoomMod         = ImGuiModFlags_None;
+    map.ZoomRate        = 0.1f;
+}
+
+//-----------------------------------------------------------------------------
+// [Section] Miscellaneous
+//-----------------------------------------------------------------------------
+
+void ItemIcon(const ImVec4& col) {
+    ItemIcon(ImGui::ColorConvertFloat4ToU32(col));
+}
+
+void ItemIcon(ImU32 col) {
+    const float txt_size = ImGui::GetTextLineHeight();
+    ImVec2 size(txt_size-4,txt_size);
+    ImGuiWindow* window = ImGui::GetCurrentWindow();
+    ImVec2 pos = window->DC.CursorPos;
+    ImGui::GetWindowDrawList()->AddRectFilled(pos + ImVec2(0,2), pos + size - ImVec2(0,2), col);
+    ImGui::Dummy(size);
+}
+
+void ColormapIcon(ImPlotColormap cmap) {
+    ImPlotContext& gp = *GImPlot;
+    const float txt_size = ImGui::GetTextLineHeight();
+    ImVec2 size(txt_size-4,txt_size);
+    ImGuiWindow* window = ImGui::GetCurrentWindow();
+    ImVec2 pos = window->DC.CursorPos;
+    ImRect rect(pos+ImVec2(0,2),pos+size-ImVec2(0,2));
+    ImDrawList& DrawList = *ImGui::GetWindowDrawList();
+    RenderColorBar(gp.ColormapData.GetKeys(cmap),gp.ColormapData.GetKeyCount(cmap),DrawList,rect,false,false,!gp.ColormapData.IsQual(cmap));
+    ImGui::Dummy(size);
+}
+
+ImDrawList* GetPlotDrawList() {
+    return ImGui::GetWindowDrawList();
+}
+
+void PushPlotClipRect(float expand) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "PushPlotClipRect() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    ImRect rect = gp.CurrentPlot->PlotRect;
+    rect.Expand(expand);
+    ImGui::PushClipRect(rect.Min, rect.Max, true);
+}
+
+void PopPlotClipRect() {
+    SetupLock();
+    ImGui::PopClipRect();
+}
+
+static void HelpMarker(const char* desc) {
+    ImGui::TextDisabled("(?)");
+    if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+        ImGui::TextUnformatted(desc);
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
+}
+
+bool ShowStyleSelector(const char* label)
+{
+    static int style_idx = -1;
+    if (ImGui::Combo(label, &style_idx, "Auto\0Classic\0Dark\0Light\0"))
+    {
+        switch (style_idx)
+        {
+        case 0: StyleColorsAuto(); break;
+        case 1: StyleColorsClassic(); break;
+        case 2: StyleColorsDark(); break;
+        case 3: StyleColorsLight(); break;
+        }
+        return true;
+    }
+    return false;
+}
+
+bool ShowColormapSelector(const char* label) {
+    ImPlotContext& gp = *GImPlot;
+    bool set = false;
+    if (ImGui::BeginCombo(label, gp.ColormapData.GetName(gp.Style.Colormap))) {
+        for (int i = 0; i < gp.ColormapData.Count; ++i) {
+            const char* name = gp.ColormapData.GetName(i);
+            if (ImGui::Selectable(name, gp.Style.Colormap == i)) {
+                gp.Style.Colormap = i;
+                ImPlot::BustItemCache();
+                set = true;
+            }
+        }
+        ImGui::EndCombo();
+    }
+    return set;
+}
+
+bool ShowInputMapSelector(const char* label) {
+    static int map_idx = -1;
+    if (ImGui::Combo(label, &map_idx, "Default\0Reversed\0"))
+    {
+        switch (map_idx)
+        {
+        case 0: MapInputDefault(); break;
+        case 1: MapInputReverse(); break;
+        }
+        return true;
+    }
+    return false;
+}
+
+
+void ShowStyleEditor(ImPlotStyle* ref) {
+    ImPlotContext& gp = *GImPlot;
+    ImPlotStyle& style = GetStyle();
+    static ImPlotStyle ref_saved_style;
+    // Default to using internal storage as reference
+    static bool init = true;
+    if (init && ref == NULL)
+        ref_saved_style = style;
+    init = false;
+    if (ref == NULL)
+        ref = &ref_saved_style;
+
+    if (ImPlot::ShowStyleSelector("Colors##Selector"))
+        ref_saved_style = style;
+
+    // Save/Revert button
+    if (ImGui::Button("Save Ref"))
+        *ref = ref_saved_style = style;
+    ImGui::SameLine();
+    if (ImGui::Button("Revert Ref"))
+        style = *ref;
+    ImGui::SameLine();
+    HelpMarker("Save/Revert in local non-persistent storage. Default Colors definition are not affected. "
+               "Use \"Export\" below to save them somewhere.");
+    if (ImGui::BeginTabBar("##StyleEditor")) {
+        if (ImGui::BeginTabItem("Variables")) {
+            ImGui::Text("Item Styling");
+            ImGui::SliderFloat("LineWeight", &style.LineWeight, 0.0f, 5.0f, "%.1f");
+            ImGui::SliderFloat("MarkerSize", &style.MarkerSize, 2.0f, 10.0f, "%.1f");
+            ImGui::SliderFloat("MarkerWeight", &style.MarkerWeight, 0.0f, 5.0f, "%.1f");
+            ImGui::SliderFloat("FillAlpha", &style.FillAlpha, 0.0f, 1.0f, "%.2f");
+            ImGui::SliderFloat("ErrorBarSize", &style.ErrorBarSize, 0.0f, 10.0f, "%.1f");
+            ImGui::SliderFloat("ErrorBarWeight", &style.ErrorBarWeight, 0.0f, 5.0f, "%.1f");
+            ImGui::SliderFloat("DigitalBitHeight", &style.DigitalBitHeight, 0.0f, 20.0f, "%.1f");
+            ImGui::SliderFloat("DigitalBitGap", &style.DigitalBitGap, 0.0f, 20.0f, "%.1f");
+            ImGui::Text("Plot Styling");
+            ImGui::SliderFloat("PlotBorderSize", &style.PlotBorderSize, 0.0f, 2.0f, "%.0f");
+            ImGui::SliderFloat("MinorAlpha", &style.MinorAlpha, 0.0f, 1.0f, "%.2f");
+            ImGui::SliderFloat2("MajorTickLen", (float*)&style.MajorTickLen, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("MinorTickLen", (float*)&style.MinorTickLen, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("MajorTickSize",  (float*)&style.MajorTickSize, 0.0f, 2.0f, "%.1f");
+            ImGui::SliderFloat2("MinorTickSize", (float*)&style.MinorTickSize, 0.0f, 2.0f, "%.1f");
+            ImGui::SliderFloat2("MajorGridSize", (float*)&style.MajorGridSize, 0.0f, 2.0f, "%.1f");
+            ImGui::SliderFloat2("MinorGridSize", (float*)&style.MinorGridSize, 0.0f, 2.0f, "%.1f");
+            ImGui::SliderFloat2("PlotDefaultSize", (float*)&style.PlotDefaultSize, 0.0f, 1000, "%.0f");
+            ImGui::SliderFloat2("PlotMinSize", (float*)&style.PlotMinSize, 0.0f, 300, "%.0f");
+            ImGui::Text("Plot Padding");
+            ImGui::SliderFloat2("PlotPadding", (float*)&style.PlotPadding, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("LabelPadding", (float*)&style.LabelPadding, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("LegendPadding", (float*)&style.LegendPadding, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("LegendInnerPadding", (float*)&style.LegendInnerPadding, 0.0f, 10.0f, "%.0f");
+            ImGui::SliderFloat2("LegendSpacing", (float*)&style.LegendSpacing, 0.0f, 5.0f, "%.0f");
+            ImGui::SliderFloat2("MousePosPadding", (float*)&style.MousePosPadding, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("AnnotationPadding", (float*)&style.AnnotationPadding, 0.0f, 5.0f, "%.0f");
+            ImGui::SliderFloat2("FitPadding", (float*)&style.FitPadding, 0, 0.2f, "%.2f");
+
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Colors")) {
+            static int output_dest = 0;
+            static bool output_only_modified = false;
+
+            if (ImGui::Button("Export", ImVec2(75,0))) {
+                if (output_dest == 0)
+                    ImGui::LogToClipboard();
+                else
+                    ImGui::LogToTTY();
+                ImGui::LogText("ImVec4* colors = ImPlot::GetStyle().Colors;\n");
+                for (int i = 0; i < ImPlotCol_COUNT; i++) {
+                    const ImVec4& col = style.Colors[i];
+                    const char* name = ImPlot::GetStyleColorName(i);
+                    if (!output_only_modified || memcmp(&col, &ref->Colors[i], sizeof(ImVec4)) != 0) {
+                        if (IsColorAuto(i))
+                            ImGui::LogText("colors[ImPlotCol_%s]%*s= IMPLOT_AUTO_COL;\n",name,14 - (int)strlen(name), "");
+                        else
+                            ImGui::LogText("colors[ImPlotCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, %.2ff);\n",
+                                        name, 14 - (int)strlen(name), "", col.x, col.y, col.z, col.w);
+                    }
+                }
+                ImGui::LogFinish();
+            }
+            ImGui::SameLine(); ImGui::SetNextItemWidth(120); ImGui::Combo("##output_type", &output_dest, "To Clipboard\0To TTY\0");
+            ImGui::SameLine(); ImGui::Checkbox("Only Modified Colors", &output_only_modified);
+
+            static ImGuiTextFilter filter;
+            filter.Draw("Filter colors", ImGui::GetFontSize() * 16);
+
+            static ImGuiColorEditFlags alpha_flags = ImGuiColorEditFlags_AlphaPreviewHalf;
+            if (ImGui::RadioButton("Opaque", alpha_flags == ImGuiColorEditFlags_None))             { alpha_flags = ImGuiColorEditFlags_None; } ImGui::SameLine();
+            if (ImGui::RadioButton("Alpha",  alpha_flags == ImGuiColorEditFlags_AlphaPreview))     { alpha_flags = ImGuiColorEditFlags_AlphaPreview; } ImGui::SameLine();
+            if (ImGui::RadioButton("Both",   alpha_flags == ImGuiColorEditFlags_AlphaPreviewHalf)) { alpha_flags = ImGuiColorEditFlags_AlphaPreviewHalf; } ImGui::SameLine();
+            HelpMarker(
+                "In the color list:\n"
+                "Left-click on colored square to open color picker,\n"
+                "Right-click to open edit options menu.");
+            ImGui::Separator();
+            ImGui::PushItemWidth(-160);
+            for (int i = 0; i < ImPlotCol_COUNT; i++) {
+                const char* name = ImPlot::GetStyleColorName(i);
+                if (!filter.PassFilter(name))
+                    continue;
+                ImGui::PushID(i);
+                ImVec4 temp = GetStyleColorVec4(i);
+                const bool is_auto = IsColorAuto(i);
+                if (!is_auto)
+                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.25f);
+                if (ImGui::Button("Auto")) {
+                    if (is_auto)
+                        style.Colors[i] = temp;
+                    else
+                        style.Colors[i] = IMPLOT_AUTO_COL;
+                    BustItemCache();
+                }
+                if (!is_auto)
+                    ImGui::PopStyleVar();
+                ImGui::SameLine();
+                if (ImGui::ColorEdit4(name, &temp.x, ImGuiColorEditFlags_NoInputs | alpha_flags)) {
+                    style.Colors[i] = temp;
+                    BustItemCache();
+                }
+                if (memcmp(&style.Colors[i], &ref->Colors[i], sizeof(ImVec4)) != 0) {
+                    ImGui::SameLine(175); if (ImGui::Button("Save")) { ref->Colors[i] = style.Colors[i]; }
+                    ImGui::SameLine(); if (ImGui::Button("Revert")) {
+                        style.Colors[i] = ref->Colors[i];
+                        BustItemCache();
+                    }
+                }
+                ImGui::PopID();
+            }
+            ImGui::PopItemWidth();
+            ImGui::Separator();
+            ImGui::Text("Colors that are set to Auto (i.e. IMPLOT_AUTO_COL) will\n"
+                        "be automatically deduced from your ImGui style or the\n"
+                        "current ImPlot Colormap. If you want to style individual\n"
+                        "plot items, use Push/PopStyleColor around its function.");
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Colormaps")) {
+            static int output_dest = 0;
+            if (ImGui::Button("Export", ImVec2(75,0))) {
+                if (output_dest == 0)
+                    ImGui::LogToClipboard();
+                else
+                    ImGui::LogToTTY();
+                int size = GetColormapSize();
+                const char* name = GetColormapName(gp.Style.Colormap);
+                ImGui::LogText("static const ImU32 %s_Data[%d] = {\n", name, size);
+                for (int i = 0; i < size; ++i) {
+                    ImU32 col = GetColormapColorU32(i,gp.Style.Colormap);
+                    ImGui::LogText("    %u%s\n", col, i == size - 1 ? "" : ",");
+                }
+                ImGui::LogText("};\nImPlotColormap %s = ImPlot::AddColormap(\"%s\", %s_Data, %d);", name, name, name, size);
+                ImGui::LogFinish();
+            }
+            ImGui::SameLine(); ImGui::SetNextItemWidth(120); ImGui::Combo("##output_type", &output_dest, "To Clipboard\0To TTY\0");
+            ImGui::SameLine();
+            static bool edit = false;
+            ImGui::Checkbox("Edit Mode",&edit);
+
+            // built-in/added
+            ImGui::Separator();
+            for (int i = 0; i < gp.ColormapData.Count; ++i) {
+                ImGui::PushID(i);
+                int size = gp.ColormapData.GetKeyCount(i);
+                bool selected = i == gp.Style.Colormap;
+
+                const char* name = GetColormapName(i);
+                if (!selected)
+                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.25f);
+                if (ImGui::Button(name, ImVec2(100,0))) {
+                    gp.Style.Colormap = i;
+                    BustItemCache();
+                }
+                if (!selected)
+                    ImGui::PopStyleVar();
+                ImGui::SameLine();
+                ImGui::BeginGroup();
+                if (edit) {
+                    for (int c = 0; c < size; ++c) {
+                        ImGui::PushID(c);
+                        ImVec4 col4 = ImGui::ColorConvertU32ToFloat4(gp.ColormapData.GetKeyColor(i,c));
+                        if (ImGui::ColorEdit4("",&col4.x,ImGuiColorEditFlags_NoInputs)) {
+                            ImU32 col32 = ImGui::ColorConvertFloat4ToU32(col4);
+                            gp.ColormapData.SetKeyColor(i,c,col32);
+                            BustItemCache();
+                        }
+                        if ((c + 1) % 12 != 0 && c != size -1)
+                            ImGui::SameLine();
+                        ImGui::PopID();
+                    }
+                }
+                else {
+                    if (ImPlot::ColormapButton("##",ImVec2(-1,0),i))
+                        edit = true;
+                }
+                ImGui::EndGroup();
+                ImGui::PopID();
+            }
+
+
+            static ImVector<ImVec4> custom;
+            if (custom.Size == 0) {
+                custom.push_back(ImVec4(1,0,0,1));
+                custom.push_back(ImVec4(0,1,0,1));
+                custom.push_back(ImVec4(0,0,1,1));
+            }
+            ImGui::Separator();
+            ImGui::BeginGroup();
+            static char name[16] = "MyColormap";
+
+
+            if (ImGui::Button("+", ImVec2((100 - ImGui::GetStyle().ItemSpacing.x)/2,0)))
+                custom.push_back(ImVec4(0,0,0,1));
+            ImGui::SameLine();
+            if (ImGui::Button("-", ImVec2((100 - ImGui::GetStyle().ItemSpacing.x)/2,0)) && custom.Size > 2)
+                custom.pop_back();
+            ImGui::SetNextItemWidth(100);
+            ImGui::InputText("##Name",name,16,ImGuiInputTextFlags_CharsNoBlank);
+            static bool qual = true;
+            ImGui::Checkbox("Qualitative",&qual);
+            if (ImGui::Button("Add", ImVec2(100, 0)) && gp.ColormapData.GetIndex(name)==-1)
+                AddColormap(name,custom.Data,custom.Size,qual);
+
+            ImGui::EndGroup();
+            ImGui::SameLine();
+            ImGui::BeginGroup();
+            for (int c = 0; c < custom.Size; ++c) {
+                ImGui::PushID(c);
+                if (ImGui::ColorEdit4("##Col1", &custom[c].x, ImGuiColorEditFlags_NoInputs)) {
+
+                }
+                if ((c + 1) % 12 != 0)
+                    ImGui::SameLine();
+                ImGui::PopID();
+            }
+            ImGui::EndGroup();
+
+
+            ImGui::EndTabItem();
+        }
+        ImGui::EndTabBar();
+    }
+}
+
+void ShowUserGuide() {
+        ImGui::BulletText("Left-click drag within the plot area to pan X and Y axes.");
+    ImGui::Indent();
+        ImGui::BulletText("Left-click drag on axis labels to pan an individual axis.");
+    ImGui::Unindent();
+    ImGui::BulletText("Scroll in the plot area to zoom both X any Y axes.");
+    ImGui::Indent();
+        ImGui::BulletText("Scroll on axis labels to zoom an individual axis.");
+    ImGui::Unindent();
+    ImGui::BulletText("Right-click drag to box select data.");
+    ImGui::Indent();
+        ImGui::BulletText("Hold Alt to expand box selection horizontally.");
+        ImGui::BulletText("Hold Shift to expand box selection vertically.");
+        ImGui::BulletText("Left-click while box selecting to cancel the selection.");
+    ImGui::Unindent();
+    ImGui::BulletText("Double left-click to fit all visible data.");
+    ImGui::Indent();
+        ImGui::BulletText("Double left-click axis labels to fit the individual axis.");
+    ImGui::Unindent();
+    ImGui::BulletText("Right-click open the full plot context menu.");
+    ImGui::Indent();
+        ImGui::BulletText("Right-click axis labels to open an individual axis context menu.");
+    ImGui::Unindent();
+    ImGui::BulletText("Click legend label icons to show/hide plot items.");
+}
+
+void ShowTicksMetrics(const ImPlotTicker& ticker) {
+    ImGui::BulletText("Size: %d", ticker.TickCount());
+    ImGui::BulletText("MaxSize: [%f,%f]", ticker.MaxSize.x, ticker.MaxSize.y);
+}
+
+void ShowAxisMetrics(const ImPlotPlot& plot, const ImPlotAxis& axis) {
+    ImGui::BulletText("Label: %s", axis.LabelOffset == -1 ? "[none]" : plot.GetAxisLabel(axis));
+    ImGui::BulletText("Flags: 0x%08X", axis.Flags);
+    ImGui::BulletText("Range: [%f,%f]",axis.Range.Min, axis.Range.Max);
+    ImGui::BulletText("Pixels: %f", axis.PixelSize());
+    ImGui::BulletText("Aspect: %f", axis.GetAspect());
+    ImGui::BulletText(axis.OrthoAxis == NULL ? "OrtherAxis: NULL" : "OrthoAxis: 0x%08X", axis.OrthoAxis->ID);
+    ImGui::BulletText("LinkedMin: %p", (void*)axis.LinkedMin);
+    ImGui::BulletText("LinkedMax: %p", (void*)axis.LinkedMax);
+    ImGui::BulletText("HasRange: %s", axis.HasRange ? "true" : "false");
+    ImGui::BulletText("Hovered: %s", axis.Hovered ? "true" : "false");
+    ImGui::BulletText("Held: %s", axis.Held ? "true" : "false");
+
+    if (ImGui::TreeNode("Transform")) {
+        ImGui::BulletText("PixelMin: %f", axis.PixelMin);
+        ImGui::BulletText("PixelMax: %f", axis.PixelMax);
+        ImGui::BulletText("ScaleToPixel: %f", axis.ScaleToPixel);
+        ImGui::BulletText("ScaleMax: %f", axis.ScaleMax);
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Ticks")) {
+        ShowTicksMetrics(axis.Ticker);
+        ImGui::TreePop();
+    }
+}
+
+void ShowMetricsWindow(bool* p_popen) {
+
+    static bool show_plot_rects = false;
+    static bool show_axes_rects = false;
+    static bool show_axis_rects = false;
+    static bool show_canvas_rects = false;
+    static bool show_frame_rects = false;
+    static bool show_subplot_frame_rects = false;
+    static bool show_subplot_grid_rects = false;
+
+    ImDrawList& fg = *ImGui::GetForegroundDrawList();
+
+    ImPlotContext& gp = *GImPlot;
+    // ImGuiContext& g = *GImGui;
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui::Begin("ImPlot Metrics", p_popen);
+    ImGui::Text("ImPlot " IMPLOT_VERSION);
+    ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate, io.Framerate);
+    ImGui::Text("Mouse Position: [%.0f,%.0f]", io.MousePos.x, io.MousePos.y);
+    ImGui::Separator();
+    if (ImGui::TreeNode("Tools")) {
+        if (ImGui::Button("Bust Plot Cache"))
+            BustPlotCache();
+        ImGui::SameLine();
+        if (ImGui::Button("Bust Item Cache"))
+            BustItemCache();
+        ImGui::Checkbox("Show Frame Rects", &show_frame_rects);
+        ImGui::Checkbox("Show Canvas Rects",&show_canvas_rects);
+        ImGui::Checkbox("Show Plot Rects",  &show_plot_rects);
+        ImGui::Checkbox("Show Axes Rects",  &show_axes_rects);
+        ImGui::Checkbox("Show Axis Rects",  &show_axis_rects);
+        ImGui::Checkbox("Show Subplot Frame Rects",  &show_subplot_frame_rects);
+        ImGui::Checkbox("Show Subplot Grid Rects",  &show_subplot_grid_rects);
+        ImGui::TreePop();
+    }
+    const int n_plots = gp.Plots.GetBufSize();
+    const int n_subplots = gp.Subplots.GetBufSize();
+    // render rects
+    for (int p = 0; p < n_plots; ++p) {
+        ImPlotPlot* plot = gp.Plots.GetByIndex(p);
+        if (show_frame_rects)
+            fg.AddRect(plot->FrameRect.Min, plot->FrameRect.Max, IM_COL32(255,0,255,255));
+        if (show_canvas_rects)
+            fg.AddRect(plot->CanvasRect.Min, plot->CanvasRect.Max, IM_COL32(0,255,255,255));
+        if (show_plot_rects)
+            fg.AddRect(plot->PlotRect.Min, plot->PlotRect.Max, IM_COL32(255,255,0,255));
+        if (show_axes_rects)
+            fg.AddRect(plot->AxesRect.Min, plot->AxesRect.Max, IM_COL32(0,255,128,255));
+        if (show_axis_rects) {
+            for (int i = 0; i < ImAxis_COUNT; ++i) {
+                if (plot->Axes[i].Enabled)
+                    fg.AddRect(plot->Axes[i].HoverRect.Min, plot->Axes[i].HoverRect.Max, IM_COL32(0,255,0,255));
+            }
+        }
+    }
+    for (int p = 0; p < n_subplots; ++p) {
+        ImPlotSubplot* subplot = gp.Subplots.GetByIndex(p);
+        if (show_subplot_frame_rects)
+            fg.AddRect(subplot->FrameRect.Min, subplot->FrameRect.Max, IM_COL32(255,0,0,255));
+        if (show_subplot_grid_rects)
+            fg.AddRect(subplot->GridRect.Min, subplot->GridRect.Max, IM_COL32(0,0,255,255));
+    }
+    if (ImGui::TreeNode("Plots","Plots (%d)", n_plots)) {
+        for (int p = 0; p < n_plots; ++p) {
+            // plot
+            ImPlotPlot& plot = *gp.Plots.GetByIndex(p);
+            ImGui::PushID(p);
+            if (ImGui::TreeNode("Plot", "Plot [0x%08X]", plot.ID)) {
+                int n_items = plot.Items.GetItemCount();
+                if (ImGui::TreeNode("Items", "Items (%d)", n_items)) {
+                    for (int i = 0; i < n_items; ++i) {
+                        ImPlotItem* item = plot.Items.GetItemByIndex(i);
+                        ImGui::PushID(i);
+                        if (ImGui::TreeNode("Item", "Item [0x%08X]", item->ID)) {
+                            ImGui::Bullet(); ImGui::Checkbox("Show", &item->Show);
+                            ImGui::Bullet();
+                            ImVec4 temp = ImGui::ColorConvertU32ToFloat4(item->Color);
+                            if (ImGui::ColorEdit4("Color",&temp.x, ImGuiColorEditFlags_NoInputs))
+                                item->Color = ImGui::ColorConvertFloat4ToU32(temp);
+
+                            ImGui::BulletText("NameOffset: %d",item->NameOffset);
+                            ImGui::BulletText("Name: %s", item->NameOffset != -1 ? plot.Items.Legend.Labels.Buf.Data + item->NameOffset : "N/A");
+                            ImGui::BulletText("Hovered: %s",item->LegendHovered ? "true" : "false");
+                            ImGui::TreePop();
+                        }
+                        ImGui::PopID();
+                    }
+                    ImGui::TreePop();
+                }
+                char buff[16];
+                for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i) {
+                    ImFormatString(buff,16,"X-Axis %d", i+1);
+                    if (plot.XAxis(i).Enabled && ImGui::TreeNode(buff, "X-Axis %d [0x%08X]", i+1, plot.XAxis(i).ID)) {
+                        ShowAxisMetrics(plot, plot.XAxis(i));
+                        ImGui::TreePop();
+                    }
+                }
+                for (int i = 0; i < IMPLOT_NUM_Y_AXES; ++i) {
+                    ImFormatString(buff,16,"Y-Axis %d", i+1);
+                    if (plot.YAxis(i).Enabled && ImGui::TreeNode(buff, "Y-Axis %d [0x%08X]", i+1, plot.YAxis(i).ID)) {
+                        ShowAxisMetrics(plot, plot.YAxis(i));
+                        ImGui::TreePop();
+                    }
+                }
+                ImGui::BulletText("Title: %s", plot.HasTitle() ? plot.GetTitle() : "none");
+                ImGui::BulletText("Flags: 0x%08X", plot.Flags);
+                ImGui::BulletText("Initialized: %s", plot.Initialized ? "true" : "false");
+                ImGui::BulletText("Selecting: %s", plot.Selecting ? "true" : "false");
+                ImGui::BulletText("Selected: %s", plot.Selected ? "true" : "false");
+                ImGui::BulletText("Hovered: %s", plot.Hovered ? "true" : "false");
+                ImGui::BulletText("Held: %s", plot.Held ? "true" : "false");
+                ImGui::BulletText("LegendHovered: %s", plot.Items.Legend.Hovered ? "true" : "false");
+                ImGui::BulletText("ContextLocked: %s", plot.ContextLocked ? "true" : "false");
+                ImGui::TreePop();
+            }
+            ImGui::PopID();
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Subplots","Subplots (%d)", n_subplots)) {
+        for (int p = 0; p < n_subplots; ++p) {
+            // plot
+            ImPlotSubplot& plot = *gp.Subplots.GetByIndex(p);
+            ImGui::PushID(p);
+            if (ImGui::TreeNode("Subplot", "Subplot [0x%08X]", plot.ID)) {
+                int n_items = plot.Items.GetItemCount();
+                if (ImGui::TreeNode("Items", "Items (%d)", n_items)) {
+                    for (int i = 0; i < n_items; ++i) {
+                        ImPlotItem* item = plot.Items.GetItemByIndex(i);
+                        ImGui::PushID(i);
+                        if (ImGui::TreeNode("Item", "Item [0x%08X]", item->ID)) {
+                            ImGui::Bullet(); ImGui::Checkbox("Show", &item->Show);
+                            ImGui::Bullet();
+                            ImVec4 temp = ImGui::ColorConvertU32ToFloat4(item->Color);
+                            if (ImGui::ColorEdit4("Color",&temp.x, ImGuiColorEditFlags_NoInputs))
+                                item->Color = ImGui::ColorConvertFloat4ToU32(temp);
+
+                            ImGui::BulletText("NameOffset: %d",item->NameOffset);
+                            ImGui::BulletText("Name: %s", item->NameOffset != -1 ? plot.Items.Legend.Labels.Buf.Data + item->NameOffset : "N/A");
+                            ImGui::BulletText("Hovered: %s",item->LegendHovered ? "true" : "false");
+                            ImGui::TreePop();
+                        }
+                        ImGui::PopID();
+                    }
+                    ImGui::TreePop();
+                }
+                ImGui::BulletText("Flags: 0x%08X", plot.Flags);
+                ImGui::BulletText("FrameHovered: %s", plot.FrameHovered ? "true" : "false");
+                ImGui::BulletText("LegendHovered: %s", plot.Items.Legend.Hovered ? "true" : "false");
+                ImGui::TreePop();
+            }
+            ImGui::PopID();
+        }
+        ImGui::TreePop();
+    }
+    if (ImGui::TreeNode("Colormaps")) {
+        ImGui::BulletText("Colormaps:  %d", gp.ColormapData.Count);
+        ImGui::BulletText("Memory: %d bytes", gp.ColormapData.Tables.Size * 4);
+        if (ImGui::TreeNode("Data")) {
+            for (int m = 0; m < gp.ColormapData.Count; ++m) {
+                if (ImGui::TreeNode(gp.ColormapData.GetName(m))) {
+                    int count = gp.ColormapData.GetKeyCount(m);
+                    int size = gp.ColormapData.GetTableSize(m);
+                    bool qual = gp.ColormapData.IsQual(m);
+                    ImGui::BulletText("Qualitative: %s", qual ? "true" : "false");
+                    ImGui::BulletText("Key Count: %d", count);
+                    ImGui::BulletText("Table Size: %d", size);
+                    ImGui::Indent();
+
+                    static float t = 0.5;
+                    ImVec4 samp;
+                    float wid = 32 * 10 - ImGui::GetFrameHeight() - ImGui::GetStyle().ItemSpacing.x;
+                    ImGui::SetNextItemWidth(wid);
+                    ImPlot::ColormapSlider("##Sample",&t,&samp,"%.3f",m);
+                    ImGui::SameLine();
+                    ImGui::ColorButton("Sampler",samp);
+                    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0,0,0,0));
+                    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0,0));
+                    for (int c = 0; c < size; ++c) {
+                        ImVec4 col = ImGui::ColorConvertU32ToFloat4(gp.ColormapData.GetTableColor(m,c));
+                        ImGui::PushID(m*1000+c);
+                        ImGui::ColorButton("",col,0,ImVec2(10,10));
+                        ImGui::PopID();
+                        if ((c + 1) % 32 != 0 && c != size - 1)
+                            ImGui::SameLine();
+                    }
+                    ImGui::PopStyleVar();
+                    ImGui::PopStyleColor();
+                    ImGui::Unindent();
+                    ImGui::TreePop();
+                }
+            }
+            ImGui::TreePop();
+        }
+        ImGui::TreePop();
+    }
+    ImGui::End();
+}
+
+bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime* t1, const ImPlotTime* t2) {
+
+    ImGui::PushID(id);
+    ImGui::BeginGroup();
+
+    ImGuiStyle& style = ImGui::GetStyle();
+    ImVec4 col_txt    = style.Colors[ImGuiCol_Text];
+    ImVec4 col_dis    = style.Colors[ImGuiCol_TextDisabled];
+    ImVec4 col_btn    = style.Colors[ImGuiCol_Button];
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0,0,0,0));
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0,0));
+
+    const float ht    = ImGui::GetFrameHeight();
+    ImVec2 cell_size(ht*1.25f,ht);
+    char buff[32];
+    bool clk = false;
+    tm& Tm = GImPlot->Tm;
+
+    const int min_yr = 1970;
+    const int max_yr = 2999;
+
+    // t1 parts
+    int t1_mo = 0; int t1_md = 0; int t1_yr = 0;
+    if (t1 != NULL) {
+        GetTime(*t1,&Tm);
+        t1_mo = Tm.tm_mon;
+        t1_md = Tm.tm_mday;
+        t1_yr = Tm.tm_year + 1900;
+    }
+
+     // t2 parts
+    int t2_mo = 0; int t2_md = 0; int t2_yr = 0;
+    if (t2 != NULL) {
+        GetTime(*t2,&Tm);
+        t2_mo = Tm.tm_mon;
+        t2_md = Tm.tm_mday;
+        t2_yr = Tm.tm_year + 1900;
+    }
+
+    // day widget
+    if (*level == 0) {
+        *t = FloorTime(*t, ImPlotTimeUnit_Day);
+        GetTime(*t, &Tm);
+        const int this_year = Tm.tm_year + 1900;
+        const int last_year = this_year - 1;
+        const int next_year = this_year + 1;
+        const int this_mon  = Tm.tm_mon;
+        const int last_mon  = this_mon == 0 ? 11 : this_mon - 1;
+        const int next_mon  = this_mon == 11 ? 0 : this_mon + 1;
+        const int days_this_mo = GetDaysInMonth(this_year, this_mon);
+        const int days_last_mo = GetDaysInMonth(this_mon == 0 ? last_year : this_year, last_mon);
+        ImPlotTime t_first_mo = FloorTime(*t,ImPlotTimeUnit_Mo);
+        GetTime(t_first_mo,&Tm);
+        const int first_wd = Tm.tm_wday;
+        // month year
+        ImFormatString(buff, 32, "%s %d", MONTH_NAMES[this_mon], this_year);
+        if (ImGui::Button(buff))
+            *level = 1;
+        ImGui::SameLine(5*cell_size.x);
+        BeginDisabledControls(this_year <= min_yr && this_mon == 0);
+        if (ImGui::ArrowButtonEx("##Up",ImGuiDir_Up,cell_size))
+            *t = AddTime(*t, ImPlotTimeUnit_Mo, -1);
+        EndDisabledControls(this_year <= min_yr && this_mon == 0);
+        ImGui::SameLine();
+        BeginDisabledControls(this_year >= max_yr && this_mon == 11);
+        if (ImGui::ArrowButtonEx("##Down",ImGuiDir_Down,cell_size))
+            *t = AddTime(*t, ImPlotTimeUnit_Mo, 1);
+        EndDisabledControls(this_year >= max_yr && this_mon == 11);
+        // render weekday abbreviations
+        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+        for (int i = 0; i < 7; ++i) {
+            ImGui::Button(WD_ABRVS[i],cell_size);
+            if (i != 6) { ImGui::SameLine(); }
+        }
+        ImGui::PopItemFlag();
+        // 0 = last mo, 1 = this mo, 2 = next mo
+        int mo = first_wd > 0 ? 0 : 1;
+        int day = mo == 1 ? 1 : days_last_mo - first_wd + 1;
+        for (int i = 0; i < 6; ++i) {
+            for (int j = 0; j < 7; ++j) {
+                if (mo == 0 && day > days_last_mo) {
+                    mo = 1;
+                    day = 1;
+                }
+                else if (mo == 1 && day > days_this_mo) {
+                    mo = 2;
+                    day = 1;
+                }
+                const int now_yr = (mo == 0 && this_mon == 0) ? last_year : ((mo == 2 && this_mon == 11) ? next_year : this_year);
+                const int now_mo = mo == 0 ? last_mon : (mo == 1 ? this_mon : next_mon);
+                const int now_md = day;
+
+                const bool off_mo   = mo == 0 || mo == 2;
+                const bool t1_or_t2 = (t1 != NULL && t1_mo == now_mo && t1_yr == now_yr && t1_md == now_md) ||
+                                      (t2 != NULL && t2_mo == now_mo && t2_yr == now_yr && t2_md == now_md);
+
+                if (off_mo)
+                    ImGui::PushStyleColor(ImGuiCol_Text, col_dis);
+                if (t1_or_t2) {
+                    ImGui::PushStyleColor(ImGuiCol_Button, col_btn);
+                    ImGui::PushStyleColor(ImGuiCol_Text, col_txt);
+                }
+                ImGui::PushID(i*7+j);
+                ImFormatString(buff,32,"%d",day);
+                if (now_yr == min_yr-1 || now_yr == max_yr+1) {
+                    ImGui::Dummy(cell_size);
+                }
+                else if (ImGui::Button(buff,cell_size) && !clk) {
+                    *t = MakeTime(now_yr, now_mo, now_md);
+                    clk = true;
+                }
+                ImGui::PopID();
+                if (t1_or_t2)
+                    ImGui::PopStyleColor(2);
+                if (off_mo)
+                    ImGui::PopStyleColor();
+                if (j != 6)
+                    ImGui::SameLine();
+                day++;
+            }
+        }
+    }
+    // month widget
+    else if (*level == 1) {
+        *t = FloorTime(*t, ImPlotTimeUnit_Mo);
+        GetTime(*t, &Tm);
+        int this_yr  = Tm.tm_year + 1900;
+        ImFormatString(buff, 32, "%d", this_yr);
+        if (ImGui::Button(buff))
+            *level = 2;
+        BeginDisabledControls(this_yr <= min_yr);
+        ImGui::SameLine(5*cell_size.x);
+        if (ImGui::ArrowButtonEx("##Up",ImGuiDir_Up,cell_size))
+            *t = AddTime(*t, ImPlotTimeUnit_Yr, -1);
+        EndDisabledControls(this_yr <= min_yr);
+        ImGui::SameLine();
+        BeginDisabledControls(this_yr >= max_yr);
+        if (ImGui::ArrowButtonEx("##Down",ImGuiDir_Down,cell_size))
+            *t = AddTime(*t, ImPlotTimeUnit_Yr, 1);
+        EndDisabledControls(this_yr >= max_yr);
+        // ImGui::Dummy(cell_size);
+        cell_size.x *= 7.0f/4.0f;
+        cell_size.y *= 7.0f/3.0f;
+        int mo = 0;
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                const bool t1_or_t2 = (t1 != NULL && t1_yr == this_yr && t1_mo == mo) ||
+                                      (t2 != NULL && t2_yr == this_yr && t2_mo == mo);
+                if (t1_or_t2)
+                    ImGui::PushStyleColor(ImGuiCol_Button, col_btn);
+                if (ImGui::Button(MONTH_ABRVS[mo],cell_size) && !clk) {
+                    *t = MakeTime(this_yr, mo);
+                    *level = 0;
+                }
+                if (t1_or_t2)
+                    ImGui::PopStyleColor();
+                if (j != 3)
+                    ImGui::SameLine();
+                mo++;
+            }
+        }
+    }
+    else if (*level == 2) {
+        *t = FloorTime(*t, ImPlotTimeUnit_Yr);
+        int this_yr = GetYear(*t);
+        int yr = this_yr  - this_yr % 20;
+        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+        ImFormatString(buff,32,"%d-%d",yr,yr+19);
+        ImGui::Button(buff);
+        ImGui::PopItemFlag();
+        ImGui::SameLine(5*cell_size.x);
+        BeginDisabledControls(yr <= min_yr);
+        if (ImGui::ArrowButtonEx("##Up",ImGuiDir_Up,cell_size))
+            *t = MakeTime(yr-20);
+        EndDisabledControls(yr <= min_yr);
+        ImGui::SameLine();
+        BeginDisabledControls(yr + 20 >= max_yr);
+        if (ImGui::ArrowButtonEx("##Down",ImGuiDir_Down,cell_size))
+            *t = MakeTime(yr+20);
+        EndDisabledControls(yr+ 20 >= max_yr);
+        // ImGui::Dummy(cell_size);
+        cell_size.x *= 7.0f/4.0f;
+        cell_size.y *= 7.0f/5.0f;
+        for (int i = 0; i < 5; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                const bool t1_or_t2 = (t1 != NULL && t1_yr == yr) || (t2 != NULL && t2_yr == yr);
+                if (t1_or_t2)
+                    ImGui::PushStyleColor(ImGuiCol_Button, col_btn);
+                ImFormatString(buff,32,"%d",yr);
+                if (yr<1970||yr>3000) {
+                    ImGui::Dummy(cell_size);
+                }
+                else if (ImGui::Button(buff,cell_size)) {
+                    *t = MakeTime(yr);
+                    *level = 1;
+                }
+                if (t1_or_t2)
+                    ImGui::PopStyleColor();
+                if (j != 3)
+                    ImGui::SameLine();
+                yr++;
+            }
+        }
+    }
+    ImGui::PopStyleVar();
+    ImGui::PopStyleColor();
+    ImGui::EndGroup();
+    ImGui::PopID();
+    return clk;
+}
+
+bool ShowTimePicker(const char* id, ImPlotTime* t) {
+    ImGui::PushID(id);
+    tm& Tm = GImPlot->Tm;
+    GetTime(*t,&Tm);
+
+    static const char* nums[] = { "00","01","02","03","04","05","06","07","08","09",
+                                  "10","11","12","13","14","15","16","17","18","19",
+                                  "20","21","22","23","24","25","26","27","28","29",
+                                  "30","31","32","33","34","35","36","37","38","39",
+                                  "40","41","42","43","44","45","46","47","48","49",
+                                  "50","51","52","53","54","55","56","57","58","59"};
+
+    static const char* am_pm[] = {"am","pm"};
+
+    bool hour24 = GImPlot->Style.Use24HourClock;
+
+    int hr  = hour24 ? Tm.tm_hour : ((Tm.tm_hour == 0 || Tm.tm_hour == 12) ? 12 : Tm.tm_hour % 12);
+    int min = Tm.tm_min;
+    int sec = Tm.tm_sec;
+    int ap  = Tm.tm_hour < 12 ? 0 : 1;
+
+    bool changed = false;
+
+    ImVec2 spacing = ImGui::GetStyle().ItemSpacing;
+    spacing.x = 0;
+    float width    = ImGui::CalcTextSize("888").x;
+    float height   = ImGui::GetFrameHeight();
+
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, spacing);
+    ImGui::PushStyleVar(ImGuiStyleVar_ScrollbarSize,2.0f);
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0,0,0,0));
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0,0,0,0));
+    ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ImGui::GetStyleColorVec4(ImGuiCol_ButtonHovered));
+
+    ImGui::SetNextItemWidth(width);
+    if (ImGui::BeginCombo("##hr",nums[hr],ImGuiComboFlags_NoArrowButton)) {
+        const int ia = hour24 ? 0 : 1;
+        const int ib = hour24 ? 24 : 13;
+        for (int i = ia; i < ib; ++i) {
+            if (ImGui::Selectable(nums[i],i==hr)) {
+                hr = i;
+                changed = true;
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ImGui::SameLine();
+    ImGui::Text(":");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(width);
+    if (ImGui::BeginCombo("##min",nums[min],ImGuiComboFlags_NoArrowButton)) {
+        for (int i = 0; i < 60; ++i) {
+            if (ImGui::Selectable(nums[i],i==min)) {
+                min = i;
+                changed = true;
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ImGui::SameLine();
+    ImGui::Text(":");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(width);
+    if (ImGui::BeginCombo("##sec",nums[sec],ImGuiComboFlags_NoArrowButton)) {
+        for (int i = 0; i < 60; ++i) {
+            if (ImGui::Selectable(nums[i],i==sec)) {
+                sec = i;
+                changed = true;
+            }
+        }
+        ImGui::EndCombo();
+    }
+    if (!hour24) {
+        ImGui::SameLine();
+        if (ImGui::Button(am_pm[ap],ImVec2(0,height))) {
+            ap = 1 - ap;
+            changed = true;
+        }
+    }
+
+    ImGui::PopStyleColor(3);
+    ImGui::PopStyleVar(2);
+    ImGui::PopID();
+
+    if (changed) {
+        if (!hour24)
+            hr = hr % 12 + ap * 12;
+        Tm.tm_hour = hr;
+        Tm.tm_min  = min;
+        Tm.tm_sec  = sec;
+        *t = MkTime(&Tm);
+    }
+
+    return changed;
+}
+
+void StyleColorsAuto(ImPlotStyle* dst) {
+    ImPlotStyle* style              = dst ? dst : &ImPlot::GetStyle();
+    ImVec4* colors                  = style->Colors;
+
+    style->MinorAlpha               = 0.25f;
+
+    colors[ImPlotCol_Line]          = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_Fill]          = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_MarkerOutline] = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_MarkerFill]    = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_ErrorBar]      = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_FrameBg]       = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_PlotBg]        = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_PlotBorder]    = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_LegendBg]      = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_LegendBorder]  = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_LegendText]    = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_TitleText]     = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_InlayText]     = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_PlotBorder]    = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_AxisText]      = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_AxisGrid]      = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_AxisTick]      = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_AxisBg]        = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_AxisBgHovered] = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_AxisBgActive]  = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_Selection]     = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_Crosshairs]    = IMPLOT_AUTO_COL;
+}
+
+void StyleColorsClassic(ImPlotStyle* dst) {
+    ImPlotStyle* style              = dst ? dst : &ImPlot::GetStyle();
+    ImVec4* colors                  = style->Colors;
+
+    style->MinorAlpha               = 0.5f;
+
+    colors[ImPlotCol_Line]          = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_Fill]          = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_MarkerOutline] = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_MarkerFill]    = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_ErrorBar]      = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    colors[ImPlotCol_FrameBg]       = ImVec4(0.43f, 0.43f, 0.43f, 0.39f);
+    colors[ImPlotCol_PlotBg]        = ImVec4(0.00f, 0.00f, 0.00f, 0.35f);
+    colors[ImPlotCol_PlotBorder]    = ImVec4(0.50f, 0.50f, 0.50f, 0.50f);
+    colors[ImPlotCol_LegendBg]      = ImVec4(0.11f, 0.11f, 0.14f, 0.92f);
+    colors[ImPlotCol_LegendBorder]  = ImVec4(0.50f, 0.50f, 0.50f, 0.50f);
+    colors[ImPlotCol_LegendText]    = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    colors[ImPlotCol_TitleText]     = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    colors[ImPlotCol_InlayText]     = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    colors[ImPlotCol_AxisText]      = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    colors[ImPlotCol_AxisGrid]      = ImVec4(0.90f, 0.90f, 0.90f, 0.25f);
+    colors[ImPlotCol_AxisTick]      = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_AxisBg]        = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_AxisBgHovered] = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_AxisBgActive]  = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_Selection]     = ImVec4(0.97f, 0.97f, 0.39f, 1.00f);
+    colors[ImPlotCol_Crosshairs]    = ImVec4(0.50f, 0.50f, 0.50f, 0.75f);
+}
+
+void StyleColorsDark(ImPlotStyle* dst) {
+    ImPlotStyle* style              = dst ? dst : &ImPlot::GetStyle();
+    ImVec4* colors                  = style->Colors;
+
+    style->MinorAlpha               = 0.25f;
+
+    colors[ImPlotCol_Line]          = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_Fill]          = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_MarkerOutline] = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_MarkerFill]    = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_ErrorBar]      = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_FrameBg]       = ImVec4(1.00f, 1.00f, 1.00f, 0.07f);
+    colors[ImPlotCol_PlotBg]        = ImVec4(0.00f, 0.00f, 0.00f, 0.50f);
+    colors[ImPlotCol_PlotBorder]    = ImVec4(0.43f, 0.43f, 0.50f, 0.50f);
+    colors[ImPlotCol_LegendBg]      = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
+    colors[ImPlotCol_LegendBorder]  = ImVec4(0.43f, 0.43f, 0.50f, 0.50f);
+    colors[ImPlotCol_LegendText]    = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImPlotCol_TitleText]     = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImPlotCol_InlayText]     = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImPlotCol_AxisText]      = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImPlotCol_AxisGrid]      = ImVec4(1.00f, 1.00f, 1.00f, 0.25f);
+    colors[ImPlotCol_AxisTick]      = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_AxisBg]        = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_AxisBgHovered] = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_AxisBgActive]  = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_Selection]     = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+    colors[ImPlotCol_Crosshairs]    = ImVec4(1.00f, 1.00f, 1.00f, 0.50f);
+}
+
+void StyleColorsLight(ImPlotStyle* dst) {
+    ImPlotStyle* style              = dst ? dst : &ImPlot::GetStyle();
+    ImVec4* colors                  = style->Colors;
+
+    style->MinorAlpha               = 1.0f;
+
+    colors[ImPlotCol_Line]          = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_Fill]          = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_MarkerOutline] = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_MarkerFill]    = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_ErrorBar]      = IMPLOT_AUTO_COL;
+    colors[ImPlotCol_FrameBg]       = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImPlotCol_PlotBg]        = ImVec4(0.42f, 0.57f, 1.00f, 0.13f);
+    colors[ImPlotCol_PlotBorder]    = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImPlotCol_LegendBg]      = ImVec4(1.00f, 1.00f, 1.00f, 0.98f);
+    colors[ImPlotCol_LegendBorder]  = ImVec4(0.82f, 0.82f, 0.82f, 0.80f);
+    colors[ImPlotCol_LegendText]    = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+    colors[ImPlotCol_TitleText]     = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+    colors[ImPlotCol_InlayText]     = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+    colors[ImPlotCol_AxisText]      = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+    colors[ImPlotCol_AxisGrid]      = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+    colors[ImPlotCol_AxisTick]      = ImVec4(0.00f, 0.00f, 0.00f, 0.25f);
+    colors[ImPlotCol_AxisBg]        = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_AxisBgHovered] = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_AxisBgActive]  = IMPLOT_AUTO_COL; // TODO
+    colors[ImPlotCol_Selection]     = ImVec4(0.82f, 0.64f, 0.03f, 1.00f);
+    colors[ImPlotCol_Crosshairs]    = ImVec4(0.00f, 0.00f, 0.00f, 0.50f);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Obsolete Functions/Types
+//-----------------------------------------------------------------------------
+
+#ifndef IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
+
+bool BeginPlot(const char* title, const char* x_label, const char* y1_label, const ImVec2& size,
+               ImPlotFlags flags, ImPlotAxisFlags x_flags, ImPlotAxisFlags y1_flags, ImPlotAxisFlags y2_flags, ImPlotAxisFlags y3_flags,
+               const char* y2_label, const char* y3_label)
+{
+    if (!BeginPlot(title, size, flags))
+        return false;
+    SetupAxis(ImAxis_X1, x_label, x_flags);
+    SetupAxis(ImAxis_Y1, y1_label, y1_flags);
+    if (ImHasFlag(flags, ImPlotFlags_YAxis2))
+        SetupAxis(ImAxis_Y2, y2_label, y2_flags);
+    if (ImHasFlag(flags, ImPlotFlags_YAxis3))
+        SetupAxis(ImAxis_Y3, y3_label, y3_flags);
+    return true;
+}
+
+#endif
+
+}  // namespace ImPlot

--- a/lib/implot/implot.cpp
+++ b/lib/implot/implot.cpp
@@ -1,6 +1,7 @@
 // MIT License
 
-// Copyright (c) 2022 Evan Pezent
+// Copyright (c) 2020-2024 Evan Pezent
+// Copyright (c) 2025-2026 Breno Cunha Queiroz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// ImPlot v0.14
+// ImPlot v1.1 WIP
 
 /*
 
@@ -31,6 +32,71 @@ Below is a change-log of API breaking changes only. If you are using one of the 
 When you are not sure about a old symbol or function name, try using the Search/Find function of your IDE to look for comments or references in all implot files.
 You can read releases logs https://github.com/epezent/implot/releases for more details.
 
+- 2026/02/12 (1.0) - ImPlotSpec replaces the SetNextXXX style functions. The guide below shows show to migrate from SetNextXXX to ImPlotSpec.
+                        - `SetNextLineStyle` has been removed, styling should be set via ImPlotSpec.
+                          ```
+                          // Before
+                          ImPlot::SetNextLineStyle(line_color, line_weight);
+                          ImPlot::PlotLine("Line", xs, ys, count);
+
+                          // After
+                          ImPlotSpec spec;
+                          spec.LineColor = line_color;
+                          spec.LineWeight = line_weight;
+                          ImPlot::PlotLine("Line", xs, ys, count, spec);
+                          ```
+                        - `SetNextFillStyle` has been removed, styling should be set via ImPlotSpec.
+                          ```
+                          // Before
+                          ImPlot::SetNextFillStyle(fill_color, fill_alpha);
+                          ImPlot::PlotLine("Shaded", xs, ys, count, ImPlotLineFlags_Shaded);
+
+                          // After
+                          ImPlotSpec spec;
+                          spec.FillColor = fill_color;
+                          spec.FillAlpha = fill_alpha;
+                          spec.Flags = ImPlotLineFlags_Shaded;
+                          ImPlot::PlotTLine("Shaded", xs, ys, count, spec);
+                          ```
+                        - SetNextMarkerStyle has been removed, styling should be set via ImPlotSpec.
+                           ```
+                           // Before
+                           ImPlot::SetNextMarkerStyle(marker, marker_size, fill_color, line_weight, marker_outline_color);
+                           ImPlot::PlotScatter("Scatter", xs, ys, count);
+
+                           // After
+                           ImPlotSpec spec;
+                           spec.LineWeight = line_weight;
+                           spec.Marker = marker;
+                           spec.MarkerSize = marker_size;
+                           spec.MarkerLineColor = marker_outline_color;
+                           spec.MarkerFillColor = fill_color;
+                           ImPlot::PlotScatter("Scatter", xs, ys, count, spec);
+                           ```
+                        - SetNextErrorBarStyle has been removed, styling should be set via ImPlotSpec.
+                           ```
+                           // Before
+                           ImPlot::SetNextErrorBarStyle(color, size, weight);
+                           ImPlot::PlotErrorBars("ErrorBar", xs, ys, err, count);
+
+                           // After
+                           ImPlotSpec spec;
+                           spec.LineColor = color;
+                           spec.Size = size;
+                           spec.LineWeight = weight;
+                           ImPlot::PlotErrorBars("ErrorBar", xs, ys, err, count, spec);
+                           ```
+                        - Flags, Offset and Stride should also be set via ImPlotSpec now.
+- 2023/10/02 (1.0) - ImPlotSpec was made the default and _only_ way of styling plot items. Therefore the following features were removed:
+                      - ImPlotCol_Line, ImPlotCol_Fill, ImPlotCol_MarkerOutline, ImPlotCol_MarkerFill, ImPlotCol_ErrorBar have been removed and thus are no longer supported by PushStyleColor.
+                        You can use a common ImPlotSpec instance across multiple PlotX calls to emulate PushStyleColor behavior.
+                      - ImPlotStyleVar_LineWeight, ImPlotStyleVar_Marker, ImPlotStyleVar_MarkerSize, ImPlotStyleVar_MarkerWeight, ImPlotStyleVar_FillAlpha, ImPlotStyleVar_ErrorBarSize, and ImPlotStyleVar_ErrorBarWeight
+                        have been removed and thus are no longer supported by PushStyleVar. You can use a common ImPlotSpec instance across multiple PlotX calls to emulate PushStyleVar behavior.
+                      - ImPlotStyle/ImPlotStyleVar_ DigitalBitGap was renamed to DigitalSpacing; DigitalBitHeight was removed (use ImPlotSpec::Size); DigitalPadding was added for padding from bottom.
+                      - PlotX offset, stride, and flags parameters are now incorporated into ImPlotSpec; specify these variables in the ImPlotSpec passed to PlotX.
+- 2023/08/20 (0.17) - ImPlotFlags_NoChild was removed as child windows are no longer needed to capture scroll. You can safely remove this flag if you were using it.
+- 2023/06/26 (0.15) - Various build fixes related to updates in Dear ImGui internals.
+- 2022/11/25 (0.15) - Make PlotText honor ImPlotItemFlags_NoFit.
 - 2022/06/19 (0.14) - The signature of ColormapScale has changed to accommodate a new ImPlotColormapScaleFlags parameter
 - 2022/06/17 (0.14) - **IMPORTANT** All PlotX functions now take an ImPlotX_Flags `flags` parameter. Where applicable, it is located before the existing `offset` and `stride` parameters.
                       If you were providing offset and stride values, you will need to update your function call to include a `flags` value. If you fail to do this, you will likely see
@@ -93,7 +159,7 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 - 2020/09/07 (0.8)  - Plotting functions which accept a custom getter function pointer have been post-fixed with a G (e.g. PlotLineG)
 - 2020/09/06 (0.7)  - Several flags under ImPlotFlags and ImPlotAxisFlags were inverted (e.g. ImPlotFlags_Legend -> ImPlotFlags_NoLegend) so that the default flagset
                       is simply 0. This more closely matches ImGui's style and makes it easier to enable non-default but commonly used flags (e.g. ImPlotAxisFlags_Time).
-- 2020/08/28 (0.5)  - ImPlotMarker_ can no longer be combined with bitwise OR, |. This features caused unecessary slow-down, and almost no one used it.
+- 2020/08/28 (0.5)  - ImPlotMarker_ can no longer be combined with bitwise OR, |. This features caused unnecessary slow-down, and almost no one used it.
 - 2020/08/25 (0.5)  - ImPlotAxisFlags_Scientific was removed. Logarithmic axes automatically uses scientific notation.
 - 2020/08/17 (0.5)  - PlotText was changed so that text is centered horizontally and vertically about the desired point.
 - 2020/08/16 (0.5)  - An ImPlotContext must be explicitly created and destroyed now with `CreateContext` and `DestroyContext`. Previously, the context was statically initialized in this source file.
@@ -122,7 +188,11 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 
 */
 
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "implot.h"
+#ifndef IMGUI_DISABLE
 #include "implot_internal.h"
 
 #include <stdlib.h>
@@ -130,6 +200,11 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 // Support for pre-1.82 versions. Users on 1.82+ can use 0 (default) flags to mean "all corners" but in order to support older versions we are more explicit.
 #if (IMGUI_VERSION_NUM < 18102) && !defined(ImDrawFlags_RoundCornersAll)
 #define ImDrawFlags_RoundCornersAll ImDrawCornerFlags_All
+#endif
+
+// Support for pre-1.89.7 versions.
+#if (IMGUI_VERSION_NUM < 18966)
+#define ImGuiButtonFlags_AllowOverlap ImGuiButtonFlags_AllowItemOverlap
 #endif
 
 // Visual Studio warnings
@@ -140,13 +215,16 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 // Clang/GCC warnings with -Weverything
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wformat-nonliteral"  // warning: format string is not a string literal
+#pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion" // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
+#pragma clang diagnostic ignored "-Wenum-enum-conversion" // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"    // warning: format not a string literal, format string not checked
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion" // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #endif
 
 // Global plot context
 #ifndef GImPlot
-ImPlotContext* GImPlot = NULL;
+ImPlotContext* GImPlot = nullptr;
 #endif
 
 //-----------------------------------------------------------------------------
@@ -158,17 +236,8 @@ ImPlotInputMap::ImPlotInputMap() {
 }
 
 ImPlotStyle::ImPlotStyle() {
-
-    LineWeight         = 1;
-    Marker             = ImPlotMarker_None;
-    MarkerSize         = 4;
-    MarkerWeight       = 1;
-    FillAlpha          = 1;
-    ErrorBarSize       = 5;
-    ErrorBarWeight     = 1.5f;
-    DigitalBitHeight   = 8;
-    DigitalBitGap      = 4;
-
+    PlotDefaultSize    = ImVec2(400,300);
+    PlotMinSize        = ImVec2(200,150);
     PlotBorderSize     = 1;
     MinorAlpha         = 0.25f;
     MajorTickLen       = ImVec2(10,10);
@@ -185,9 +254,9 @@ ImPlotStyle::ImPlotStyle() {
     MousePosPadding    = ImVec2(10,10);
     AnnotationPadding  = ImVec2(2,2);
     FitPadding         = ImVec2(0,0);
-    PlotDefaultSize    = ImVec2(400,300);
-    PlotMinSize        = ImVec2(200,150);
-
+    DigitalPadding     = 20;
+    DigitalSpacing     = 4;
+    
     ImPlot::StyleColorsAuto(this);
 
     Colormap = ImPlotColormap_Deep;
@@ -205,11 +274,6 @@ namespace ImPlot {
 
 const char* GetStyleColorName(ImPlotCol col) {
     static const char* col_names[ImPlotCol_COUNT] = {
-        "Line",
-        "Fill",
-        "MarkerOutline",
-        "MarkerFill",
-        "ErrorBar",
         "FrameBg",
         "PlotBg",
         "PlotBorder",
@@ -233,6 +297,7 @@ const char* GetStyleColorName(ImPlotCol col) {
 const char* GetMarkerName(ImPlotMarker marker) {
     switch (marker) {
         case ImPlotMarker_None:     return "None";
+        case ImPlotMarker_Auto:     return "Auto";
         case ImPlotMarker_Circle:   return "Circle";
         case ImPlotMarker_Square:   return "Square";
         case ImPlotMarker_Diamond:  return "Diamond";
@@ -243,6 +308,8 @@ const char* GetMarkerName(ImPlotMarker marker) {
         case ImPlotMarker_Cross:    return "Cross";
         case ImPlotMarker_Plus:     return "Plus";
         case ImPlotMarker_Asterisk: return "Asterisk";
+        case ImPlotMarker_Vertical: return "Vertical";
+        case ImPlotMarker_Horizontal: return "Horizontal";
         default:                    return "";
     }
 }
@@ -250,11 +317,6 @@ const char* GetMarkerName(ImPlotMarker marker) {
 ImVec4 GetAutoColor(ImPlotCol idx) {
     ImVec4 col(0,0,0,1);
     switch(idx) {
-        case ImPlotCol_Line:          return col; // these are plot dependent!
-        case ImPlotCol_Fill:          return col; // these are plot dependent!
-        case ImPlotCol_MarkerOutline: return col; // these are plot dependent!
-        case ImPlotCol_MarkerFill:    return col; // these are plot dependent!
-        case ImPlotCol_ErrorBar:      return ImGui::GetStyleColorVec4(ImGuiCol_Text);
         case ImPlotCol_FrameBg:       return ImGui::GetStyleColorVec4(ImGuiCol_FrameBg);
         case ImPlotCol_PlotBg:        return ImGui::GetStyleColorVec4(ImGuiCol_WindowBg);
         case ImPlotCol_PlotBorder:    return ImGui::GetStyleColorVec4(ImGuiCol_Border);
@@ -284,35 +346,26 @@ struct ImPlotStyleVarInfo {
 
 static const ImPlotStyleVarInfo GPlotStyleVarInfo[] =
 {
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, LineWeight)         }, // ImPlotStyleVar_LineWeight
-    { ImGuiDataType_S32,   1, (ImU32)IM_OFFSETOF(ImPlotStyle, Marker)             }, // ImPlotStyleVar_Marker
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, MarkerSize)         }, // ImPlotStyleVar_MarkerSize
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, MarkerWeight)       }, // ImPlotStyleVar_MarkerWeight
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, FillAlpha)          }, // ImPlotStyleVar_FillAlpha
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, ErrorBarSize)       }, // ImPlotStyleVar_ErrorBarSize
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, ErrorBarWeight)     }, // ImPlotStyleVar_ErrorBarWeight
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, DigitalBitHeight)   }, // ImPlotStyleVar_DigitalBitHeight
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, DigitalBitGap)      }, // ImPlotStyleVar_DigitalBitGap
-
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, PlotBorderSize)     }, // ImPlotStyleVar_PlotBorderSize
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImPlotStyle, MinorAlpha)         }, // ImPlotStyleVar_MinorAlpha
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MajorTickLen)       }, // ImPlotStyleVar_MajorTickLen
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MinorTickLen)       }, // ImPlotStyleVar_MinorTickLen
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MajorTickSize)      }, // ImPlotStyleVar_MajorTickSize
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MinorTickSize)      }, // ImPlotStyleVar_MinorTickSize
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MajorGridSize)      }, // ImPlotStyleVar_MajorGridSize
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MinorGridSize)      }, // ImPlotStyleVar_MinorGridSize
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, PlotPadding)        }, // ImPlotStyleVar_PlotPadding
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, LabelPadding)       }, // ImPlotStyleVar_LabelPaddine
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, LegendPadding)      }, // ImPlotStyleVar_LegendPadding
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, LegendInnerPadding) }, // ImPlotStyleVar_LegendInnerPadding
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, LegendSpacing)      }, // ImPlotStyleVar_LegendSpacing
-
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, MousePosPadding)    }, // ImPlotStyleVar_MousePosPadding
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, AnnotationPadding)  }, // ImPlotStyleVar_AnnotationPadding
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, FitPadding)         }, // ImPlotStyleVar_FitPadding
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, PlotDefaultSize)    }, // ImPlotStyleVar_PlotDefaultSize
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImPlotStyle, PlotMinSize)        }  // ImPlotStyleVar_PlotMinSize
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, PlotDefaultSize)    }, // ImPlotStyleVar_PlotDefaultSize
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, PlotMinSize)        }, // ImPlotStyleVar_PlotMinSize
+    { ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlotStyle, PlotBorderSize)     }, // ImPlotStyleVar_PlotBorderSize
+    { ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlotStyle, MinorAlpha)         }, // ImPlotStyleVar_MinorAlpha
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MajorTickLen)       }, // ImPlotStyleVar_MajorTickLen
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MinorTickLen)       }, // ImPlotStyleVar_MinorTickLen
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MajorTickSize)      }, // ImPlotStyleVar_MajorTickSize
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MinorTickSize)      }, // ImPlotStyleVar_MinorTickSize
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MajorGridSize)      }, // ImPlotStyleVar_MajorGridSize
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MinorGridSize)      }, // ImPlotStyleVar_MinorGridSize
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, PlotPadding)        }, // ImPlotStyleVar_PlotPadding
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LabelPadding)       }, // ImPlotStyleVar_LabelPadding
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LegendPadding)      }, // ImPlotStyleVar_LegendPadding
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LegendInnerPadding) }, // ImPlotStyleVar_LegendInnerPadding
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, LegendSpacing)      }, // ImPlotStyleVar_LegendSpacing
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, MousePosPadding)    }, // ImPlotStyleVar_MousePosPadding
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, AnnotationPadding)  }, // ImPlotStyleVar_AnnotationPadding
+    { ImGuiDataType_Float, 2, (ImU32)offsetof(ImPlotStyle, FitPadding)         }, // ImPlotStyleVar_FitPadding
+    { ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlotStyle, DigitalPadding)     }, // ImPlotStyleVar_DigitalPadding
+    { ImGuiDataType_Float, 1, (ImU32)offsetof(ImPlotStyle, DigitalSpacing)     }, // ImPlotStyleVar_DigitalSpacing
 };
 
 static const ImPlotStyleVarInfo* GetPlotStyleVarInfo(ImPlotStyleVar idx) {
@@ -330,11 +383,16 @@ void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char *te
     if (!text_end)
         text_end = text_begin + strlen(text_begin);
     ImGuiContext& g = *GImGui;
+#ifdef IMGUI_HAS_TEXTURES
+    ImFontBaked* font = g.Font->GetFontBaked(g.FontSize);
+    const float scale = g.FontSize / font->Size;
+#else
     ImFont* font = g.Font;
-    // Align to be pixel perfect
-    pos.x = IM_FLOOR(pos.x);
-    pos.y = IM_FLOOR(pos.y);
     const float scale = g.FontSize / font->FontSize;
+#endif
+    // Align to be pixel perfect
+    pos.x = ImFloor(pos.x);
+    pos.y = ImFloor(pos.y);
     const char* s = text_begin;
     int chars_exp = (int)(text_end - s);
     int chars_rnd = 0;
@@ -352,7 +410,7 @@ void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char *te
                 break;
         }
         const ImFontGlyph * glyph = font->FindGlyph((ImWchar)c);
-        if (glyph == NULL) {
+        if (glyph == nullptr) {
             continue;
         }
         DrawList->PrimQuadUV(pos + ImVec2(glyph->Y0, -glyph->X0) * scale, pos + ImVec2(glyph->Y0, -glyph->X1) * scale,
@@ -419,16 +477,16 @@ void SetImGuiContext(ImGuiContext* ctx) {
 ImPlotContext* CreateContext() {
     ImPlotContext* ctx = IM_NEW(ImPlotContext)();
     Initialize(ctx);
-    if (GImPlot == NULL)
+    if (GImPlot == nullptr)
         SetCurrentContext(ctx);
     return ctx;
 }
 
 void DestroyContext(ImPlotContext* ctx) {
-    if (ctx == NULL)
+    if (ctx == nullptr)
         ctx = GImPlot;
     if (GImPlot == ctx)
-        SetCurrentContext(NULL);
+        SetCurrentContext(nullptr);
     IM_DELETE(ctx);
 }
 
@@ -448,22 +506,22 @@ void Initialize(ImPlotContext* ctx) {
     ResetCtxForNextAlignedPlots(ctx);
     ResetCtxForNextSubplot(ctx);
 
-    const ImU32 Deep[]     = {4289753676, 4283598045, 4285048917, 4283584196, 4289950337, 4284512403, 4291005402, 4287401100, 4285839820, 4291671396                        };
-    const ImU32 Dark[]     = {4280031972, 4290281015, 4283084621, 4288892568, 4278222847, 4281597951, 4280833702, 4290740727, 4288256409                                    };
-    const ImU32 Pastel[]   = {4289639675, 4293119411, 4291161036, 4293184478, 4289124862, 4291624959, 4290631909, 4293712637, 4294111986                                    };
-    const ImU32 Paired[]   = {4293119554, 4290017311, 4287291314, 4281114675, 4288256763, 4280031971, 4285513725, 4278222847, 4292260554, 4288298346, 4288282623, 4280834481};
-    const ImU32 Viridis[]  = {4283695428, 4285867080, 4287054913, 4287455029, 4287526954, 4287402273, 4286883874, 4285579076, 4283552122, 4280737725, 4280674301            };
-    const ImU32 Plasma[]   = {4287039501, 4288480321, 4289200234, 4288941455, 4287638193, 4286072780, 4284638433, 4283139314, 4281771772, 4280667900, 4280416752            };
-    const ImU32 Hot[]      = {4278190144, 4278190208, 4278190271, 4278190335, 4278206719, 4278223103, 4278239231, 4278255615, 4283826175, 4289396735, 4294967295            };
-    const ImU32 Cool[]     = {4294967040, 4294960666, 4294954035, 4294947661, 4294941030, 4294934656, 4294928025, 4294921651, 4294915020, 4294908646, 4294902015            };
-    const ImU32 Pink[]     = {4278190154, 4282532475, 4284308894, 4285690554, 4286879686, 4287870160, 4288794330, 4289651940, 4291685869, 4293392118, 4294967295            };
-    const ImU32 Jet[]      = {4289331200, 4294901760, 4294923520, 4294945280, 4294967040, 4289396565, 4283826090, 4278255615, 4278233855, 4278212095, 4278190335            };
+    const ImU32 Deep[]     = {IM_RGB(76,114,176),IM_RGB(221,132,82),IM_RGB(85,168,104),IM_RGB(196,78,82),IM_RGB(129,114,179),IM_RGB(147,120,96),IM_RGB(218,139,195),IM_RGB(140,140,140),IM_RGB(204,185,116),IM_RGB(100,181,205)};
+    const ImU32 Dark[]     = {IM_RGB(228,26,28),IM_RGB(55,126,184),IM_RGB(77,175,74),IM_RGB(152,78,163),IM_RGB(255,127,0),IM_RGB(255,255,51),IM_RGB(166,86,40),IM_RGB(247,129,191),IM_RGB(153,153,153)};
+    const ImU32 Pastel[]   = {IM_RGB(251,180,174),IM_RGB(179,205,227),IM_RGB(204,235,197),IM_RGB(222,203,228),IM_RGB(254,217,166),IM_RGB(255,255,204),IM_RGB(229,216,189),IM_RGB(253,218,236),IM_RGB(242,242,242)};
+    const ImU32 Paired[]   = {IM_RGB(66,206,227),IM_RGB(31,120,180),IM_RGB(178,223,138),IM_RGB(51,160,44),IM_RGB(251,154,153),IM_RGB(227,26,28),IM_RGB(253,191,111),IM_RGB(255,127,0),IM_RGB(202,178,214),IM_RGB(106,61,154),IM_RGB(255,255,153),IM_RGB(177,89,40)};
+    const ImU32 Viridis[]  = {IM_RGB(68,1,84),IM_RGB(72,36,117),IM_RGB(65,68,135),IM_RGB(53,95,141),IM_RGB(42,120,142),IM_RGB(33,145,140),IM_RGB(34,168,132),IM_RGB(68,191,112),IM_RGB(122,209,81),IM_RGB(189,223,38),IM_RGB(253,231,37)};
+    const ImU32 Plasma[]   = {IM_RGB(13,8,135),IM_RGB(65,4,157),IM_RGB(106,0,168),IM_RGB(143,13,164),IM_RGB(177,42,144),IM_RGB(204,71,120),IM_RGB(225,100,98),IM_RGB(242,132,75),IM_RGB(252,166,54),IM_RGB(252,206,37),IM_RGB(240,249,33)};
+    const ImU32 Hot[]      = {IM_RGB(64,0,0),IM_RGB(128,0,0),IM_RGB(191,0,0),IM_RGB(255,0,0),IM_RGB(255,64,0),IM_RGB(255,128,0),IM_RGB(255,191,0),IM_RGB(255,255,0),IM_RGB(255,255,85),IM_RGB(255,255,170),IM_RGB(255,255,255)};
+    const ImU32 Cool[]     = {IM_RGB(0,255,255),IM_RGB(26,230,255),IM_RGB(51,204,255),IM_RGB(77,179,255),IM_RGB(102,153,255),IM_RGB(128,128,255),IM_RGB(153,102,255),IM_RGB(179,77,255),IM_RGB(204,51,255),IM_RGB(230,26,255),IM_RGB(255,0,255)};
+    const ImU32 Pink[]     = {IM_RGB(74,0,0),IM_RGB(123,66,66),IM_RGB(158,93,93),IM_RGB(186,114,114),IM_RGB(198,151,132),IM_RGB(208,180,147),IM_RGB(218,206,161),IM_RGB(228,228,174),IM_RGB(237,237,205),IM_RGB(246,246,231),IM_RGB(255,255,255)};
+    const ImU32 Jet[]      = {IM_RGB(0,0,170),IM_RGB(0,0,255),IM_RGB(0,85,255),IM_RGB(0,170,255),IM_RGB(0,255,255),IM_RGB(85,255,170),IM_RGB(170,255,85),IM_RGB(255,255,0),IM_RGB(255,170,0),IM_RGB(255,85,0),IM_RGB(255,0,0)};
     const ImU32 Twilight[] = {IM_RGB(226,217,226),IM_RGB(166,191,202),IM_RGB(109,144,192),IM_RGB(95,88,176),IM_RGB(83,30,124),IM_RGB(47,20,54),IM_RGB(100,25,75),IM_RGB(159,60,80),IM_RGB(192,117,94),IM_RGB(208,179,158),IM_RGB(226,217,226)};
     const ImU32 RdBu[]     = {IM_RGB(103,0,31),IM_RGB(178,24,43),IM_RGB(214,96,77),IM_RGB(244,165,130),IM_RGB(253,219,199),IM_RGB(247,247,247),IM_RGB(209,229,240),IM_RGB(146,197,222),IM_RGB(67,147,195),IM_RGB(33,102,172),IM_RGB(5,48,97)};
     const ImU32 BrBG[]     = {IM_RGB(84,48,5),IM_RGB(140,81,10),IM_RGB(191,129,45),IM_RGB(223,194,125),IM_RGB(246,232,195),IM_RGB(245,245,245),IM_RGB(199,234,229),IM_RGB(128,205,193),IM_RGB(53,151,143),IM_RGB(1,102,94),IM_RGB(0,60,48)};
     const ImU32 PiYG[]     = {IM_RGB(142,1,82),IM_RGB(197,27,125),IM_RGB(222,119,174),IM_RGB(241,182,218),IM_RGB(253,224,239),IM_RGB(247,247,247),IM_RGB(230,245,208),IM_RGB(184,225,134),IM_RGB(127,188,65),IM_RGB(77,146,33),IM_RGB(39,100,25)};
     const ImU32 Spectral[] = {IM_RGB(158,1,66),IM_RGB(213,62,79),IM_RGB(244,109,67),IM_RGB(253,174,97),IM_RGB(254,224,139),IM_RGB(255,255,191),IM_RGB(230,245,152),IM_RGB(171,221,164),IM_RGB(102,194,165),IM_RGB(50,136,189),IM_RGB(94,79,162)};
-    const ImU32 Greys[]    = {IM_COL32_WHITE, IM_COL32_BLACK                                                                                                                };
+    const ImU32 Greys[]    = {IM_COL32_WHITE, IM_COL32_BLACK};
 
     IMPLOT_APPEND_CMAP(Deep, true);
     IMPLOT_APPEND_CMAP(Dark, true);
@@ -484,10 +542,6 @@ void Initialize(ImPlotContext* ctx) {
 }
 
 void ResetCtxForNextPlot(ImPlotContext* ctx) {
-    // end child window if it was made
-    if (ctx->ChildWindowMade)
-        ImGui::EndChild();
-    ctx->ChildWindowMade = false;
     // reset the next plot/item data
     ctx->NextPlotData.Reset();
     ctx->NextItemData.Reset();
@@ -500,20 +554,20 @@ void ResetCtxForNextPlot(ImPlotContext* ctx) {
     ctx->DigitalPlotItemCnt = 0;
     ctx->DigitalPlotOffset = 0;
     // nullify plot
-    ctx->CurrentPlot  = NULL;
-    ctx->CurrentItem  = NULL;
-    ctx->PreviousItem = NULL;
+    ctx->CurrentPlot  = nullptr;
+    ctx->CurrentItem  = nullptr;
+    ctx->PreviousItem = nullptr;
 }
 
 void ResetCtxForNextAlignedPlots(ImPlotContext* ctx) {
-    ctx->CurrentAlignmentH = NULL;
-    ctx->CurrentAlignmentV = NULL;
+    ctx->CurrentAlignmentH = nullptr;
+    ctx->CurrentAlignmentV = nullptr;
 }
 
 void ResetCtxForNextSubplot(ImPlotContext* ctx) {
-    ctx->CurrentSubplot      = NULL;
-    ctx->CurrentAlignmentH   = NULL;
-    ctx->CurrentAlignmentV   = NULL;
+    ctx->CurrentSubplot      = nullptr;
+    ctx->CurrentAlignmentH   = nullptr;
+    ctx->CurrentAlignmentV   = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -531,8 +585,9 @@ ImPlotPlot* GetCurrentPlot() {
 }
 
 void BustPlotCache() {
-    GImPlot->Plots.Clear();
-    GImPlot->Subplots.Clear();
+    ImPlotContext& gp = *GImPlot;
+    gp.Plots.Clear();
+    gp.Subplots.Clear();
 }
 
 //-----------------------------------------------------------------------------
@@ -569,7 +624,7 @@ ImVec2 CalcLegendSize(ImPlotItemGroup& items, const ImVec2& pad, const ImVec2& s
     float sum_label_width = 0;
     for (int i = 0; i < nItems; ++i) {
         const char* label       = items.GetLegendLabel(i);
-        const float label_width = ImGui::CalcTextSize(label, NULL, true).x;
+        const float label_width = ImGui::CalcTextSize(label, nullptr, true).x;
         max_label_width         = label_width > max_label_width ? label_width : max_label_width;
         sum_label_width        += label_width;
     }
@@ -578,6 +633,28 @@ ImVec2 CalcLegendSize(ImPlotItemGroup& items, const ImVec2& pad, const ImVec2& s
                                ImVec2(pad.x * 2 + icon_size + max_label_width, pad.y * 2 + nItems * txt_ht + (nItems - 1) * spacing.y) :
                                ImVec2(pad.x * 2 + icon_size * nItems + sum_label_width + (nItems - 1) * spacing.x, pad.y * 2 + txt_ht);
     return legend_size;
+}
+
+bool ClampLegendRect(ImRect& legend_rect, const ImRect& outer_rect, const ImVec2& pad) {
+    bool clamped = false;
+    ImRect outer_rect_pad(outer_rect.Min + pad, outer_rect.Max - pad);
+    if (legend_rect.Min.x < outer_rect_pad.Min.x) {
+        legend_rect.Min.x = outer_rect_pad.Min.x;
+        clamped = true;
+    }
+    if (legend_rect.Min.y < outer_rect_pad.Min.y) {
+        legend_rect.Min.y = outer_rect_pad.Min.y;
+        clamped = true;
+    }
+    if (legend_rect.Max.x > outer_rect_pad.Max.x) {
+        legend_rect.Max.x = outer_rect_pad.Max.x;
+        clamped = true;
+    }
+    if (legend_rect.Max.y > outer_rect_pad.Max.y) {
+        legend_rect.Max.y = outer_rect_pad.Max.y;
+        clamped = true;
+    }
+    return clamped;
 }
 
 int LegendSortingComp(const void* _a, const void* _b) {
@@ -595,7 +672,7 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
     const float icon_size   = txt_ht;
     const float icon_shrink = 2;
     ImU32 col_txt           = GetStyleColorU32(ImPlotCol_LegendText);
-    ImU32  col_txt_dis      = ImAlphaU32(col_txt, 0.25f);
+    ImU32 col_txt_dis       = ImAlphaU32(col_txt, 0.25f);
     // render each legend item
     float sum_label_width = 0;
     bool any_item_hovered = false;
@@ -604,20 +681,21 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
     if (num_items < 1)
         return hovered;
     // build render order
-    ImVector<int>& indices = GImPlot->TempInt1;
+    ImPlotContext& gp = *GImPlot;
+    ImVector<int>& indices = gp.TempInt1;
     indices.resize(num_items);
     for (int i = 0; i < num_items; ++i)
         indices[i] = i;
     if (ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_Sort) && num_items > 1) {
-        GImPlot->SortItems = &items;
+        gp.SortItems = &items;
         qsort(indices.Data, num_items, sizeof(int), LegendSortingComp);
     }
     // render
     for (int i = 0; i < num_items; ++i) {
-        const int idx           = indices[i];
+        const int idx           = ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_Reverse) ? indices[num_items - 1 - i] : indices[i];
         ImPlotItem* item        = items.GetLegendItem(idx);
         const char* label       = items.GetLegendLabel(idx);
-        const float label_width = ImGui::CalcTextSize(label, NULL, true).x;
+        const float label_width = ImGui::CalcTextSize(label, nullptr, true).x;
         const ImVec2 top_left   = vertical ?
                                   legend_bb.Min + pad + ImVec2(0, i * (txt_ht + spacing.y)) :
                                   legend_bb.Min + pad + ImVec2(i * (icon_size + spacing.x) + sum_label_width, 0);
@@ -668,7 +746,7 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
             col_icon = item->Show ? col_item : col_txt_dis;
 
         DrawList.AddRectFilled(icon_bb.Min, icon_bb.Max, col_icon);
-        const char* text_display_end = ImGui::FindRenderedTextEnd(label, NULL);
+        const char* text_display_end = ImGui::FindRenderedTextEnd(label, nullptr);
         if (label != text_display_end)
             DrawList.AddText(top_left + ImVec2(icon_size, 0), item->Show ? col_txt_hl  : col_txt_dis, label, text_display_end);
     }
@@ -679,8 +757,8 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
 // Locators
 //-----------------------------------------------------------------------------
 
-static const float TICK_FILL_X = 0.8f;
-static const float TICK_FILL_Y = 1.0f;
+constexpr float TICK_FILL_X = 0.8f;
+constexpr float TICK_FILL_Y = 1.0f;
 
 void Locator_Default(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data) {
     if (range.Min == range.Max)
@@ -770,9 +848,9 @@ void Locator_Log10(ImPlotTicker& ticker, const ImPlotRange& range, float pixels,
 
 float CalcSymLogPixel(double plt, const ImPlotRange& range, float pixels) {
     double scaleToPixels = pixels / range.Size();
-    double scaleMin      = TransformForward_SymLog(range.Min,NULL);
-    double scaleMax      = TransformForward_SymLog(range.Max,NULL);
-    double s             = TransformForward_SymLog(plt, NULL);
+    double scaleMin      = TransformForward_SymLog(range.Min,nullptr);
+    double scaleMax      = TransformForward_SymLog(range.Max,nullptr);
+    double s             = TransformForward_SymLog(plt, nullptr);
     double t             = (s - scaleMin) / (scaleMax - scaleMin);
     plt                  = range.Min + range.Size() * t;
 
@@ -804,7 +882,7 @@ void Locator_SymLog(ImPlotTicker& ticker, const ImPlotRange& range, float pixels
 
 void AddTicksCustom(const double* values, const char* const labels[], int n, ImPlotTicker& ticker, ImPlotFormatter formatter, void* data) {
     for (int i = 0; i < n; ++i) {
-        if (labels != NULL)
+        if (labels != nullptr)
             ticker.AddTick(values[i], false, 0, true, labels[i]);
         else
             ticker.AddTick(values[i], false, 0, true, formatter, data);
@@ -816,7 +894,7 @@ void AddTicksCustom(const double* values, const char* const labels[], int n, ImP
 //-----------------------------------------------------------------------------
 
 // this may not be thread safe?
-static const double TimeUnitSpans[ImPlotTimeUnit_COUNT] = {
+constexpr double TimeUnitSpans[ImPlotTimeUnit_COUNT] = {
     0.000001,
     0.001,
     1,
@@ -828,7 +906,7 @@ static const double TimeUnitSpans[ImPlotTimeUnit_COUNT] = {
 };
 
 inline ImPlotTimeUnit GetUnitForRange(double range) {
-    static double cutoffs[ImPlotTimeUnit_COUNT] = {0.001, 1, 60, 3600, 86400, 2629800, 31557600, IMPLOT_MAX_TIME};
+    constexpr double cutoffs[ImPlotTimeUnit_COUNT] = {0.001, 1, 60, 3600, 86400, 2629800, 31557600, IMPLOT_MAX_TIME};
     for (int i = 0; i < ImPlotTimeUnit_COUNT; ++i) {
         if (range <= cutoffs[i])
             return (ImPlotTimeUnit)i;
@@ -848,28 +926,28 @@ inline int LowerBoundStep(int max_divs, const int* divs, const int* step, int si
 
 inline int GetTimeStep(int max_divs, ImPlotTimeUnit unit) {
     if (unit == ImPlotTimeUnit_Ms || unit == ImPlotTimeUnit_Us) {
-        static const int step[] = {500,250,200,100,50,25,20,10,5,2,1};
-        static const int divs[] = {2,4,5,10,20,40,50,100,200,500,1000};
+        constexpr int step[] = {500,250,200,100,50,25,20,10,5,2,1};
+        constexpr int divs[] = {2,4,5,10,20,40,50,100,200,500,1000};
         return LowerBoundStep(max_divs, divs, step, 11);
     }
     if (unit == ImPlotTimeUnit_S || unit == ImPlotTimeUnit_Min) {
-        static const int step[] = {30,15,10,5,1};
-        static const int divs[] = {2,4,6,12,60};
+        constexpr int step[] = {30,15,10,5,1};
+        constexpr int divs[] = {2,4,6,12,60};
         return LowerBoundStep(max_divs, divs, step, 5);
     }
     else if (unit == ImPlotTimeUnit_Hr) {
-        static const int step[] = {12,6,3,2,1};
-        static const int divs[] = {2,4,8,12,24};
+        constexpr int step[] = {12,6,3,2,1};
+        constexpr int divs[] = {2,4,8,12,24};
         return LowerBoundStep(max_divs, divs, step, 5);
     }
     else if (unit == ImPlotTimeUnit_Day) {
-        static const int step[] = {14,7,2,1};
-        static const int divs[] = {2,4,14,28};
+        constexpr int step[] = {14,7,2,1};
+        constexpr int divs[] = {2,4,14,28};
         return LowerBoundStep(max_divs, divs, step, 4);
     }
     else if (unit == ImPlotTimeUnit_Mo) {
-        static const int step[] = {6,3,2,1};
-        static const int divs[] = {2,4,6,12};
+        constexpr int step[] = {6,3,2,1};
+        constexpr int divs[] = {2,4,6,12};
         return LowerBoundStep(max_divs, divs, step, 4);
     }
     return 0;
@@ -893,7 +971,7 @@ tm* GetGmtTime(const ImPlotTime& t, tm* ptm)
   if (gmtime_s(ptm, &t.S) == 0)
     return ptm;
   else
-    return NULL;
+    return nullptr;
 #else
   return gmtime_r(&t.S, ptm);
 #endif
@@ -912,24 +990,10 @@ tm* GetLocTime(const ImPlotTime& t, tm* ptm) {
   if (localtime_s(ptm, &t.S) == 0)
     return ptm;
   else
-    return NULL;
+    return nullptr;
 #else
     return localtime_r(&t.S, ptm);
 #endif
-}
-
-inline ImPlotTime MkTime(struct tm *ptm) {
-    if (GetStyle().UseLocalTime)
-        return MkLocTime(ptm);
-    else
-        return MkGmtTime(ptm);
-}
-
-inline tm* GetTime(const ImPlotTime& t, tm* ptm) {
-    if (GetStyle().UseLocalTime)
-        return GetLocTime(t,ptm);
-    else
-        return GetGmtTime(t,ptm);
 }
 
 ImPlotTime MakeTime(int year, int month, int day, int hour, int min, int sec, int us) {
@@ -959,6 +1023,12 @@ int GetYear(const ImPlotTime& t) {
     tm& Tm = GImPlot->Tm;
     GetTime(t, &Tm);
     return Tm.tm_year + 1900;
+}
+
+int GetMonth(const ImPlotTime& t) {
+    tm& Tm = GImPlot->Tm;
+    ImPlot::GetTime(t, &Tm);
+    return Tm.tm_mon;
 }
 
 ImPlotTime AddTime(const ImPlotTime& t, ImPlotTimeUnit unit, int count) {
@@ -994,19 +1064,20 @@ ImPlotTime AddTime(const ImPlotTime& t, ImPlotTimeUnit unit, int count) {
 }
 
 ImPlotTime FloorTime(const ImPlotTime& t, ImPlotTimeUnit unit) {
-    GetTime(t, &GImPlot->Tm);
+    ImPlotContext& gp = *GImPlot;
+    GetTime(t, &gp.Tm);
     switch (unit) {
         case ImPlotTimeUnit_S:   return ImPlotTime(t.S, 0);
         case ImPlotTimeUnit_Ms:  return ImPlotTime(t.S, (t.Us / 1000) * 1000);
         case ImPlotTimeUnit_Us:  return t;
-        case ImPlotTimeUnit_Yr:  GImPlot->Tm.tm_mon  = 0; // fall-through
-        case ImPlotTimeUnit_Mo:  GImPlot->Tm.tm_mday = 1; // fall-through
-        case ImPlotTimeUnit_Day: GImPlot->Tm.tm_hour = 0; // fall-through
-        case ImPlotTimeUnit_Hr:  GImPlot->Tm.tm_min  = 0; // fall-through
-        case ImPlotTimeUnit_Min: GImPlot->Tm.tm_sec  = 0; break;
+        case ImPlotTimeUnit_Yr:  gp.Tm.tm_mon  = 0; // fall-through
+        case ImPlotTimeUnit_Mo:  gp.Tm.tm_mday = 1; // fall-through
+        case ImPlotTimeUnit_Day: gp.Tm.tm_hour = 0; // fall-through
+        case ImPlotTimeUnit_Hr:  gp.Tm.tm_min  = 0; // fall-through
+        case ImPlotTimeUnit_Min: gp.Tm.tm_sec  = 0; break;
         default:                 return t;
     }
-    return MkTime(&GImPlot->Tm);
+    return MkTime(&gp.Tm);
 }
 
 ImPlotTime CeilTime(const ImPlotTime& t, ImPlotTimeUnit unit) {
@@ -1022,12 +1093,13 @@ ImPlotTime RoundTime(const ImPlotTime& t, ImPlotTimeUnit unit) {
 }
 
 ImPlotTime CombineDateTime(const ImPlotTime& date_part, const ImPlotTime& tod_part) {
-    tm& Tm = GImPlot->Tm;
-    GetTime(date_part, &GImPlot->Tm);
+    ImPlotContext& gp = *GImPlot;
+    tm& Tm = gp.Tm;
+    GetTime(date_part, &gp.Tm);
     int y = Tm.tm_year;
     int m = Tm.tm_mon;
     int d = Tm.tm_mday;
-    GetTime(tod_part, &GImPlot->Tm);
+    GetTime(tod_part, &gp.Tm);
     Tm.tm_year = y;
     Tm.tm_mon  = m;
     Tm.tm_mday = d;
@@ -1291,12 +1363,12 @@ bool DragFloat(const char*, F*, float, F, F) {
 
 template <>
 bool DragFloat<double>(const char* label, double* v, float v_speed, double v_min, double v_max) {
-    return ImGui::DragScalar(label, ImGuiDataType_Double, v, v_speed, &v_min, &v_max, "%.3f", 1);
+    return ImGui::DragScalar(label, ImGuiDataType_Double, v, v_speed, &v_min, &v_max, "%.3g", 1);
 }
 
 template <>
 bool DragFloat<float>(const char* label, float* v, float v_speed, float v_min, float v_max) {
-    return ImGui::DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, "%.3f", 1);
+    return ImGui::DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, "%.3g", 1);
 }
 
 inline void BeginDisabledControls(bool cond) {
@@ -1380,7 +1452,7 @@ void ShowAxisContextMenu(ImPlotAxis& axis, ImPlotAxis* equal_axis, bool /*time_a
         double temp_min = axis.Range.Min;
         if (DragFloat("Min", &temp_min, (float)drag_speed, -HUGE_VAL, axis.Range.Max - DBL_EPSILON)) {
             axis.SetMin(temp_min,true);
-            if (equal_axis != NULL)
+            if (equal_axis != nullptr)
                 equal_axis->SetAspect(axis.GetAspect());
         }
         EndDisabledControls(axis.IsLockedMin() || always_locked);
@@ -1393,7 +1465,7 @@ void ShowAxisContextMenu(ImPlotAxis& axis, ImPlotAxis* equal_axis, bool /*time_a
         double temp_max = axis.Range.Max;
         if (DragFloat("Max", &temp_max, (float)drag_speed, axis.Range.Min + DBL_EPSILON, HUGE_VAL)) {
             axis.SetMax(temp_max,true);
-            if (equal_axis != NULL)
+            if (equal_axis != nullptr)
                 equal_axis->SetAspect(axis.GetAspect());
         }
         EndDisabledControls(axis.IsLockedMax() || always_locked);
@@ -1456,33 +1528,34 @@ bool ShowLegendContextMenu(ImPlotLegend& legend, bool visible) {
 
 void ShowSubplotsContextMenu(ImPlotSubplot& subplot) {
     if ((ImGui::BeginMenu("Linking"))) {
-        if (ImGui::MenuItem("Link Rows",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows)))
+        if (ImGui::MenuItem("Link Rows",nullptr,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows);
-        if (ImGui::MenuItem("Link Cols",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkCols)))
+        if (ImGui::MenuItem("Link Cols",nullptr,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkCols)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkCols);
-        if (ImGui::MenuItem("Link All X",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllX)))
+        if (ImGui::MenuItem("Link All X",nullptr,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllX)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllX);
-        if (ImGui::MenuItem("Link All Y",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY)))
+        if (ImGui::MenuItem("Link All Y",nullptr,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY);
         ImGui::EndMenu();
     }
     if ((ImGui::BeginMenu("Settings"))) {
         BeginDisabledControls(!subplot.HasTitle);
-        if (ImGui::MenuItem("Title",NULL,subplot.HasTitle && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle)))
+        if (ImGui::MenuItem("Title",nullptr,subplot.HasTitle && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle);
         EndDisabledControls(!subplot.HasTitle);
-        if (ImGui::MenuItem("Resizable",NULL,!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoResize)))
+        if (ImGui::MenuItem("Resizable",nullptr,!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoResize)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_NoResize);
-        if (ImGui::MenuItem("Align",NULL,!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoAlign)))
+        if (ImGui::MenuItem("Align",nullptr,!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoAlign)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_NoAlign);
-        if (ImGui::MenuItem("Share Items",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems)))
+        if (ImGui::MenuItem("Share Items",nullptr,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems);
         ImGui::EndMenu();
     }
 }
 
 void ShowPlotContextMenu(ImPlotPlot& plot) {
-    const bool owns_legend = GImPlot->CurrentItems == &plot.Items;
+    ImPlotContext& gp = *GImPlot;
+    const bool owns_legend = gp.CurrentItems == &plot.Items;
     const bool equal = ImHasFlag(plot.Flags, ImPlotFlags_Equal);
 
     char buf[16] = {};
@@ -1494,7 +1567,7 @@ void ShowPlotContextMenu(ImPlotPlot& plot) {
         ImGui::PushID(i);
         ImFormatString(buf, sizeof(buf) - 1, i == 0 ? "X-Axis" : "X-Axis %d", i + 1);
         if (ImGui::BeginMenu(x_axis.HasLabel() ? plot.GetAxisLabel(x_axis) : buf)) {
-            ShowAxisContextMenu(x_axis, equal ? x_axis.OrthoAxis : NULL, false);
+            ShowAxisContextMenu(x_axis, equal ? x_axis.OrthoAxis : nullptr, false);
             ImGui::EndMenu();
         }
         ImGui::PopID();
@@ -1507,45 +1580,45 @@ void ShowPlotContextMenu(ImPlotPlot& plot) {
         ImGui::PushID(i);
         ImFormatString(buf, sizeof(buf) - 1, i == 0 ? "Y-Axis" : "Y-Axis %d", i + 1);
         if (ImGui::BeginMenu(y_axis.HasLabel() ? plot.GetAxisLabel(y_axis) : buf)) {
-            ShowAxisContextMenu(y_axis, equal ? y_axis.OrthoAxis : NULL, false);
+            ShowAxisContextMenu(y_axis, equal ? y_axis.OrthoAxis : nullptr, false);
             ImGui::EndMenu();
         }
         ImGui::PopID();
     }
 
     ImGui::Separator();
-    if (!ImHasFlag(GImPlot->CurrentItems->Legend.Flags, ImPlotLegendFlags_NoMenus)) {
+    if (!ImHasFlag(gp.CurrentItems->Legend.Flags, ImPlotLegendFlags_NoMenus)) {
         if ((ImGui::BeginMenu("Legend"))) {
             if (owns_legend) {
                 if (ShowLegendContextMenu(plot.Items.Legend, !ImHasFlag(plot.Flags, ImPlotFlags_NoLegend)))
                     ImFlipFlag(plot.Flags, ImPlotFlags_NoLegend);
             }
-            else if (GImPlot->CurrentSubplot != NULL) {
-                if (ShowLegendContextMenu(GImPlot->CurrentSubplot->Items.Legend, !ImHasFlag(GImPlot->CurrentSubplot->Flags, ImPlotSubplotFlags_NoLegend)))
-                    ImFlipFlag(GImPlot->CurrentSubplot->Flags, ImPlotSubplotFlags_NoLegend);
+            else if (gp.CurrentSubplot != nullptr) {
+                if (ShowLegendContextMenu(gp.CurrentSubplot->Items.Legend, !ImHasFlag(gp.CurrentSubplot->Flags, ImPlotSubplotFlags_NoLegend)))
+                    ImFlipFlag(gp.CurrentSubplot->Flags, ImPlotSubplotFlags_NoLegend);
             }
             ImGui::EndMenu();
         }
     }
     if ((ImGui::BeginMenu("Settings"))) {
-        if (ImGui::MenuItem("Equal", NULL, ImHasFlag(plot.Flags, ImPlotFlags_Equal)))
+        if (ImGui::MenuItem("Equal", nullptr, ImHasFlag(plot.Flags, ImPlotFlags_Equal)))
             ImFlipFlag(plot.Flags, ImPlotFlags_Equal);
-        if (ImGui::MenuItem("Box Select",NULL,!ImHasFlag(plot.Flags, ImPlotFlags_NoBoxSelect)))
+        if (ImGui::MenuItem("Box Select",nullptr,!ImHasFlag(plot.Flags, ImPlotFlags_NoBoxSelect)))
             ImFlipFlag(plot.Flags, ImPlotFlags_NoBoxSelect);
         BeginDisabledControls(plot.TitleOffset == -1);
-        if (ImGui::MenuItem("Title",NULL,plot.HasTitle()))
+        if (ImGui::MenuItem("Title",nullptr,plot.HasTitle()))
             ImFlipFlag(plot.Flags, ImPlotFlags_NoTitle);
         EndDisabledControls(plot.TitleOffset == -1);
-        if (ImGui::MenuItem("Mouse Position",NULL,!ImHasFlag(plot.Flags, ImPlotFlags_NoMouseText)))
+        if (ImGui::MenuItem("Mouse Position",nullptr,!ImHasFlag(plot.Flags, ImPlotFlags_NoMouseText)))
             ImFlipFlag(plot.Flags, ImPlotFlags_NoMouseText);
-        if (ImGui::MenuItem("Crosshairs",NULL,ImHasFlag(plot.Flags, ImPlotFlags_Crosshairs)))
+        if (ImGui::MenuItem("Crosshairs",nullptr,ImHasFlag(plot.Flags, ImPlotFlags_Crosshairs)))
             ImFlipFlag(plot.Flags, ImPlotFlags_Crosshairs);
         ImGui::EndMenu();
     }
-    if (GImPlot->CurrentSubplot != NULL && !ImHasFlag(GImPlot->CurrentPlot->Flags, ImPlotSubplotFlags_NoMenus)) {
+    if (gp.CurrentSubplot != nullptr && !ImHasFlag(gp.CurrentSubplot->Flags, ImPlotSubplotFlags_NoMenus)) {
         ImGui::Separator();
         if ((ImGui::BeginMenu("Subplots"))) {
-            ShowSubplotsContextMenu(*GImPlot->CurrentSubplot);
+            ShowSubplotsContextMenu(*gp.CurrentSubplot);
             ImGui::EndMenu();
         }
     }
@@ -1618,8 +1691,10 @@ void PadAndDatumAxesX(ImPlotPlot& plot, float& pad_T, float& pad_B, ImPlotAlignm
         if (opp) {
             if (count_T++ > 0)
                 pad_T += K + P;
-            if (label)
-                pad_T += T + P;
+            if (label) {
+                ImVec2 label_size = ImGui::CalcTextSize(plot.GetAxisLabel(axis));
+                pad_T += label_size.y + P;
+            }
             if (ticks)
                 pad_T += ImMax(T, axis.Ticker.MaxSize.y) + P + (time ? T + P : 0);
             axis.Datum1 = plot.CanvasRect.Min.y + pad_T;
@@ -1629,8 +1704,10 @@ void PadAndDatumAxesX(ImPlotPlot& plot, float& pad_T, float& pad_B, ImPlotAlignm
         else {
             if (count_B++ > 0)
                 pad_B += K + P;
-            if (label)
-                pad_B += T + P;
+            if (label) {
+                ImVec2 label_size = ImGui::CalcTextSize(plot.GetAxisLabel(axis));
+                pad_B += label_size.y + P;
+            }
             if (ticks)
                 pad_B += ImMax(T, axis.Ticker.MaxSize.y) + P + (time ? T + P : 0);
             axis.Datum1 = plot.CanvasRect.Max.y - pad_B;
@@ -1790,8 +1867,8 @@ static inline void RenderSelectionRect(ImDrawList& DrawList, const ImVec2& p_min
 // Input Handling
 //-----------------------------------------------------------------------------
 
-static const float MOUSE_CURSOR_DRAG_THRESHOLD = 5.0f;
-static const float BOX_SELECT_DRAG_THRESHOLD   = 4.0f;
+constexpr float MOUSE_CURSOR_DRAG_THRESHOLD = 5.0f;
+constexpr float BOX_SELECT_DRAG_THRESHOLD   = 4.0f;
 
 bool UpdateInput(ImPlotPlot& plot) {
 
@@ -1802,7 +1879,7 @@ bool UpdateInput(ImPlotPlot& plot) {
 
     // BUTTON STATE -----------------------------------------------------------
 
-    const ImGuiButtonFlags plot_button_flags = ImGuiButtonFlags_AllowItemOverlap
+    const ImGuiButtonFlags plot_button_flags = ImGuiButtonFlags_AllowOverlap
                                              | ImGuiButtonFlags_PressedOnClick
                                              | ImGuiButtonFlags_PressedOnDoubleClick
                                              | ImGuiButtonFlags_MouseButtonLeft
@@ -1812,7 +1889,9 @@ bool UpdateInput(ImPlotPlot& plot) {
                                              | plot_button_flags;
 
     const bool plot_clicked = ImGui::ButtonBehavior(plot.PlotRect,plot.ID,&plot.Hovered,&plot.Held,plot_button_flags);
-    ImGui::SetItemAllowOverlap();
+#if (IMGUI_VERSION_NUM < 18966)
+    ImGui::SetItemAllowOverlap(); // Handled by ButtonBehavior()
+#endif
 
     if (plot_clicked) {
         if (!ImHasFlag(plot.Flags, ImPlotFlags_NoBoxSelect) && IO.MouseClicked[gp.InputMap.Select] && ImHasFlag(IO.KeyMods, gp.InputMap.SelectMod)) {
@@ -1911,7 +1990,7 @@ bool UpdateInput(ImPlotPlot& plot) {
                     const double plot_r = x_axis.PixelsToPlot(plot.PlotRect.Max.x - IO.MouseDelta.x);
                     x_axis.SetMin(x_axis.IsInverted() ? plot_r : plot_l);
                     x_axis.SetMax(x_axis.IsInverted() ? plot_l : plot_r);
-                    if (axis_equal && x_axis.OrthoAxis != NULL)
+                    if (axis_equal && x_axis.OrthoAxis != nullptr)
                         x_axis.OrthoAxis->SetAspect(x_axis.GetAspect());
                     changed = true;
                 }
@@ -1927,7 +2006,7 @@ bool UpdateInput(ImPlotPlot& plot) {
                     const double plot_b = y_axis.PixelsToPlot(plot.PlotRect.Max.y - IO.MouseDelta.y);
                     y_axis.SetMin(y_axis.IsInverted() ? plot_t : plot_b);
                     y_axis.SetMax(y_axis.IsInverted() ? plot_b : plot_t);
-                    if (axis_equal && y_axis.OrthoAxis != NULL)
+                    if (axis_equal && y_axis.OrthoAxis != nullptr)
                         y_axis.OrthoAxis->SetAspect(y_axis.GetAspect());
                     changed = true;
                 }
@@ -1945,44 +2024,58 @@ bool UpdateInput(ImPlotPlot& plot) {
 
     // SCROLL INPUT -----------------------------------------------------------
 
-    if (any_hov && IO.MouseWheel != 0 && ImHasFlag(IO.KeyMods, gp.InputMap.ZoomMod)) {
+    if (any_hov && ImHasFlag(IO.KeyMods, gp.InputMap.ZoomMod)) {
 
         float zoom_rate = gp.InputMap.ZoomRate;
-        if (IO.MouseWheel > 0)
+        if (IO.MouseWheel == 0.0f)
+            zoom_rate = 0;
+        else if (IO.MouseWheel > 0)
             zoom_rate = (-zoom_rate) / (1.0f + (2.0f * zoom_rate));
         ImVec2 rect_size = plot.PlotRect.GetSize();
         float tx = ImRemap(IO.MousePos.x, plot.PlotRect.Min.x, plot.PlotRect.Max.x, 0.0f, 1.0f);
         float ty = ImRemap(IO.MousePos.y, plot.PlotRect.Min.y, plot.PlotRect.Max.y, 0.0f, 1.0f);
 
+        // Track which axis to use as reference for equal aspect
+        ImPlotAxis* equal_ref_axis = nullptr;
+
         for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
             ImPlotAxis& x_axis = plot.XAxis(i);
-            const bool equal_zoom   = axis_equal && x_axis.OrthoAxis != NULL;
+            const bool equal_zoom   = axis_equal && x_axis.OrthoAxis != nullptr;
             const bool equal_locked = (equal_zoom != false) && x_axis.OrthoAxis->IsInputLocked();
             if (x_hov[i] && !x_axis.IsInputLocked() && !equal_locked) {
-                float correction = (plot.Hovered && equal_zoom) ? 0.5f : 1.0f;
-                const double plot_l = x_axis.PixelsToPlot(plot.PlotRect.Min.x - rect_size.x * tx * zoom_rate * correction);
-                const double plot_r = x_axis.PixelsToPlot(plot.PlotRect.Max.x + rect_size.x * (1 - tx) * zoom_rate * correction);
-                x_axis.SetMin(x_axis.IsInverted() ? plot_r : plot_l);
-                x_axis.SetMax(x_axis.IsInverted() ? plot_l : plot_r);
-                if (axis_equal && x_axis.OrthoAxis != NULL)
-                    x_axis.OrthoAxis->SetAspect(x_axis.GetAspect());
-                changed = true;
+                ImGui::SetKeyOwner(ImGuiKey_MouseWheelY, plot.ID);
+                if (zoom_rate != 0.0f) {
+                    const double plot_l = x_axis.PixelsToPlot(plot.PlotRect.Min.x - rect_size.x * tx * zoom_rate);
+                    const double plot_r = x_axis.PixelsToPlot(plot.PlotRect.Max.x + rect_size.x * (1 - tx) * zoom_rate);
+                    x_axis.SetMin(x_axis.IsInverted() ? plot_r : plot_l);
+                    x_axis.SetMax(x_axis.IsInverted() ? plot_l : plot_r);
+                    if (equal_zoom)
+                        equal_ref_axis = &x_axis;
+                    changed = true;
+                }
             }
         }
         for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
             ImPlotAxis& y_axis = plot.YAxis(i);
-            const bool equal_zoom   = axis_equal && y_axis.OrthoAxis != NULL;
+            const bool equal_zoom   = axis_equal && y_axis.OrthoAxis != nullptr;
             const bool equal_locked = equal_zoom && y_axis.OrthoAxis->IsInputLocked();
             if (y_hov[i] && !y_axis.IsInputLocked() && !equal_locked) {
-                float correction = (plot.Hovered && equal_zoom) ? 0.5f : 1.0f;
-                const double plot_t = y_axis.PixelsToPlot(plot.PlotRect.Min.y - rect_size.y * ty * zoom_rate * correction);
-                const double plot_b = y_axis.PixelsToPlot(plot.PlotRect.Max.y + rect_size.y * (1 - ty) * zoom_rate * correction);
-                y_axis.SetMin(y_axis.IsInverted() ? plot_t : plot_b);
-                y_axis.SetMax(y_axis.IsInverted() ? plot_b : plot_t);
-                if (axis_equal && y_axis.OrthoAxis != NULL)
-                    y_axis.OrthoAxis->SetAspect(y_axis.GetAspect());
-                changed = true;
+                ImGui::SetKeyOwner(ImGuiKey_MouseWheelY, plot.ID);
+                if (zoom_rate != 0.0f) {
+                    const double plot_t = y_axis.PixelsToPlot(plot.PlotRect.Min.y - rect_size.y * ty * zoom_rate);
+                    const double plot_b = y_axis.PixelsToPlot(plot.PlotRect.Max.y + rect_size.y * (1 - ty) * zoom_rate);
+                    y_axis.SetMin(y_axis.IsInverted() ? plot_t : plot_b);
+                    y_axis.SetMax(y_axis.IsInverted() ? plot_b : plot_t);
+                    if (equal_zoom)
+                        equal_ref_axis = &y_axis;
+                    changed = true;
+                }
             }
+        }
+
+        // Apply equal aspect constraint after zooming both axes
+        if (equal_ref_axis != nullptr && equal_ref_axis->OrthoAxis != nullptr) {
+            equal_ref_axis->OrthoAxis->SetAspect(equal_ref_axis->GetAspect());
         }
     }
 
@@ -2056,7 +2149,7 @@ bool UpdateInput(ImPlotPlot& plot) {
 
 void ApplyNextPlotData(ImAxis idx) {
     ImPlotContext& gp = *GImPlot;
-    ImPlotPlot& plot  = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot  = *gp.CurrentPlot;
     ImPlotAxis& axis  = plot.Axes[idx];
     if (!axis.Enabled)
         return;
@@ -2081,10 +2174,11 @@ void ApplyNextPlotData(ImAxis idx) {
 //-----------------------------------------------------------------------------
 
 void SetupAxis(ImAxis idx, const char* label, ImPlotAxisFlags flags) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
     // get plot and axis
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     // set ID
     axis.ID = plot.ID + idx + 1;
@@ -2101,9 +2195,10 @@ void SetupAxis(ImAxis idx, const char* label, ImPlotAxisFlags flags) {
 }
 
 void SetupAxisLimits(ImAxis idx, double min_lim, double max_lim, ImPlotCond cond) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");    // get plot and axis
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     if (!plot.Initialized || cond == ImPlotCond_Always)
@@ -2113,20 +2208,22 @@ void SetupAxisLimits(ImAxis idx, double min_lim, double max_lim, ImPlotCond cond
 }
 
 void SetupAxisFormat(ImAxis idx, const char* fmt) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
-    axis.HasFormatSpec = fmt != NULL;
-    if (fmt != NULL)
+    axis.HasFormatSpec = fmt != nullptr;
+    if (fmt != nullptr)
         ImStrncpy(axis.FormatSpec,fmt,sizeof(axis.FormatSpec));
 }
 
 void SetupAxisLinks(ImAxis idx, double* min_lnk, double* max_lnk) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     axis.LinkedMin = min_lnk;
@@ -2135,9 +2232,10 @@ void SetupAxisLinks(ImAxis idx, double* min_lnk, double* max_lnk) {
 }
 
 void SetupAxisFormat(ImAxis idx, ImPlotFormatter formatter, void* data) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     axis.Formatter = formatter;
@@ -2145,9 +2243,10 @@ void SetupAxisFormat(ImAxis idx, ImPlotFormatter formatter, void* data) {
 }
 
 void SetupAxisTicks(ImAxis idx, const double* values, int n_ticks, const char* const labels[], bool show_default) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     axis.ShowDefaultTicks = show_default;
@@ -2160,26 +2259,30 @@ void SetupAxisTicks(ImAxis idx, const double* values, int n_ticks, const char* c
 }
 
 void SetupAxisTicks(ImAxis idx, double v_min, double v_max, int n_ticks, const char* const labels[], bool show_default) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
+    IM_ASSERT_USER_ERROR(labels == nullptr || n_ticks >= 2,
+                         "When providing custom labels, n_ticks must be at least 2!");
     n_ticks = n_ticks < 2 ? 2 : n_ticks;
-    FillRange(GImPlot->TempDouble1, n_ticks, v_min, v_max);
-    SetupAxisTicks(idx, GImPlot->TempDouble1.Data, n_ticks, labels, show_default);
+    FillRange(gp.TempDouble1, n_ticks, v_min, v_max);
+    SetupAxisTicks(idx, gp.TempDouble1.Data, n_ticks, labels, show_default);
 }
 
 void SetupAxisScale(ImAxis idx, ImPlotScale scale) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     axis.Scale = scale;
     switch (scale)
     {
     case ImPlotScale_Time:
-        axis.TransformForward = NULL;
-        axis.TransformInverse = NULL;
-        axis.TransformData    = NULL;
+        axis.TransformForward = nullptr;
+        axis.TransformInverse = nullptr;
+        axis.TransformData    = nullptr;
         axis.Locator          = Locator_Time;
         axis.ConstraintRange  = ImPlotRange(IMPLOT_MIN_TIME, IMPLOT_MAX_TIME);
         axis.Ticker.Levels    = 2;
@@ -2187,31 +2290,32 @@ void SetupAxisScale(ImAxis idx, ImPlotScale scale) {
     case ImPlotScale_Log10:
         axis.TransformForward = TransformForward_Log10;
         axis.TransformInverse = TransformInverse_Log10;
-        axis.TransformData    = NULL;
+        axis.TransformData    = nullptr;
         axis.Locator          = Locator_Log10;
         axis.ConstraintRange  = ImPlotRange(DBL_MIN, INFINITY);
         break;
     case ImPlotScale_SymLog:
         axis.TransformForward = TransformForward_SymLog;
         axis.TransformInverse = TransformInverse_SymLog;
-        axis.TransformData    = NULL;
+        axis.TransformData    = nullptr;
         axis.Locator          = Locator_SymLog;
         axis.ConstraintRange  = ImPlotRange(-INFINITY, INFINITY);
         break;
     default:
-        axis.TransformForward = NULL;
-        axis.TransformInverse = NULL;
-        axis.TransformData    = NULL;
-        axis.Locator          = NULL;
+        axis.TransformForward = nullptr;
+        axis.TransformInverse = nullptr;
+        axis.TransformData    = nullptr;
+        axis.Locator          = nullptr;
         axis.ConstraintRange  = ImPlotRange(-INFINITY, INFINITY);
         break;
     }
 }
 
 void SetupAxisScale(ImAxis idx, ImPlotTransform fwd, ImPlotTransform inv, void* data) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     axis.Scale = IMPLOT_AUTO;
@@ -2221,9 +2325,10 @@ void SetupAxisScale(ImAxis idx, ImPlotTransform fwd, ImPlotTransform inv, void* 
 }
 
 void SetupAxisLimitsConstraints(ImAxis idx, double v_min, double v_max) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     axis.ConstraintRange.Min = v_min;
@@ -2231,9 +2336,10 @@ void SetupAxisLimitsConstraints(ImAxis idx, double v_min, double v_max) {
 }
 
 void SetupAxisZoomConstraints(ImAxis idx, double z_min, double z_max) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    ImPlotPlot& plot = *GImPlot->CurrentPlot;
+    ImPlotPlot& plot = *gp.CurrentPlot;
     ImPlotAxis& axis = plot.Axes[idx];
     IM_ASSERT_USER_ERROR(axis.Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     axis.ConstraintZoom.Min = z_min;
@@ -2251,26 +2357,28 @@ void SetupAxesLimits(double x_min, double x_max, double y_min, double y_max, ImP
 }
 
 void SetupLegend(ImPlotLocation location, ImPlotLegendFlags flags) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
-                         "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentItems != NULL,
-                         "SetupLegend() needs to be called within an itemized context!");
-    ImPlotLegend& legend = GImPlot->CurrentItems->Legend;
-    // check and set location
-    if (location != legend.PreviousLocation)
-        legend.Location = location;
-    legend.PreviousLocation = location;
-    // check and set flags
-    if (flags != legend.PreviousFlags)
-        legend.Flags = flags;
-    legend.PreviousFlags = flags;
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR((gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked) || (gp.CurrentSubplot != nullptr && gp.CurrentPlot == nullptr),
+                         "Setup needs to be called after BeginPlot or BeginSubplots and before any setup locking functions (e.g. PlotX)!");
+    if (gp.CurrentItems) {
+        ImPlotLegend& legend = gp.CurrentItems->Legend;
+        // check and set location
+        if (location != legend.PreviousLocation)
+            legend.Location = location;
+        legend.PreviousLocation = location;
+        // check and set flags
+        if (flags != legend.PreviousFlags)
+            legend.Flags = flags;
+        legend.PreviousFlags = flags;
+    }
 }
 
 void SetupMouseText(ImPlotLocation location, ImPlotMouseTextFlags flags) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL && !GImPlot->CurrentPlot->SetupLocked,
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr && !gp.CurrentPlot->SetupLocked,
                          "Setup needs to be called after BeginPlot and before any setup locking functions (e.g. PlotX)!");
-    GImPlot->CurrentPlot->MouseTextLocation = location;
-    GImPlot->CurrentPlot->MouseTextFlags = flags;
+    gp.CurrentPlot->MouseTextLocation = location;
+    gp.CurrentPlot->MouseTextFlags = flags;
 }
 
 //-----------------------------------------------------------------------------
@@ -2279,7 +2387,7 @@ void SetupMouseText(ImPlotLocation location, ImPlotMouseTextFlags flags) {
 
 void SetNextAxisLimits(ImAxis axis, double v_min, double v_max, ImPlotCond cond) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot == NULL, "SetNextAxisLimits() needs to be called before BeginPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot == nullptr, "SetNextAxisLimits() needs to be called before BeginPlot()!");
     IM_ASSERT(cond == 0 || ImIsPowerOfTwo(cond)); // Make sure the user doesn't attempt to combine multiple condition flags.
     gp.NextPlotData.HasRange[axis]  = true;
     gp.NextPlotData.RangeCond[axis] = cond;
@@ -2289,14 +2397,14 @@ void SetNextAxisLimits(ImAxis axis, double v_min, double v_max, ImPlotCond cond)
 
 void SetNextAxisLinks(ImAxis axis, double* link_min, double* link_max) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot == NULL, "SetNextAxisLinks() needs to be called before BeginPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot == nullptr, "SetNextAxisLinks() needs to be called before BeginPlot()!");
     gp.NextPlotData.LinkedMin[axis] = link_min;
     gp.NextPlotData.LinkedMax[axis] = link_max;
 }
 
 void SetNextAxisToFit(ImAxis axis) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot == NULL, "SetNextAxisToFit() needs to be called before BeginPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot == nullptr, "SetNextAxisToFit() needs to be called before BeginPlot()!");
     gp.NextPlotData.Fit[axis] = true;
 }
 
@@ -2315,16 +2423,16 @@ void SetNextAxesToFit() {
 //-----------------------------------------------------------------------------
 
 bool BeginPlot(const char* title_id, const ImVec2& size, ImPlotFlags flags) {
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot == NULL, "Mismatched BeginPlot()/EndPlot()!");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot == nullptr, "Mismatched BeginPlot()/EndPlot()!");
 
     // FRONT MATTER -----------------------------------------------------------
 
-    if (GImPlot->CurrentSubplot != NULL)
-        ImGui::PushID(GImPlot->CurrentSubplot->CurrentIdx);
+    if (gp.CurrentSubplot != nullptr)
+        ImGui::PushID(gp.CurrentSubplot->CurrentIdx);
 
     // get globals
-    ImPlotContext& gp        = *GImPlot;
     ImGuiContext &G          = *GImGui;
     ImGuiWindow* Window      = G.CurrentWindow;
 
@@ -2336,7 +2444,7 @@ bool BeginPlot(const char* title_id, const ImVec2& size, ImPlotFlags flags) {
 
     // ID and age (TODO: keep track of plot age in frames)
     const ImGuiID ID         = Window->GetID(title_id);
-    const bool just_created  = gp.Plots.GetByKey(ID) == NULL;
+    const bool just_created  = gp.Plots.GetByKey(ID) == nullptr;
     gp.CurrentPlot           = gp.Plots.GetOrAddByKey(ID);
 
     ImPlotPlot &plot         = *gp.CurrentPlot;
@@ -2374,36 +2482,20 @@ bool BeginPlot(const char* title_id, const ImVec2& size, ImPlotFlags flags) {
     for (int i = 0; i < ImAxis_COUNT; ++i)
         ApplyNextPlotData(i);
 
-    // capture scroll with a child region
-    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoChild)) {
-        ImVec2 child_size;
-        if (gp.CurrentSubplot != NULL)
-            child_size = gp.CurrentSubplot->CellSize;
-        else
-            child_size = ImVec2(size.x == 0 ? gp.Style.PlotDefaultSize.x : size.x, size.y == 0 ? gp.Style.PlotDefaultSize.y : size.y);
-        ImGui::BeginChild(title_id, child_size, false, ImGuiWindowFlags_NoScrollbar);
-        Window = ImGui::GetCurrentWindow();
-        Window->ScrollMax.y = 1.0f;
-        gp.ChildWindowMade = true;
-    }
-    else {
-        gp.ChildWindowMade = false;
-    }
-
     // clear text buffers
     plot.ClearTextBuffer();
     plot.SetTitle(title_id);
 
     // set frame size
     ImVec2 frame_size;
-    if (gp.CurrentSubplot != NULL)
+    if (gp.CurrentSubplot != nullptr)
         frame_size = gp.CurrentSubplot->CellSize;
     else
         frame_size = ImGui::CalcItemSize(size, gp.Style.PlotDefaultSize.x, gp.Style.PlotDefaultSize.y);
 
-    if (frame_size.x < gp.Style.PlotMinSize.x && (size.x < 0.0f || gp.CurrentSubplot != NULL))
+    if (frame_size.x < gp.Style.PlotMinSize.x && (size.x < 0.0f || gp.CurrentSubplot != nullptr))
         frame_size.x = gp.Style.PlotMinSize.x;
-    if (frame_size.y < gp.Style.PlotMinSize.y && (size.y < 0.0f || gp.CurrentSubplot != NULL))
+    if (frame_size.y < gp.Style.PlotMinSize.y && (size.y < 0.0f || gp.CurrentSubplot != nullptr))
         frame_size.y = gp.Style.PlotMinSize.y;
 
     plot.FrameRect = ImRect(Window->DC.CursorPos, Window->DC.CursorPos + frame_size);
@@ -2414,7 +2506,7 @@ bool BeginPlot(const char* title_id, const ImVec2& size, ImPlotFlags flags) {
     }
 
     // setup items (or dont)
-    if (gp.CurrentItems == NULL)
+    if (gp.CurrentItems == nullptr)
         gp.CurrentItems = &plot.Items;
 
     return true;
@@ -2425,10 +2517,10 @@ bool BeginPlot(const char* title_id, const ImVec2& size, ImPlotFlags flags) {
 //-----------------------------------------------------------------------------
 
 void SetupFinish() {
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "SetupFinish needs to be called after BeginPlot!");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "SetupFinish needs to be called after BeginPlot!");
 
-    ImPlotContext& gp       = *GImPlot;
     ImGuiContext& G         = *GImGui;
     ImDrawList& DrawList    = *G.CurrentWindow->DrawList;
     const ImGuiStyle& Style = G.Style;
@@ -2446,36 +2538,36 @@ void SetupFinish() {
             if (!plot.Initialized && axis.CanInitFit())
                 plot.FitThisFrame = axis.FitThisFrame = true;
         }
-        if (axis.Formatter == NULL) {
+        if (axis.Formatter == nullptr) {
             axis.Formatter = Formatter_Default;
             if (axis.HasFormatSpec)
                 axis.FormatterData = axis.FormatSpec;
             else
                 axis.FormatterData = (void*)IMPLOT_LABEL_FORMAT;
         }
-        if (axis.Locator == NULL) {
+        if (axis.Locator == nullptr) {
             axis.Locator = Locator_Default;
         }
     }
 
-    // setup NULL orthogonal axes
+    // setup nullptr orthogonal axes
     const bool axis_equal = ImHasFlag(plot.Flags, ImPlotFlags_Equal);
     for (int ix = ImAxis_X1, iy = ImAxis_Y1; ix < ImAxis_Y1 || iy < ImAxis_COUNT; ++ix, ++iy) {
         ImPlotAxis& x_axis = plot.Axes[ix];
         ImPlotAxis& y_axis = plot.Axes[iy];
         if (x_axis.Enabled && y_axis.Enabled) {
-            if (x_axis.OrthoAxis == NULL)
+            if (x_axis.OrthoAxis == nullptr)
                 x_axis.OrthoAxis = &y_axis;
-            if (y_axis.OrthoAxis == NULL)
+            if (y_axis.OrthoAxis == nullptr)
                 y_axis.OrthoAxis = &x_axis;
         }
         else if (x_axis.Enabled)
         {
-            if (x_axis.OrthoAxis == NULL && !axis_equal)
+            if (x_axis.OrthoAxis == nullptr && !axis_equal)
                 x_axis.OrthoAxis = &plot.Axes[ImAxis_Y1];
         }
         else if (y_axis.Enabled) {
-            if (y_axis.OrthoAxis == NULL && !axis_equal)
+            if (y_axis.OrthoAxis == nullptr && !axis_equal)
                 y_axis.OrthoAxis = &plot.Axes[ImAxis_X1];
         }
     }
@@ -2517,7 +2609,7 @@ void SetupFinish() {
     // (0) calc top padding form title
     ImVec2 title_size(0.0f, 0.0f);
     if (plot.HasTitle())
-         title_size = ImGui::CalcTextSize(plot.GetTitle(), NULL, true);
+         title_size = ImGui::CalcTextSize(plot.GetTitle(), nullptr, true);
     if (title_size.x > 0) {
         pad_top += title_size.y + gp.Style.LabelPadding.y;
         plot.AxesRect.Min.y += gp.Style.PlotPadding.y + pad_top;
@@ -2531,7 +2623,7 @@ void SetupFinish() {
     // (2) get y tick labels (needed for left/right pad)
     for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
         ImPlotAxis& axis = plot.YAxis(i);
-        if (axis.WillRender() && axis.ShowDefaultTicks) {
+        if (axis.WillRender() && axis.ShowDefaultTicks && plot_height > 0) {
             axis.Locator(axis.Ticker, axis.Range, plot_height, true, axis.Formatter, axis.FormatterData);
         }
     }
@@ -2544,9 +2636,20 @@ void SetupFinish() {
     // (4) get x ticks
     for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
         ImPlotAxis& axis = plot.XAxis(i);
-        if (axis.WillRender() && axis.ShowDefaultTicks) {
+        if (axis.WillRender() && axis.ShowDefaultTicks && plot_width > 0) {
             axis.Locator(axis.Ticker, axis.Range, plot_width, false, axis.Formatter, axis.FormatterData);
         }
+    }
+
+    // (4.5) recalc padding now that we have actual X-axis tick labels (handles multi-line labels)
+    // Save title padding before resetting
+    const float title_pad = (title_size.x > 0) ? (title_size.y + gp.Style.LabelPadding.y) : 0.0f;
+    pad_top = title_pad;
+    pad_bot = 0;
+    PadAndDatumAxesX(plot,pad_top,pad_bot,gp.CurrentAlignmentH);
+    // Update AxesRect to account for title padding (was done in step 0)
+    if (title_size.x > 0) {
+        plot.AxesRect.Min.y = plot.FrameRect.Min.y + gp.Style.PlotPadding.y + title_pad;
     }
 
     // (5) calc plot bb
@@ -2578,7 +2681,7 @@ void SetupFinish() {
     if (axis_equal) {
         for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i) {
             ImPlotAxis& x_axis = plot.XAxis(i);
-            if (x_axis.OrthoAxis == NULL)
+            if (x_axis.OrthoAxis == nullptr)
                 continue;
             double xar = x_axis.GetAspect();
             double yar = x_axis.OrthoAxis->GetAspect();
@@ -2725,12 +2828,12 @@ void SetupFinish() {
 //-----------------------------------------------------------------------------
 
 void EndPlot() {
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "Mismatched BeginPlot()/EndPlot()!");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "Mismatched BeginPlot()/EndPlot()!");
 
     SetupLock();
 
-    ImPlotContext& gp     = *GImPlot;
     ImGuiContext &G       = *GImGui;
     ImPlotPlot &plot      = *gp.CurrentPlot;
     ImGuiWindow * Window  = G.CurrentWindow;
@@ -2739,7 +2842,7 @@ void EndPlot() {
 
     // FINAL RENDER -----------------------------------------------------------
 
-    const bool render_border  = gp.Style.PlotBorderSize > 0 && gp.Style.Colors[ImPlotCol_PlotBorder].w > 0;
+    const bool render_border  = gp.Style.PlotBorderSize > 0 && GetStyleColorVec4(ImPlotCol_PlotBorder).w > 0;
     const bool any_x_held = plot.Held    || AnyAxesHeld(&plot.Axes[ImAxis_X1], IMPLOT_NUM_X_AXES);
     const bool any_y_held = plot.Held    || AnyAxesHeld(&plot.Axes[ImAxis_Y1], IMPLOT_NUM_Y_AXES);
 
@@ -3004,24 +3107,61 @@ void EndPlot() {
                                                   legend.Location,
                                                   legend_out ? gp.Style.PlotPadding : gp.Style.LegendPadding);
         legend.Rect = ImRect(legend_pos, legend_pos + legend_size);
-        // test hover
-        legend.Hovered = ImGui::IsWindowHovered() && legend.Rect.Contains(IO.MousePos);
+        legend.RectClamped = legend.Rect;
+        const bool legend_scrollable = ClampLegendRect(legend.RectClamped,
+                                                        legend_out ? plot.FrameRect : plot.PlotRect,
+                                                        legend_out ? gp.Style.PlotPadding : gp.Style.LegendPadding
+                                                        );
+        const ImGuiButtonFlags legend_button_flags = ImGuiButtonFlags_AllowOverlap
+                                                    | ImGuiButtonFlags_PressedOnClick
+                                                    | ImGuiButtonFlags_PressedOnDoubleClick
+                                                    | ImGuiButtonFlags_MouseButtonLeft
+                                                    | ImGuiButtonFlags_MouseButtonRight
+                                                    | ImGuiButtonFlags_MouseButtonMiddle
+                                                    | ImGuiButtonFlags_FlattenChildren;
+        ImGui::KeepAliveID(plot.Items.ID);
+        ImGui::ButtonBehavior(legend.RectClamped, plot.Items.ID, &legend.Hovered, &legend.Held, legend_button_flags);
+        legend.Hovered = legend.Hovered || (ImGui::IsWindowHovered() && legend.RectClamped.Contains(IO.MousePos));
 
-        if (legend_out)
-            ImGui::PushClipRect(plot.FrameRect.Min, plot.FrameRect.Max, true);
-        else
-            PushPlotClipRect();
-        ImU32  col_bg      = GetStyleColorU32(ImPlotCol_LegendBg);
-        ImU32  col_bd      = GetStyleColorU32(ImPlotCol_LegendBorder);
-        DrawList.AddRectFilled(legend.Rect.Min, legend.Rect.Max, col_bg);
-        DrawList.AddRect(legend.Rect.Min, legend.Rect.Max, col_bd);
+        if (legend_scrollable) {
+            if (legend.Hovered) {
+                ImGui::SetKeyOwner(ImGuiKey_MouseWheelY, plot.Items.ID);
+                if (IO.MouseWheel != 0.0f) {
+                    ImVec2 max_step = legend.Rect.GetSize() * 0.67f;
+#if IMGUI_VERSION_NUM < 19172
+                    float font_size = ImGui::GetCurrentWindow()->CalcFontSize();
+#else
+                    float font_size = ImGui::GetCurrentWindow()->FontRefSize;
+#endif
+                    float scroll_step = ImFloor(ImMin(2 * font_size, max_step.x));
+                    legend.Scroll.x += scroll_step * IO.MouseWheel;
+                    legend.Scroll.y += scroll_step * IO.MouseWheel;
+                }
+            }
+            const ImVec2 min_scroll_offset = legend.RectClamped.GetSize() - legend.Rect.GetSize();
+            legend.Scroll.x = ImClamp(legend.Scroll.x, min_scroll_offset.x, 0.0f);
+            legend.Scroll.y = ImClamp(legend.Scroll.y, min_scroll_offset.y, 0.0f);
+            const ImVec2 scroll_offset = legend_horz ? ImVec2(legend.Scroll.x, 0) : ImVec2(0, legend.Scroll.y);
+            ImVec2 legend_offset = legend.RectClamped.Min - legend.Rect.Min + scroll_offset;
+            legend.Rect.Min += legend_offset;
+            legend.Rect.Max += legend_offset;
+        } else {
+            legend.Scroll = ImVec2(0,0);
+        }
+
+        const ImU32 col_bg  = GetStyleColorU32(ImPlotCol_LegendBg);
+        const ImU32 col_bd  = GetStyleColorU32(ImPlotCol_LegendBorder);
+        ImGui::PushClipRect(legend.RectClamped.Min, legend.RectClamped.Max, true);
+        DrawList.AddRectFilled(legend.RectClamped.Min, legend.RectClamped.Max, col_bg);
         bool legend_contextable = ShowLegendEntries(plot.Items, legend.Rect, legend.Hovered, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, DrawList)
                                 && !ImHasFlag(legend.Flags, ImPlotLegendFlags_NoMenus);
+        DrawList.AddRect(legend.RectClamped.Min, legend.RectClamped.Max, col_bd);
+        ImGui::PopClipRect();
 
         // main ctx menu
         if (gp.OpenContextThisFrame && legend_contextable && !ImHasFlag(plot.Flags, ImPlotFlags_NoMenus))
             ImGui::OpenPopup("##LegendContext");
-        ImGui::PopClipRect();
+
         if (ImGui::BeginPopup("##LegendContext")) {
             ImGui::Text("Legend"); ImGui::Separator();
             if (ShowLegendContextMenu(legend, !ImHasFlag(plot.Flags, ImPlotFlags_NoLegend)))
@@ -3034,8 +3174,13 @@ void EndPlot() {
     }
 
     // render border
+#if IMGUI_VERSION_NUM < 19276
     if (render_border)
-        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, ImDrawFlags_RoundCornersAll, gp.Style.PlotBorderSize);
+        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, ImDrawFlags_None, gp.Style.PlotBorderSize);
+#else
+    if (render_border)
+        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, gp.Style.PlotBorderSize, ImDrawFlags_None);
+#endif
 
     // render tags
     for (int i = 0; i < gp.Tags.Size; ++i) {
@@ -3080,7 +3225,7 @@ void EndPlot() {
             ImPlotAxis& x_axis = plot.XAxis(i);
             if (x_axis.FitThisFrame) {
                 x_axis.ApplyFit(gp.Style.FitPadding.x);
-                if (axis_equal && x_axis.OrthoAxis != NULL) {
+                if (axis_equal && x_axis.OrthoAxis != nullptr) {
                     double aspect = x_axis.GetAspect();
                     ImPlotAxis& y_axis = *x_axis.OrthoAxis;
                     if (y_axis.FitThisFrame) {
@@ -3097,7 +3242,7 @@ void EndPlot() {
             ImPlotAxis& y_axis = plot.YAxis(i);
             if (y_axis.FitThisFrame) {
                 y_axis.ApplyFit(gp.Style.FitPadding.y);
-                if (axis_equal && y_axis.OrthoAxis != NULL) {
+                if (axis_equal && y_axis.OrthoAxis != nullptr) {
                     double aspect = y_axis.GetAspect();
                     ImPlotAxis& x_axis = *y_axis.OrthoAxis;
                     if (x_axis.FitThisFrame) {
@@ -3140,7 +3285,7 @@ void EndPlot() {
         if (ImGui::BeginPopup("##XContext")) {
             ImGui::Text(x_axis.HasLabel() ? plot.GetAxisLabel(x_axis) :  i == 0 ? "X-Axis" : "X-Axis %d", i + 1);
             ImGui::Separator();
-            ShowAxisContextMenu(x_axis, axis_equal ? x_axis.OrthoAxis : NULL, true);
+            ShowAxisContextMenu(x_axis, axis_equal ? x_axis.OrthoAxis : nullptr, true);
             ImGui::EndPopup();
         }
         ImGui::PopID();
@@ -3153,7 +3298,7 @@ void EndPlot() {
         if (ImGui::BeginPopup("##YContext")) {
             ImGui::Text(y_axis.HasLabel() ? plot.GetAxisLabel(y_axis) : i == 0 ? "Y-Axis" : "Y-Axis %d", i + 1);
             ImGui::Separator();
-            ShowAxisContextMenu(y_axis, axis_equal ? y_axis.OrthoAxis : NULL, false);
+            ShowAxisContextMenu(y_axis, axis_equal ? y_axis.OrthoAxis : nullptr, false);
             ImGui::EndPopup();
         }
         ImGui::PopID();
@@ -3170,7 +3315,7 @@ void EndPlot() {
 
     // remove items
     if (gp.CurrentItems == &plot.Items)
-        gp.CurrentItems = NULL;
+        gp.CurrentItems = nullptr;
     // reset the plot items for the next frame
     for (int i = 0; i < plot.Items.GetItemCount(); ++i) {
         plot.Items.GetItemByIndex(i)->SeenThisFrame = false;
@@ -3184,7 +3329,7 @@ void EndPlot() {
     ResetCtxForNextPlot(GImPlot);
 
     // setup next subplot
-    if (gp.CurrentSubplot != NULL) {
+    if (gp.CurrentSubplot != nullptr) {
         ImGui::PopID();
         SubplotNextCell();
     }
@@ -3194,9 +3339,9 @@ void EndPlot() {
 // BEGIN/END SUBPLOT
 //-----------------------------------------------------------------------------
 
-static const float SUBPLOT_BORDER_SIZE             = 1.0f;
-static const float SUBPLOT_SPLITTER_HALF_THICKNESS = 4.0f;
-static const float SUBPLOT_SPLITTER_FEEDBACK_TIMER = 0.06f;
+constexpr float SUBPLOT_BORDER_SIZE             = 1.0f;
+constexpr float SUBPLOT_SPLITTER_HALF_THICKNESS = 4.0f;
+constexpr float SUBPLOT_SPLITTER_FEEDBACK_TIMER = 0.06f;
 
 void SubplotSetCell(int row, int col) {
     ImPlotContext& gp      = *GImPlot;
@@ -3223,10 +3368,10 @@ void SubplotSetCell(int row, int col) {
     const bool lr = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows);
     const bool lc = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkCols);
 
-    SetNextAxisLinks(ImAxis_X1, lx ? &subplot.ColLinkData[0].Min : lc ? &subplot.ColLinkData[col].Min : NULL,
-                                lx ? &subplot.ColLinkData[0].Max : lc ? &subplot.ColLinkData[col].Max : NULL);
-    SetNextAxisLinks(ImAxis_Y1, ly ? &subplot.RowLinkData[0].Min : lr ? &subplot.RowLinkData[row].Min : NULL,
-                                ly ? &subplot.RowLinkData[0].Max : lr ? &subplot.RowLinkData[row].Max : NULL);
+    SetNextAxisLinks(ImAxis_X1, lx ? &subplot.ColLinkData[0].Min : lc ? &subplot.ColLinkData[col].Min : nullptr,
+                                lx ? &subplot.ColLinkData[0].Max : lc ? &subplot.ColLinkData[col].Max : nullptr);
+    SetNextAxisLinks(ImAxis_Y1, ly ? &subplot.RowLinkData[0].Min : lr ? &subplot.RowLinkData[row].Min : nullptr,
+                                ly ? &subplot.RowLinkData[0].Max : lr ? &subplot.RowLinkData[row].Max : nullptr);
     // setup alignment
     if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoAlign)) {
         gp.CurrentAlignmentH = &subplot.RowAlignmentData[row];
@@ -3264,20 +3409,20 @@ void SubplotNextCell() {
 
 bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, ImPlotSubplotFlags flags, float* row_sizes, float* col_sizes) {
     IM_ASSERT_USER_ERROR(rows > 0 && cols > 0, "Invalid sizing arguments!");
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentSubplot == NULL, "Mismatched BeginSubplots()/EndSubplots()!");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
     ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentSubplot == nullptr, "Mismatched BeginSubplots()/EndSubplots()!");
     ImGuiContext &G = *GImGui;
     ImGuiWindow * Window = G.CurrentWindow;
     if (Window->SkipItems)
         return false;
     const ImGuiID ID = Window->GetID(title);
-    bool just_created = gp.Subplots.GetByKey(ID) == NULL;
+    bool just_created = gp.Subplots.GetByKey(ID) == nullptr;
     gp.CurrentSubplot = gp.Subplots.GetOrAddByKey(ID);
     ImPlotSubplot& subplot = *gp.CurrentSubplot;
     subplot.ID       = ID;
     subplot.Items.ID = ID - 1;
-    subplot.HasTitle = ImGui::FindRenderedTextEnd(title, NULL) != title;
+    subplot.HasTitle = ImGui::FindRenderedTextEnd(title, nullptr) != title;
     // push ID
     ImGui::PushID(ID);
 
@@ -3308,12 +3453,12 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     }
     // check incoming size requests
     float row_sum = 0, col_sum = 0;
-    if (row_sizes != NULL) {
+    if (row_sizes != nullptr) {
         row_sum = ImSum(row_sizes, rows);
         for (int r = 0; r < rows; ++r)
             subplot.RowRatios[r] = row_sizes[r] / row_sum;
     }
-    if (col_sizes != NULL) {
+    if (col_sizes != nullptr) {
         col_sum = ImSum(col_sizes, cols);
         for (int c = 0; c < cols; ++c)
             subplot.ColRatios[c] = col_sizes[c] / col_sum;
@@ -3324,14 +3469,14 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     // calc plot frame sizes
     ImVec2 title_size(0.0f, 0.0f);
     if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle))
-         title_size = ImGui::CalcTextSize(title, NULL, true);
+         title_size = ImGui::CalcTextSize(title, nullptr, true);
     const float pad_top = title_size.x > 0.0f ? title_size.y + gp.Style.LabelPadding.y : 0;
     const ImVec2 half_pad = gp.Style.PlotPadding/2;
     const ImVec2 frame_size = ImGui::CalcItemSize(size, gp.Style.PlotDefaultSize.x, gp.Style.PlotDefaultSize.y);
     subplot.FrameRect = ImRect(Window->DC.CursorPos, Window->DC.CursorPos + frame_size);
     subplot.GridRect.Min = subplot.FrameRect.Min + half_pad + ImVec2(0,pad_top);
     subplot.GridRect.Max = subplot.FrameRect.Max - half_pad;
-    subplot.FrameHovered = subplot.FrameRect.Contains(ImGui::GetMousePos()) && ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
+    subplot.FrameHovered = subplot.FrameRect.Contains(ImGui::GetMousePos()) && ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows|ImGuiHoveredFlags_AllowWhenBlockedByActiveItem);
 
     // outside legend adjustments (TODO: make function)
     const bool share_items = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems);
@@ -3378,7 +3523,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
             ImGui::KeepAliveID(sep_id);
             const ImRect sep_bb = ImRect(subplot.GridRect.Min.x, ypos-SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Max.x, ypos+SUBPLOT_SPLITTER_HALF_THICKNESS);
             bool sep_hov = false, sep_hld = false;
-            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
             if ((sep_hov && G.HoveredIdTimer > SUBPLOT_SPLITTER_FEEDBACK_TIMER) || sep_hld) {
                 if (sep_clk && ImGui::IsMouseDoubleClicked(0)) {
                     float p = (subplot.RowRatios[r] + subplot.RowRatios[r+1])/2;
@@ -3408,7 +3553,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
             ImGui::KeepAliveID(sep_id);
             const ImRect sep_bb = ImRect(xpos-SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Min.y, xpos+SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Max.y);
             bool sep_hov = false, sep_hld = false;
-            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
             if ((sep_hov && G.HoveredIdTimer > SUBPLOT_SPLITTER_FEEDBACK_TIMER) || sep_hld) {
                 if (sep_clk && ImGui::IsMouseDoubleClicked(0)) {
                     float p = (subplot.ColRatios[c] + subplot.ColRatios[c+1])/2;
@@ -3435,11 +3580,11 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     }
 
     // set outgoing sizes
-    if (row_sizes != NULL) {
+    if (row_sizes != nullptr) {
         for (int r = 0; r < rows; ++r)
             row_sizes[r] = subplot.RowRatios[r] * row_sum;
     }
-    if (col_sizes != NULL) {
+    if (col_sizes != nullptr) {
         for (int c = 0; c < cols; ++c)
             col_sizes[c] = subplot.ColRatios[c] * col_sum;
     }
@@ -3465,10 +3610,11 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
 }
 
 void EndSubplots() {
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentSubplot != NULL, "Mismatched BeginSubplots()/EndSubplots()!");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
     ImPlotContext& gp = *GImPlot;
-    ImPlotSubplot& subplot = *GImPlot->CurrentSubplot;
+    IM_ASSERT_USER_ERROR(gp.CurrentSubplot != nullptr, "Mismatched BeginSubplots()/EndSubplots()!");
+    ImPlotSubplot& subplot = *gp.CurrentSubplot;
+    const ImGuiIO& IO  = ImGui::GetIO();
     // set alignments
     for (int r = 0; r < subplot.Rows; ++r)
         subplot.RowAlignmentData[r].End();
@@ -3487,24 +3633,64 @@ void EndSubplots() {
     const bool share_items = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems);
     ImDrawList& DrawList = *ImGui::GetWindowDrawList();
     if (share_items && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoLegend) && subplot.Items.GetLegendCount() > 0) {
-        const bool   legend_horz = ImHasFlag(subplot.Items.Legend.Flags, ImPlotLegendFlags_Horizontal);
+        ImPlotLegend& legend = subplot.Items.Legend;
+        const bool   legend_horz = ImHasFlag(legend.Flags, ImPlotLegendFlags_Horizontal);
         const ImVec2 legend_size = CalcLegendSize(subplot.Items, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz);
-        const ImVec2 legend_pos  = GetLocationPos(subplot.FrameRect, legend_size, subplot.Items.Legend.Location, gp.Style.PlotPadding);
-        subplot.Items.Legend.Rect = ImRect(legend_pos, legend_pos + legend_size);
-        subplot.Items.Legend.Hovered = subplot.FrameHovered && subplot.Items.Legend.Rect.Contains(ImGui::GetIO().MousePos);
-        ImGui::PushClipRect(subplot.FrameRect.Min, subplot.FrameRect.Max, true);
-        ImU32  col_bg      = GetStyleColorU32(ImPlotCol_LegendBg);
-        ImU32  col_bd      = GetStyleColorU32(ImPlotCol_LegendBorder);
-        DrawList.AddRectFilled(subplot.Items.Legend.Rect.Min, subplot.Items.Legend.Rect.Max, col_bg);
-        DrawList.AddRect(subplot.Items.Legend.Rect.Min, subplot.Items.Legend.Rect.Max, col_bd);
-        bool legend_contextable = ShowLegendEntries(subplot.Items, subplot.Items.Legend.Rect, subplot.Items.Legend.Hovered, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, DrawList)
-                                && !ImHasFlag(subplot.Items.Legend.Flags, ImPlotLegendFlags_NoMenus);
+        const ImVec2 legend_pos  = GetLocationPos(subplot.FrameRect, legend_size, legend.Location, gp.Style.PlotPadding);
+        legend.Rect = ImRect(legend_pos, legend_pos + legend_size);
+        legend.RectClamped = legend.Rect;
+        const bool legend_scrollable = ClampLegendRect(legend.RectClamped,subplot.FrameRect, gp.Style.PlotPadding);
+        const ImGuiButtonFlags legend_button_flags = ImGuiButtonFlags_AllowOverlap
+                                                    | ImGuiButtonFlags_PressedOnClick
+                                                    | ImGuiButtonFlags_PressedOnDoubleClick
+                                                    | ImGuiButtonFlags_MouseButtonLeft
+                                                    | ImGuiButtonFlags_MouseButtonRight
+                                                    | ImGuiButtonFlags_MouseButtonMiddle
+                                                    | ImGuiButtonFlags_FlattenChildren;
+        ImGui::KeepAliveID(subplot.Items.ID);
+        ImGui::ButtonBehavior(legend.RectClamped, subplot.Items.ID, &legend.Hovered, &legend.Held, legend_button_flags);
+        legend.Hovered = legend.Hovered || (subplot.FrameHovered && legend.RectClamped.Contains(ImGui::GetIO().MousePos));
+
+        if (legend_scrollable) {
+            if (legend.Hovered) {
+                ImGui::SetKeyOwner(ImGuiKey_MouseWheelY, subplot.Items.ID);
+                if (IO.MouseWheel != 0.0f) {
+                    ImVec2 max_step = legend.Rect.GetSize() * 0.67f;
+#if IMGUI_VERSION_NUM < 19172
+                    float font_size = ImGui::GetCurrentWindow()->CalcFontSize();
+#else
+                    float font_size = ImGui::GetCurrentWindow()->FontRefSize;
+#endif
+                    float scroll_step = ImFloor(ImMin(2 * font_size, max_step.x));
+                    legend.Scroll.x += scroll_step * IO.MouseWheel;
+                    legend.Scroll.y += scroll_step * IO.MouseWheel;
+                }
+            }
+            const ImVec2 min_scroll_offset = legend.RectClamped.GetSize() - legend.Rect.GetSize();
+            legend.Scroll.x = ImClamp(legend.Scroll.x, min_scroll_offset.x, 0.0f);
+            legend.Scroll.y = ImClamp(legend.Scroll.y, min_scroll_offset.y, 0.0f);
+            const ImVec2 scroll_offset = legend_horz ? ImVec2(legend.Scroll.x, 0) : ImVec2(0, legend.Scroll.y);
+            ImVec2 legend_offset = legend.RectClamped.Min - legend.Rect.Min + scroll_offset;
+            legend.Rect.Min += legend_offset;
+            legend.Rect.Max += legend_offset;
+        } else {
+            legend.Scroll = ImVec2(0,0);
+        }
+
+        const ImU32 col_bg = GetStyleColorU32(ImPlotCol_LegendBg);
+        const ImU32 col_bd = GetStyleColorU32(ImPlotCol_LegendBorder);
+        ImGui::PushClipRect(legend.RectClamped.Min, legend.RectClamped.Max, true);
+        DrawList.AddRectFilled(legend.RectClamped.Min, legend.RectClamped.Max, col_bg);
+        bool legend_contextable = ShowLegendEntries(subplot.Items, legend.Rect, legend.Hovered, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, !legend_horz, DrawList)
+                                && !ImHasFlag(legend.Flags, ImPlotLegendFlags_NoMenus);
+        DrawList.AddRect(legend.RectClamped.Min, legend.RectClamped.Max, col_bd);
+        ImGui::PopClipRect();
+
         if (legend_contextable && !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoMenus) && ImGui::GetIO().MouseReleased[gp.InputMap.Menu])
             ImGui::OpenPopup("##LegendContext");
-        ImGui::PopClipRect();
         if (ImGui::BeginPopup("##LegendContext")) {
             ImGui::Text("Legend"); ImGui::Separator();
-            if (ShowLegendContextMenu(subplot.Items.Legend, !ImHasFlag(subplot.Flags, ImPlotFlags_NoLegend)))
+            if (ShowLegendContextMenu(legend, !ImHasFlag(subplot.Flags, ImPlotFlags_NoLegend)))
                 ImFlipFlag(subplot.Flags, ImPlotFlags_NoLegend);
             ImGui::EndPopup();
         }
@@ -3514,8 +3700,8 @@ void EndSubplots() {
     }
     // remove items
     if (gp.CurrentItems == &subplot.Items)
-        gp.CurrentItems = NULL;
-    // reset the plot items for the next frame (TODO: put this elswhere)
+        gp.CurrentItems = nullptr;
+    // reset the plot items for the next frame (TODO: put this elsewhere)
     for (int i = 0; i < subplot.Items.GetItemCount(); ++i) {
         subplot.Items.GetItemByIndex(i)->SeenThisFrame = false;
     }
@@ -3534,7 +3720,7 @@ void EndSubplots() {
 
 void SetAxis(ImAxis axis) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "SetAxis() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "SetAxis() needs to be called between BeginPlot() and EndPlot()!");
     IM_ASSERT_USER_ERROR(axis >= ImAxis_X1 && axis < ImAxis_COUNT, "Axis index out of bounds!");
     IM_ASSERT_USER_ERROR(gp.CurrentPlot->Axes[axis].Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
     SetupLock();
@@ -3546,7 +3732,7 @@ void SetAxis(ImAxis axis) {
 
 void SetAxes(ImAxis x_idx, ImAxis y_idx) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "SetAxes() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "SetAxes() needs to be called between BeginPlot() and EndPlot()!");
     IM_ASSERT_USER_ERROR(x_idx >= ImAxis_X1 && x_idx < ImAxis_Y1, "X-Axis index out of bounds!");
     IM_ASSERT_USER_ERROR(y_idx >= ImAxis_Y1 && y_idx < ImAxis_COUNT, "Y-Axis index out of bounds!");
     IM_ASSERT_USER_ERROR(gp.CurrentPlot->Axes[x_idx].Enabled, "Axis is not enabled! Did you forget to call SetupAxis()?");
@@ -3558,7 +3744,7 @@ void SetAxes(ImAxis x_idx, ImAxis y_idx) {
 
 ImPlotPoint PixelsToPlot(float x, float y, ImAxis x_idx, ImAxis y_idx) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "PixelsToPlot() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "PixelsToPlot() needs to be called between BeginPlot() and EndPlot()!");
     IM_ASSERT_USER_ERROR(x_idx == IMPLOT_AUTO || (x_idx >= ImAxis_X1 && x_idx < ImAxis_Y1),    "X-Axis index out of bounds!");
     IM_ASSERT_USER_ERROR(y_idx == IMPLOT_AUTO || (y_idx >= ImAxis_Y1 && y_idx < ImAxis_COUNT), "Y-Axis index out of bounds!");
     SetupLock();
@@ -3574,7 +3760,7 @@ ImPlotPoint PixelsToPlot(const ImVec2& pix, ImAxis x_idx, ImAxis y_idx) {
 
 ImVec2 PlotToPixels(double x, double y, ImAxis x_idx, ImAxis y_idx) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "PlotToPixels() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "PlotToPixels() needs to be called between BeginPlot() and EndPlot()!");
     IM_ASSERT_USER_ERROR(x_idx == IMPLOT_AUTO || (x_idx >= ImAxis_X1 && x_idx < ImAxis_Y1),    "X-Axis index out of bounds!");
     IM_ASSERT_USER_ERROR(y_idx == IMPLOT_AUTO || (y_idx >= ImAxis_Y1 && y_idx < ImAxis_COUNT), "Y-Axis index out of bounds!");
     SetupLock();
@@ -3590,27 +3776,27 @@ ImVec2 PlotToPixels(const ImPlotPoint& plt, ImAxis x_idx, ImAxis y_idx) {
 
 ImVec2 GetPlotPos() {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotPos() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "GetPlotPos() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     return gp.CurrentPlot->PlotRect.Min;
 }
 
 ImVec2 GetPlotSize() {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotSize() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "GetPlotSize() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     return gp.CurrentPlot->PlotRect.GetSize();
 }
 
 ImPlotPoint GetPlotMousePos(ImAxis x_idx, ImAxis y_idx) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "GetPlotMousePos() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "GetPlotMousePos() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     return PixelsToPlot(ImGui::GetMousePos(), x_idx, y_idx);
 }
 
 ImPlotRect GetPlotLimits(ImAxis x_idx, ImAxis y_idx) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotLimits() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "GetPlotLimits() needs to be called between BeginPlot() and EndPlot()!");
     IM_ASSERT_USER_ERROR(x_idx == IMPLOT_AUTO || (x_idx >= ImAxis_X1 && x_idx < ImAxis_Y1),    "X-Axis index out of bounds!");
     IM_ASSERT_USER_ERROR(y_idx == IMPLOT_AUTO || (y_idx >= ImAxis_Y1 && y_idx < ImAxis_COUNT), "Y-Axis index out of bounds!");
     SetupLock();
@@ -3625,34 +3811,34 @@ ImPlotRect GetPlotLimits(ImAxis x_idx, ImAxis y_idx) {
 
 bool IsPlotHovered() {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "IsPlotHovered() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "IsPlotHovered() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     return gp.CurrentPlot->Hovered;
 }
 
 bool IsAxisHovered(ImAxis axis) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "IsPlotXAxisHovered() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "IsPlotXAxisHovered() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     return gp.CurrentPlot->Axes[axis].Hovered;
 }
 
 bool IsSubplotsHovered() {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentSubplot != NULL, "IsSubplotsHovered() needs to be called between BeginSubplots() and EndSubplots()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentSubplot != nullptr, "IsSubplotsHovered() needs to be called between BeginSubplots() and EndSubplots()!");
     return gp.CurrentSubplot->FrameHovered;
 }
 
 bool IsPlotSelected() {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "IsPlotSelected() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "IsPlotSelected() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     return gp.CurrentPlot->Selected;
 }
 
 ImPlotRect GetPlotSelection(ImAxis x_idx, ImAxis y_idx) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotSelection() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "GetPlotSelection() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     ImPlotPlot& plot = *gp.CurrentPlot;
     if (!plot.Selected)
@@ -3669,7 +3855,7 @@ ImPlotRect GetPlotSelection(ImAxis x_idx, ImAxis y_idx) {
 
 void CancelPlotSelection() {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "CancelPlotSelection() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "CancelPlotSelection() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     ImPlotPlot& plot = *gp.CurrentPlot;
     if (plot.Selected)
@@ -3689,7 +3875,7 @@ void HideNextItem(bool hidden, ImPlotCond cond) {
 
 void Annotation(double x, double y, const ImVec4& col, const ImVec2& offset, bool clamp, bool round) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "Annotation() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "Annotation() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     char x_buff[IMPLOT_LABEL_MAX_SIZE];
     char y_buff[IMPLOT_LABEL_MAX_SIZE];
@@ -3702,7 +3888,7 @@ void Annotation(double x, double y, const ImVec4& col, const ImVec2& offset, boo
 
 void AnnotationV(double x, double y, const ImVec4& col, const ImVec2& offset, bool clamp, const char* fmt, va_list args) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "Annotation() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "Annotation() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     ImVec2 pos = PlotToPixels(x,y,IMPLOT_AUTO,IMPLOT_AUTO);
     ImU32  bg  = ImGui::GetColorU32(col);
@@ -3742,46 +3928,52 @@ void Tag(ImAxis axis, double v, const ImVec4& color, bool round) {
 }
 
 IMPLOT_API void TagX(double x, const ImVec4& color, bool round) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagX() needs to be called between BeginPlot() and EndPlot()!");
-    Tag(GImPlot->CurrentPlot->CurrentX, x, color, round);
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "TagX() needs to be called between BeginPlot() and EndPlot()!");
+    Tag(gp.CurrentPlot->CurrentX, x, color, round);
 }
 
 IMPLOT_API void TagX(double x, const ImVec4& color, const char* fmt, ...) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagX() needs to be called between BeginPlot() and EndPlot()!");
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "TagX() needs to be called between BeginPlot() and EndPlot()!");
     va_list args;
     va_start(args, fmt);
-    TagV(GImPlot->CurrentPlot->CurrentX,x,color,fmt,args);
+    TagV(gp.CurrentPlot->CurrentX,x,color,fmt,args);
     va_end(args);
 }
 
 IMPLOT_API void TagXV(double x, const ImVec4& color, const char* fmt, va_list args) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagX() needs to be called between BeginPlot() and EndPlot()!");
-    TagV(GImPlot->CurrentPlot->CurrentX, x, color, fmt, args);
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "TagX() needs to be called between BeginPlot() and EndPlot()!");
+    TagV(gp.CurrentPlot->CurrentX, x, color, fmt, args);
 }
 
 IMPLOT_API void TagY(double y, const ImVec4& color, bool round) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagY() needs to be called between BeginPlot() and EndPlot()!");
-    Tag(GImPlot->CurrentPlot->CurrentY, y, color, round);
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "TagY() needs to be called between BeginPlot() and EndPlot()!");
+    Tag(gp.CurrentPlot->CurrentY, y, color, round);
 }
 
 IMPLOT_API void TagY(double y, const ImVec4& color, const char* fmt, ...) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagY() needs to be called between BeginPlot() and EndPlot()!");
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "TagY() needs to be called between BeginPlot() and EndPlot()!");
     va_list args;
     va_start(args, fmt);
-    TagV(GImPlot->CurrentPlot->CurrentY,y,color,fmt,args);
+    TagV(gp.CurrentPlot->CurrentY,y,color,fmt,args);
     va_end(args);
 }
 
 IMPLOT_API void TagYV(double y, const ImVec4& color, const char* fmt, va_list args) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "TagY() needs to be called between BeginPlot() and EndPlot()!");
-    TagV(GImPlot->CurrentPlot->CurrentY, y, color, fmt, args);
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "TagY() needs to be called between BeginPlot() and EndPlot()!");
+    TagV(gp.CurrentPlot->CurrentY, y, color, fmt, args);
 }
 
-static const float DRAG_GRAB_HALF_SIZE = 4.0f;
+constexpr float DRAG_GRAB_HALF_SIZE = 4.0f;
 
-bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, ImPlotDragToolFlags flags) {
+bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
     ImGui::PushID("#IMPLOT_DRAG_POINT");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "DragPoint() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "DragPoint() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
 
     if (!ImHasFlag(flags,ImPlotDragToolFlags_NoFit) && FitThisFrame()) {
@@ -3801,33 +3993,37 @@ bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, 
     bool hovered = false, held = false;
 
     ImGui::KeepAliveID(id);
-    if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+    if (input) {
+        bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        if (out_clicked) *out_clicked = clicked;
+        if (out_hovered) *out_hovered = hovered;
+        if (out_held)    *out_held    = held;
+    }
 
-    bool dragging = false;
+    bool modified = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *x = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
         *y = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
-        dragging = true;
+        modified = true;
     }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
-    if (dragging && no_delay)
+    if (modified && no_delay)
         pos = PlotToPixels(*x,*y,IMPLOT_AUTO,IMPLOT_AUTO);
     DrawList.AddCircleFilled(pos, radius, col32);
     PopPlotClipRect();
 
     ImGui::PopID();
-    return dragging;
+    return modified;
 }
 
-bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags) {
+bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
     // ImGui::PushID("#IMPLOT_DRAG_LINE_X");
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "DragLineX() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "DragLineX() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
 
     if (!ImHasFlag(flags,ImPlotDragToolFlags_NoFit) && FitThisFrame()) {
@@ -3846,8 +4042,12 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     bool hovered = false, held = false;
 
     ImGui::KeepAliveID(id);
-    if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+    if (input) {
+        bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        if (out_clicked) *out_clicked = clicked;
+        if (out_hovered) *out_hovered = hovered;
+        if (out_held)    *out_held    = held;
+    }
 
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
@@ -3856,15 +4056,15 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     ImVec4 color = IsColorAuto(col) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : col;
     ImU32 col32 = ImGui::ColorConvertFloat4ToU32(color);
 
-    bool dragging = false;
+    bool modified = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *value = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
-        dragging = true;
+        modified = true;
     }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
-    if (dragging && no_delay)
+    if (modified && no_delay)
         x  = IM_ROUND(PlotToPixels(*value,0,IMPLOT_AUTO,IMPLOT_AUTO).x);
     DrawList.AddLine(ImVec2(x,yt), ImVec2(x,yb),     col32,   thickness);
     DrawList.AddLine(ImVec2(x,yt), ImVec2(x,yt+len), col32, 3*thickness);
@@ -3872,13 +4072,13 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     PopPlotClipRect();
 
     // ImGui::PopID();
-    return dragging;
+    return modified;
 }
 
-bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags) {
+bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
     ImGui::PushID("#IMPLOT_DRAG_LINE_Y");
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "DragLineY() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "DragLineY() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
 
     if (!ImHasFlag(flags,ImPlotDragToolFlags_NoFit) && FitThisFrame()) {
@@ -3898,8 +4098,12 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     bool hovered = false, held = false;
 
     ImGui::KeepAliveID(id);
-    if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+    if (input) {
+        bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        if (out_clicked) *out_clicked = clicked;
+        if (out_hovered) *out_hovered = hovered;
+        if (out_held)    *out_held    = held;
+    }
 
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
@@ -3908,15 +4112,15 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     ImVec4 color = IsColorAuto(col) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : col;
     ImU32 col32 = ImGui::ColorConvertFloat4ToU32(color);
 
-    bool dragging = false;
+    bool modified = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *value = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
-        dragging = true;
+        modified = true;
     }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
-    if (dragging && no_delay)
+    if (modified && no_delay)
         y  = IM_ROUND(PlotToPixels(0, *value,IMPLOT_AUTO,IMPLOT_AUTO).y);
     DrawList.AddLine(ImVec2(xl,y), ImVec2(xr,y),     col32,   thickness);
     DrawList.AddLine(ImVec2(xl,y), ImVec2(xl+len,y), col32, 3*thickness);
@@ -3924,12 +4128,12 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     PopPlotClipRect();
 
     ImGui::PopID();
-    return dragging;
+    return modified;
 }
 
-bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_max, const ImVec4& col, ImPlotDragToolFlags flags) {
+bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_max, const ImVec4& col, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
     ImGui::PushID("#IMPLOT_DRAG_RECT");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "DragRect() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "DragRect() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
 
     if (!ImHasFlag(flags,ImPlotDragToolFlags_NoFit) && FitThisFrame()) {
@@ -3964,39 +4168,51 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
     ImU32 col32_a = ImGui::ColorConvertFloat4ToU32(color);
     const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
 
-    bool dragging = false;
-    bool hovered = false, held = false;
-    ImRect b_rect(pc.x-DRAG_GRAB_HALF_SIZE,pc.y-DRAG_GRAB_HALF_SIZE,pc.x+DRAG_GRAB_HALF_SIZE,pc.y+DRAG_GRAB_HALF_SIZE);
+    bool modified = false;
+    bool clicked = false, hovered = false, held = false;
 
-    ImGui::KeepAliveID(id);
-    if (input)
-        ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
-
-    if ((hovered || held) && show_curs)
-        ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
-    if (held && ImGui::IsMouseDragging(0)) {
-        for (int i = 0; i < 4; ++i) {
-            ImPlotPoint pp = PixelsToPlot(p[i] + ImGui::GetIO().MouseDelta,IMPLOT_AUTO,IMPLOT_AUTO);
-            *y[i] = pp.y;
-            *x[i] = pp.x;
+    const bool is_movable = *x_min != *x_max || *y_min != *y_max;
+    if (is_movable) {
+        ImGui::KeepAliveID(id);
+        if (input) {
+            // middle point
+            ImRect b_rect(pc.x-DRAG_GRAB_HALF_SIZE,pc.y-DRAG_GRAB_HALF_SIZE,pc.x+DRAG_GRAB_HALF_SIZE,pc.y+DRAG_GRAB_HALF_SIZE);
+            clicked = ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
+            if (out_clicked) *out_clicked = clicked;
+            if (out_hovered) *out_hovered = hovered;
+            if (out_held)    *out_held    = held;
         }
-        dragging = true;
+
+        if ((hovered || held) && show_curs)
+            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
+        if (held && ImGui::IsMouseDragging(0)) {
+            for (int i = 0; i < 4; ++i) {
+                ImPlotPoint pp = PixelsToPlot(p[i] + ImGui::GetIO().MouseDelta,IMPLOT_AUTO,IMPLOT_AUTO);
+                *y[i] = pp.y;
+                *x[i] = pp.x;
+            }
+            modified = true;
+        }
     }
 
     for (int i = 0; i < 4; ++i) {
         // points
-        b_rect = ImRect(p[i].x-DRAG_GRAB_HALF_SIZE,p[i].y-DRAG_GRAB_HALF_SIZE,p[i].x+DRAG_GRAB_HALF_SIZE,p[i].y+DRAG_GRAB_HALF_SIZE);
+        ImRect b_rect(p[i].x - DRAG_GRAB_HALF_SIZE, p[i].y - DRAG_GRAB_HALF_SIZE, p[i].x + DRAG_GRAB_HALF_SIZE, p[i].y + DRAG_GRAB_HALF_SIZE);
         ImGuiID p_id = id + i + 1;
         ImGui::KeepAliveID(p_id);
-        if (input)
-            ImGui::ButtonBehavior(b_rect,p_id,&hovered,&held);
+        if (input) {
+            clicked = ImGui::ButtonBehavior(b_rect,p_id,&hovered,&held);
+            if (out_clicked) *out_clicked = *out_clicked || clicked;
+            if (out_hovered) *out_hovered = *out_hovered || hovered;
+            if (out_held)    *out_held    = *out_held    || held;
+        }
         if ((hovered || held) && show_curs)
             ImGui::SetMouseCursor(cur[i]);
 
         if (held && ImGui::IsMouseDragging(0)) {
             *x[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
             *y[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
-            dragging = true;
+            modified = true;
         }
 
         // edges
@@ -4006,8 +4222,12 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
                     : ImRect(e_min.x - DRAG_GRAB_HALF_SIZE, e_min.y + DRAG_GRAB_HALF_SIZE, e_max.x + DRAG_GRAB_HALF_SIZE, e_max.y - DRAG_GRAB_HALF_SIZE);
         ImGuiID e_id = id + i + 5;
         ImGui::KeepAliveID(e_id);
-        if (input)
-            ImGui::ButtonBehavior(b_rect,e_id,&hovered,&held);
+        if (input) {
+            clicked = ImGui::ButtonBehavior(b_rect,e_id,&hovered,&held);
+            if (out_clicked) *out_clicked = *out_clicked || clicked;
+            if (out_hovered) *out_hovered = *out_hovered || hovered;
+            if (out_held)    *out_held    = *out_held    || held;
+        }
         if ((hovered || held) && show_curs)
             h[i] ? ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS) : ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
         if (held && ImGui::IsMouseDragging(0)) {
@@ -4015,7 +4235,7 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
                 *y[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
             else
                 *x[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
-            dragging = true;
+            modified = true;
         }
         if (hovered && ImGui::IsMouseDoubleClicked(0))
         {
@@ -4024,14 +4244,22 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
                 *y[i] = ((y[i] == y_min && *y_min < *y_max) || (y[i] == y_max && *y_max < *y_min)) ? b.Y.Min : b.Y.Max;
             else
                 *x[i] = ((x[i] == x_min && *x_min < *x_max) || (x[i] == x_max && *x_max < *x_min)) ? b.X.Min : b.X.Max;
-            dragging = true;
+            modified = true;
         }
     }
 
+    const bool mouse_inside = rect_grab.Contains(ImGui::GetMousePos());
+    const bool mouse_clicked = ImGui::IsMouseClicked(0);
+    const bool mouse_down = ImGui::IsMouseDown(0);
+    if (input && mouse_inside) {
+        if (out_clicked) *out_clicked = *out_clicked || mouse_clicked;
+        if (out_hovered) *out_hovered = true;
+        if (out_held)    *out_held    = *out_held    || mouse_down;
+    }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
-    if (dragging && no_delay) {
+    if (modified && no_delay) {
         for (int i = 0; i < 4; ++i)
             p[i] = PlotToPixels(*x[i],*y[i],IMPLOT_AUTO,IMPLOT_AUTO);
         pc = PlotToPixels((*x_min+*x_max)/2,(*y_min+*y_max)/2,IMPLOT_AUTO,IMPLOT_AUTO);
@@ -4039,18 +4267,18 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
     }
     DrawList.AddRectFilled(rect.Min, rect.Max, col32_a);
     DrawList.AddRect(rect.Min, rect.Max, col32);
-    if (input && (dragging || rect_grab.Contains(ImGui::GetMousePos()))) {
+    if (input && (modified || mouse_inside)) {
         DrawList.AddCircleFilled(pc,DRAG_GRAB_HALF_SIZE,col32);
         for (int i = 0; i < 4; ++i)
             DrawList.AddCircleFilled(p[i],DRAG_GRAB_HALF_SIZE,col32);
     }
     PopPlotClipRect();
     ImGui::PopID();
-    return dragging;
+    return modified;
 }
 
-bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags flags) {
-    return DragRect(id, &bounds->X.Min, &bounds->Y.Min,&bounds->X.Max, &bounds->Y.Max, col, flags);
+bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
+    return DragRect(id, &bounds->X.Min, &bounds->Y.Min,&bounds->X.Max, &bounds->Y.Max, col, flags, out_clicked, out_hovered, out_held);
 }
 
 //-----------------------------------------------------------------------------
@@ -4059,21 +4287,21 @@ bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags
 
 bool IsLegendEntryHovered(const char* label_id) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentItems != NULL, "IsPlotItemHighlight() needs to be called within an itemized context!");
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != nullptr, "IsPlotItemHighlight() needs to be called within an itemized context!");
     SetupLock();
-    ImGuiID id = ImGui::GetIDWithSeed(label_id, NULL, gp.CurrentItems->ID);
+    ImGuiID id = ImGui::GetIDWithSeed(label_id, nullptr, gp.CurrentItems->ID);
     ImPlotItem* item = gp.CurrentItems->GetItem(id);
     return item && item->LegendHovered;
 }
 
 bool BeginLegendPopup(const char* label_id, ImGuiMouseButton mouse_button) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentItems != NULL, "BeginLegendPopup() needs to be called within an itemized context!");
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != nullptr, "BeginLegendPopup() needs to be called within an itemized context!");
     SetupLock();
     ImGuiWindow* window = GImGui->CurrentWindow;
     if (window->SkipItems)
         return false;
-    ImGuiID id = ImGui::GetIDWithSeed(label_id, NULL, gp.CurrentItems->ID);
+    ImGuiID id = ImGui::GetIDWithSeed(label_id, nullptr, gp.CurrentItems->ID);
     if (ImGui::IsMouseReleased(mouse_button)) {
         ImPlotItem* item = gp.CurrentItems->GetItem(id);
         if (item && item->LegendHovered)
@@ -4097,7 +4325,7 @@ void ShowAltLegend(const char* title_id, bool vertical, const ImVec2 size, bool 
     ImPlotPlot* plot = GetPlot(title_id);
     ImVec2 legend_size;
     ImVec2 default_size = gp.Style.LegendPadding * 2;
-    if (plot != NULL) {
+    if (plot != nullptr) {
         legend_size  = CalcLegendSize(plot->Items, gp.Style.LegendInnerPadding, gp.Style.LegendSpacing, vertical);
         default_size = legend_size + gp.Style.LegendPadding * 2;
     }
@@ -4108,7 +4336,7 @@ void ShowAltLegend(const char* title_id, bool vertical, const ImVec2 size, bool 
         return;
     ImGui::RenderFrame(bb_frame.Min, bb_frame.Max, GetStyleColorU32(ImPlotCol_FrameBg), true, G.Style.FrameRounding);
     DrawList.PushClipRect(bb_frame.Min, bb_frame.Max, true);
-    if (plot != NULL) {
+    if (plot != nullptr) {
         const ImVec2 legend_pos  = GetLocationPos(bb_frame, legend_size, 0, gp.Style.LegendPadding);
         const ImRect legend_bb(legend_pos, legend_pos + legend_size);
         interactable = interactable && bb_frame.Contains(ImGui::GetIO().MousePos);
@@ -4129,8 +4357,9 @@ void ShowAltLegend(const char* title_id, bool vertical, const ImVec2 size, bool 
 
 bool BeginDragDropTargetPlot() {
     SetupLock();
-    ImRect rect = GImPlot->CurrentPlot->PlotRect;
-    return ImGui::BeginDragDropTargetCustom(rect, GImPlot->CurrentPlot->ID);
+    ImPlotContext& gp = *GImPlot;
+    ImRect rect = gp.CurrentPlot->PlotRect;
+    return ImGui::BeginDragDropTargetCustom(rect, gp.CurrentPlot->ID);
 }
 
 bool BeginDragDropTargetAxis(ImAxis axis) {
@@ -4145,7 +4374,7 @@ bool BeginDragDropTargetAxis(ImAxis axis) {
 bool BeginDragDropTargetLegend() {
     SetupLock();
     ImPlotItemGroup& items = *GImPlot->CurrentItems;
-    ImRect rect = items.Legend.Rect;
+    ImRect rect = items.Legend.RectClamped;
     return ImGui::BeginDragDropTargetCustom(rect, items.ID);
 }
 
@@ -4156,16 +4385,18 @@ void EndDragDropTarget() {
 
 bool BeginDragDropSourcePlot(ImGuiDragDropFlags flags) {
     SetupLock();
-    ImPlotPlot* plot = GImPlot->CurrentPlot;
-    if (GImGui->IO.KeyMods == GImPlot->InputMap.OverrideMod || GImGui->DragDropPayload.SourceId == plot->ID)
+    ImPlotContext& gp = *GImPlot;
+    ImPlotPlot* plot = gp.CurrentPlot;
+    if (GImGui->IO.KeyMods == gp.InputMap.OverrideMod || GImGui->DragDropPayload.SourceId == plot->ID)
         return ImGui::ItemAdd(plot->PlotRect, plot->ID) && ImGui::BeginDragDropSource(flags);
     return false;
 }
 
 bool BeginDragDropSourceAxis(ImAxis idx, ImGuiDragDropFlags flags) {
     SetupLock();
-    ImPlotAxis& axis = GImPlot->CurrentPlot->Axes[idx];
-    if (GImGui->IO.KeyMods == GImPlot->InputMap.OverrideMod || GImGui->DragDropPayload.SourceId == axis.ID)
+    ImPlotContext& gp = *GImPlot;
+    ImPlotAxis& axis = gp.CurrentPlot->Axes[idx];
+    if (GImGui->IO.KeyMods == gp.InputMap.OverrideMod || GImGui->DragDropPayload.SourceId == axis.ID)
         return ImGui::ItemAdd(axis.HoverRect, axis.ID) && ImGui::BeginDragDropSource(flags);
     return false;
 }
@@ -4173,10 +4404,10 @@ bool BeginDragDropSourceAxis(ImAxis idx, ImGuiDragDropFlags flags) {
 bool BeginDragDropSourceItem(const char* label_id, ImGuiDragDropFlags flags) {
     SetupLock();
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentItems != NULL, "BeginDragDropSourceItem() needs to be called within an itemized context!");
-    ImGuiID item_id = ImGui::GetIDWithSeed(label_id, NULL, gp.CurrentItems->ID);
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != nullptr, "BeginDragDropSourceItem() needs to be called within an itemized context!");
+    ImGuiID item_id = ImGui::GetIDWithSeed(label_id, nullptr, gp.CurrentItems->ID);
     ImPlotItem* item = gp.CurrentItems->GetItem(item_id);
-    if (item != NULL) {
+    if (item != nullptr) {
         return ImGui::ItemAdd(item->LegendHoverRect, item->ID) && ImGui::BeginDragDropSource(flags);
     }
     return false;
@@ -4192,9 +4423,9 @@ void EndDragDropSource() {
 //-----------------------------------------------------------------------------
 
 bool BeginAlignedPlots(const char* group_id, bool vertical) {
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentAlignmentH == NULL && GImPlot->CurrentAlignmentV == NULL, "Mismatched BeginAlignedPlots()/EndAlignedPlots()!");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
     ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentAlignmentH == nullptr && gp.CurrentAlignmentV == nullptr, "Mismatched BeginAlignedPlots()/EndAlignedPlots()!");
     ImGuiContext &G = *GImGui;
     ImGuiWindow * Window = G.CurrentWindow;
     if (Window->SkipItems)
@@ -4213,10 +4444,10 @@ bool BeginAlignedPlots(const char* group_id, bool vertical) {
 }
 
 void EndAlignedPlots() {
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentAlignmentH != NULL || GImPlot->CurrentAlignmentV != NULL, "Mismatched BeginAlignedPlots()/EndAlignedPlots()!");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
     ImPlotContext& gp = *GImPlot;
-    ImPlotAlignmentData* alignment = gp.CurrentAlignmentH != NULL ? gp.CurrentAlignmentH : (gp.CurrentAlignmentV != NULL ? gp.CurrentAlignmentV : NULL);
+    IM_ASSERT_USER_ERROR(gp.CurrentAlignmentH != nullptr || gp.CurrentAlignmentV != nullptr, "Mismatched BeginAlignedPlots()/EndAlignedPlots()!");
+    ImPlotAlignmentData* alignment = gp.CurrentAlignmentH != nullptr ? gp.CurrentAlignmentH : (gp.CurrentAlignmentV != nullptr ? gp.CurrentAlignmentV : nullptr);
     if (alignment)
         alignment->End();
     ResetCtxForNextAlignedPlots(GImPlot);
@@ -4227,7 +4458,7 @@ void EndAlignedPlots() {
 //-----------------------------------------------------------------------------
 
 ImPlotStyle& GetStyle() {
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
     ImPlotContext& gp = *GImPlot;
     return gp.Style;
 }
@@ -4235,7 +4466,7 @@ ImPlotStyle& GetStyle() {
 void PushStyleColor(ImPlotCol idx, ImU32 col) {
     ImPlotContext& gp = *GImPlot;
     ImGuiColorMod backup;
-    backup.Col = idx;
+    backup.Col = (ImGuiCol)idx;
     backup.BackupValue = gp.Style.Colors[idx];
     gp.ColorModifiers.push_back(backup);
     gp.Style.Colors[idx] = ImGui::ColorConvertU32ToFloat4(col);
@@ -4244,7 +4475,7 @@ void PushStyleColor(ImPlotCol idx, ImU32 col) {
 void PushStyleColor(ImPlotCol idx, const ImVec4& col) {
     ImPlotContext& gp = *GImPlot;
     ImGuiColorMod backup;
-    backup.Col = idx;
+    backup.Col = (ImGuiCol)idx;
     backup.BackupValue = gp.Style.Colors[idx];
     gp.ColorModifiers.push_back(backup);
     gp.Style.Colors[idx] = col;
@@ -4267,7 +4498,7 @@ void PushStyleVar(ImPlotStyleVar idx, float val) {
     const ImPlotStyleVarInfo* var_info = GetPlotStyleVarInfo(idx);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1) {
         float* pvar = (float*)var_info->GetVarPtr(&gp.Style);
-        gp.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        gp.StyleModifiers.push_back(ImGuiStyleMod((ImGuiStyleVar)idx, *pvar));
         *pvar = val;
         return;
     }
@@ -4279,27 +4510,27 @@ void PushStyleVar(ImPlotStyleVar idx, int val) {
     const ImPlotStyleVarInfo* var_info = GetPlotStyleVarInfo(idx);
     if (var_info->Type == ImGuiDataType_S32 && var_info->Count == 1) {
         int* pvar = (int*)var_info->GetVarPtr(&gp.Style);
-        gp.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        gp.StyleModifiers.push_back(ImGuiStyleMod((ImGuiStyleVar)idx, *pvar));
         *pvar = val;
         return;
     }
     else if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1) {
         float* pvar = (float*)var_info->GetVarPtr(&gp.Style);
-        gp.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        gp.StyleModifiers.push_back(ImGuiStyleMod((ImGuiStyleVar)idx, *pvar));
         *pvar = (float)val;
         return;
     }
     IM_ASSERT(0 && "Called PushStyleVar() int variant but variable is not a int!");
 }
 
-void PushStyleVar(ImGuiStyleVar idx, const ImVec2& val)
+void PushStyleVar(ImPlotStyleVar idx, const ImVec2& val)
 {
     ImPlotContext& gp = *GImPlot;
     const ImPlotStyleVarInfo* var_info = GetPlotStyleVarInfo(idx);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 2)
     {
         ImVec2* pvar = (ImVec2*)var_info->GetVarPtr(&gp.Style);
-        gp.StyleModifiers.push_back(ImGuiStyleMod(idx, *pvar));
+        gp.StyleModifiers.push_back(ImGuiStyleMod((ImGuiStyleVar)idx, *pvar));
         *pvar = val;
         return;
     }
@@ -4328,6 +4559,14 @@ void PopStyleVar(int count) {
     }
 }
 
+ImPlotMarker NextMarker() {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != nullptr, "NextMarker() needs to be called between BeginPlot() and EndPlot()!");
+    const int idx = gp.CurrentItems->MarkerIdx % ImPlotMarker_COUNT;
+    ++gp.CurrentItems->MarkerIdx;
+    return idx;
+}
+    
 //------------------------------------------------------------------------------
 // [Section] Colormaps
 //------------------------------------------------------------------------------
@@ -4392,7 +4631,7 @@ void PopColormap(int count) {
 
 ImU32 NextColormapColorU32() {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentItems != NULL, "NextColormapColor() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentItems != nullptr, "NextColormapColor() needs to be called between BeginPlot() and EndPlot()!");
     int idx = gp.CurrentItems->ColormapIdx % gp.ColormapData.GetKeyCount(gp.Style.Colormap);
     ImU32 col  = gp.ColormapData.GetKeyColor(gp.Style.Colormap, idx);
     gp.CurrentItems->ColormapIdx++;
@@ -4401,7 +4640,7 @@ ImU32 NextColormapColorU32() {
 
 ImVec4 NextColormapColor() {
     return ImGui::ColorConvertU32ToFloat4(NextColormapColorU32());
-}
+}    
 
 int GetColormapSize(ImPlotColormap cmap) {
     ImPlotContext& gp = *GImPlot;
@@ -4479,7 +4718,7 @@ void ColormapScale(const char* label, double scale_min, double scale_max, const 
     const ImGuiID ID = Window->GetID(label);
     ImVec2 label_size(0,0);
     if (!ImHasFlag(flags, ImPlotColormapScaleFlags_NoLabel)) {
-        label_size = ImGui::CalcTextSize(label,NULL,true);
+        label_size = ImGui::CalcTextSize(label,nullptr,true);
     }
 
     ImPlotContext& gp = *GImPlot;
@@ -4537,7 +4776,7 @@ void ColormapScale(const char* label, double scale_min, double scale_max, const 
         const float tick_width = gp.CTicker.Ticks[i].Major ? gp.Style.MajorTickLen.y : gp.Style.MinorTickLen.y;
         const float tick_thick = gp.CTicker.Ticks[i].Major ? gp.Style.MajorTickSize.y : gp.Style.MinorTickSize.y;
         const float tick_t     = (float)((y_pos_plt - scale_min) / (scale_max - scale_min));
-        const ImU32 tick_col = CalcTextColor(GImPlot->ColormapData.LerpTable(cmap,tick_t));
+        const ImU32 tick_col = CalcTextColor(gp.ColormapData.LerpTable(cmap,tick_t));
         if (y_pos < bb_grad.Max.y - 2 && y_pos > bb_grad.Min.y + 2) {
             DrawList.AddLine(opposite ? ImVec2(bb_grad.Min.x+1, y_pos) : ImVec2(bb_grad.Max.x-1, y_pos),
                              opposite ? ImVec2(bb_grad.Min.x + tick_width, y_pos) : ImVec2(bb_grad.Max.x - tick_width, y_pos),
@@ -4568,16 +4807,16 @@ bool ColormapSlider(const char* label, float* t, ImVec4* out, const char* format
     ImPlotContext& gp = *GImPlot;
     cmap = cmap == IMPLOT_AUTO ? gp.Style.Colormap : cmap;
     IM_ASSERT_USER_ERROR(cmap >= 0 && cmap < gp.ColormapData.Count, "Invalid colormap index!");
-    const ImU32* keys  = GImPlot->ColormapData.GetKeys(cmap);
-    const int    count = GImPlot->ColormapData.GetKeyCount(cmap);
-    const bool   qual  = GImPlot->ColormapData.IsQual(cmap);
+    const ImU32* keys  = gp.ColormapData.GetKeys(cmap);
+    const int    count = gp.ColormapData.GetKeyCount(cmap);
+    const bool   qual  = gp.ColormapData.IsQual(cmap);
     const ImVec2 pos  = ImGui::GetCurrentWindow()->DC.CursorPos;
     const float w     = ImGui::CalcItemWidth();
     const float h     = ImGui::GetFrameHeight();
     const ImRect rect = ImRect(pos.x,pos.y,pos.x+w,pos.y+h);
     RenderColorBar(keys,count,*ImGui::GetWindowDrawList(),rect,false,false,!qual);
-    const ImU32 grab = CalcTextColor(GImPlot->ColormapData.LerpTable(cmap,*t));
-    // const ImU32 text = CalcTextColor(GImPlot->ColormapData.LerpTable(cmap,0.5f));
+    const ImU32 grab = CalcTextColor(gp.ColormapData.LerpTable(cmap,*t));
+    // const ImU32 text = CalcTextColor(gp.ColormapData.LerpTable(cmap,0.5f));
     ImGui::PushStyleColor(ImGuiCol_FrameBg,IM_COL32_BLACK_TRANS);
     ImGui::PushStyleColor(ImGuiCol_FrameBgActive,IM_COL32_BLACK_TRANS);
     ImGui::PushStyleColor(ImGuiCol_FrameBgHovered,ImVec4(1,1,1,0.1f));
@@ -4588,8 +4827,8 @@ bool ColormapSlider(const char* label, float* t, ImVec4* out, const char* format
     const bool changed = ImGui::SliderFloat(label,t,0,1,format);
     ImGui::PopStyleColor(5);
     ImGui::PopStyleVar(2);
-    if (out != NULL)
-        *out = ImGui::ColorConvertU32ToFloat4(GImPlot->ColormapData.LerpTable(cmap,*t));
+    if (out != nullptr)
+        *out = ImGui::ColorConvertU32ToFloat4(gp.ColormapData.LerpTable(cmap,*t));
     return changed;
 }
 
@@ -4602,15 +4841,15 @@ bool ColormapButton(const char* label, const ImVec2& size_arg, ImPlotColormap cm
     ImPlotContext& gp = *GImPlot;
     cmap = cmap == IMPLOT_AUTO ? gp.Style.Colormap : cmap;
     IM_ASSERT_USER_ERROR(cmap >= 0 && cmap < gp.ColormapData.Count, "Invalid colormap index!");
-    const ImU32* keys  = GImPlot->ColormapData.GetKeys(cmap);
-    const int    count = GImPlot->ColormapData.GetKeyCount(cmap);
-    const bool   qual  = GImPlot->ColormapData.IsQual(cmap);
+    const ImU32* keys  = gp.ColormapData.GetKeys(cmap);
+    const int    count = gp.ColormapData.GetKeyCount(cmap);
+    const bool   qual  = gp.ColormapData.IsQual(cmap);
     const ImVec2 pos  = ImGui::GetCurrentWindow()->DC.CursorPos;
-    const ImVec2 label_size = ImGui::CalcTextSize(label, NULL, true);
+    const ImVec2 label_size = ImGui::CalcTextSize(label, nullptr, true);
     ImVec2 size = ImGui::CalcItemSize(size_arg, label_size.x + style.FramePadding.x * 2.0f, label_size.y + style.FramePadding.y * 2.0f);
     const ImRect rect = ImRect(pos.x,pos.y,pos.x+size.x,pos.y+size.y);
     RenderColorBar(keys,count,*ImGui::GetWindowDrawList(),rect,false,false,!qual);
-    const ImU32 text = CalcTextColor(GImPlot->ColormapData.LerpTable(cmap,G.Style.ButtonTextAlign.x));
+    const ImU32 text = CalcTextColor(gp.ColormapData.LerpTable(cmap,G.Style.ButtonTextAlign.x));
     ImGui::PushStyleColor(ImGuiCol_Button,IM_COL32_BLACK_TRANS);
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered,ImVec4(1,1,1,0.1f));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,ImVec4(1,1,1,0.2f));
@@ -4627,7 +4866,7 @@ bool ColormapButton(const char* label, const ImVec2& size_arg, ImPlotColormap cm
 //-----------------------------------------------------------------------------
 
 ImPlotInputMap& GetInputMap() {
-    IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
+    IM_ASSERT_USER_ERROR(GImPlot != nullptr, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
     ImPlotContext& gp = *GImPlot;
     return gp.InputMap;
 }
@@ -4635,32 +4874,32 @@ ImPlotInputMap& GetInputMap() {
 void MapInputDefault(ImPlotInputMap* dst) {
     ImPlotInputMap& map = dst ? *dst : GetInputMap();
     map.Pan             = ImGuiMouseButton_Left;
-    map.PanMod          = ImGuiModFlags_None;
+    map.PanMod          = ImGuiMod_None;
     map.Fit             = ImGuiMouseButton_Left;
     map.Menu            = ImGuiMouseButton_Right;
     map.Select          = ImGuiMouseButton_Right;
-    map.SelectMod       = ImGuiModFlags_None;
+    map.SelectMod       = ImGuiMod_None;
     map.SelectCancel    = ImGuiMouseButton_Left;
-    map.SelectHorzMod   = ImGuiModFlags_Alt;
-    map.SelectVertMod   = ImGuiModFlags_Shift;
-    map.OverrideMod     = ImGuiModFlags_Ctrl;
-    map.ZoomMod         = ImGuiModFlags_None;
+    map.SelectHorzMod   = ImGuiMod_Alt;
+    map.SelectVertMod   = ImGuiMod_Shift;
+    map.OverrideMod     = ImGuiMod_Ctrl;
+    map.ZoomMod         = ImGuiMod_None;
     map.ZoomRate        = 0.1f;
 }
 
 void MapInputReverse(ImPlotInputMap* dst) {
     ImPlotInputMap& map = dst ? *dst : GetInputMap();
     map.Pan             = ImGuiMouseButton_Right;
-    map.PanMod          = ImGuiModFlags_None;
+    map.PanMod          = ImGuiMod_None;
     map.Fit             = ImGuiMouseButton_Left;
     map.Menu            = ImGuiMouseButton_Right;
     map.Select          = ImGuiMouseButton_Left;
-    map.SelectMod       = ImGuiModFlags_None;
+    map.SelectMod       = ImGuiMod_None;
     map.SelectCancel    = ImGuiMouseButton_Right;
-    map.SelectHorzMod   = ImGuiModFlags_Alt;
-    map.SelectVertMod   = ImGuiModFlags_Shift;
-    map.OverrideMod     = ImGuiModFlags_Ctrl;
-    map.ZoomMod         = ImGuiModFlags_None;
+    map.SelectHorzMod   = ImGuiMod_Alt;
+    map.SelectVertMod   = ImGuiMod_Shift;
+    map.OverrideMod     = ImGuiMod_Ctrl;
+    map.ZoomMod         = ImGuiMod_None;
     map.ZoomRate        = 0.1f;
 }
 
@@ -4699,7 +4938,7 @@ ImDrawList* GetPlotDrawList() {
 
 void PushPlotClipRect(float expand) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "PushPlotClipRect() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "PushPlotClipRect() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     ImRect rect = gp.CurrentPlot->PlotRect;
     rect.Expand(expand);
@@ -4777,10 +5016,10 @@ void ShowStyleEditor(ImPlotStyle* ref) {
     static ImPlotStyle ref_saved_style;
     // Default to using internal storage as reference
     static bool init = true;
-    if (init && ref == NULL)
+    if (init && ref == nullptr)
         ref_saved_style = style;
     init = false;
-    if (ref == NULL)
+    if (ref == nullptr)
         ref = &ref_saved_style;
 
     if (ImPlot::ShowStyleSelector("Colors##Selector"))
@@ -4797,16 +5036,9 @@ void ShowStyleEditor(ImPlotStyle* ref) {
                "Use \"Export\" below to save them somewhere.");
     if (ImGui::BeginTabBar("##StyleEditor")) {
         if (ImGui::BeginTabItem("Variables")) {
-            ImGui::Text("Item Styling");
-            ImGui::SliderFloat("LineWeight", &style.LineWeight, 0.0f, 5.0f, "%.1f");
-            ImGui::SliderFloat("MarkerSize", &style.MarkerSize, 2.0f, 10.0f, "%.1f");
-            ImGui::SliderFloat("MarkerWeight", &style.MarkerWeight, 0.0f, 5.0f, "%.1f");
-            ImGui::SliderFloat("FillAlpha", &style.FillAlpha, 0.0f, 1.0f, "%.2f");
-            ImGui::SliderFloat("ErrorBarSize", &style.ErrorBarSize, 0.0f, 10.0f, "%.1f");
-            ImGui::SliderFloat("ErrorBarWeight", &style.ErrorBarWeight, 0.0f, 5.0f, "%.1f");
-            ImGui::SliderFloat("DigitalBitHeight", &style.DigitalBitHeight, 0.0f, 20.0f, "%.1f");
-            ImGui::SliderFloat("DigitalBitGap", &style.DigitalBitGap, 0.0f, 20.0f, "%.1f");
             ImGui::Text("Plot Styling");
+            ImGui::SliderFloat2("PlotDefaultSize", (float*)&style.PlotDefaultSize, 0.0f, 1000, "%.0f");
+            ImGui::SliderFloat2("PlotMinSize", (float*)&style.PlotMinSize, 0.0f, 300, "%.0f");
             ImGui::SliderFloat("PlotBorderSize", &style.PlotBorderSize, 0.0f, 2.0f, "%.0f");
             ImGui::SliderFloat("MinorAlpha", &style.MinorAlpha, 0.0f, 1.0f, "%.2f");
             ImGui::SliderFloat2("MajorTickLen", (float*)&style.MajorTickLen, 0.0f, 20.0f, "%.0f");
@@ -4815,8 +5047,6 @@ void ShowStyleEditor(ImPlotStyle* ref) {
             ImGui::SliderFloat2("MinorTickSize", (float*)&style.MinorTickSize, 0.0f, 2.0f, "%.1f");
             ImGui::SliderFloat2("MajorGridSize", (float*)&style.MajorGridSize, 0.0f, 2.0f, "%.1f");
             ImGui::SliderFloat2("MinorGridSize", (float*)&style.MinorGridSize, 0.0f, 2.0f, "%.1f");
-            ImGui::SliderFloat2("PlotDefaultSize", (float*)&style.PlotDefaultSize, 0.0f, 1000, "%.0f");
-            ImGui::SliderFloat2("PlotMinSize", (float*)&style.PlotMinSize, 0.0f, 300, "%.0f");
             ImGui::Text("Plot Padding");
             ImGui::SliderFloat2("PlotPadding", (float*)&style.PlotPadding, 0.0f, 20.0f, "%.0f");
             ImGui::SliderFloat2("LabelPadding", (float*)&style.LabelPadding, 0.0f, 20.0f, "%.0f");
@@ -4826,7 +5056,8 @@ void ShowStyleEditor(ImPlotStyle* ref) {
             ImGui::SliderFloat2("MousePosPadding", (float*)&style.MousePosPadding, 0.0f, 20.0f, "%.0f");
             ImGui::SliderFloat2("AnnotationPadding", (float*)&style.AnnotationPadding, 0.0f, 5.0f, "%.0f");
             ImGui::SliderFloat2("FitPadding", (float*)&style.FitPadding, 0, 0.2f, "%.2f");
-
+            ImGui::SliderFloat("DigitalPadding", &style.DigitalPadding, 0.0f, 20.0f, "%.1f");
+            ImGui::SliderFloat("DigitalSpacing", &style.DigitalSpacing, 0.0f, 10.0f, "%.1f");
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Colors")) {
@@ -4859,9 +5090,15 @@ void ShowStyleEditor(ImPlotStyle* ref) {
             filter.Draw("Filter colors", ImGui::GetFontSize() * 16);
 
             static ImGuiColorEditFlags alpha_flags = ImGuiColorEditFlags_AlphaPreviewHalf;
+#if IMGUI_VERSION_NUM < 19173
             if (ImGui::RadioButton("Opaque", alpha_flags == ImGuiColorEditFlags_None))             { alpha_flags = ImGuiColorEditFlags_None; } ImGui::SameLine();
             if (ImGui::RadioButton("Alpha",  alpha_flags == ImGuiColorEditFlags_AlphaPreview))     { alpha_flags = ImGuiColorEditFlags_AlphaPreview; } ImGui::SameLine();
             if (ImGui::RadioButton("Both",   alpha_flags == ImGuiColorEditFlags_AlphaPreviewHalf)) { alpha_flags = ImGuiColorEditFlags_AlphaPreviewHalf; } ImGui::SameLine();
+#else
+            if (ImGui::RadioButton("Opaque", alpha_flags == ImGuiColorEditFlags_AlphaOpaque))      { alpha_flags = ImGuiColorEditFlags_AlphaOpaque; } ImGui::SameLine();
+            if (ImGui::RadioButton("Alpha",  alpha_flags == ImGuiColorEditFlags_None))             { alpha_flags = ImGuiColorEditFlags_None; } ImGui::SameLine();
+            if (ImGui::RadioButton("Both",   alpha_flags == ImGuiColorEditFlags_AlphaPreviewHalf)) { alpha_flags = ImGuiColorEditFlags_AlphaPreviewHalf; } ImGui::SameLine();
+#endif
             HelpMarker(
                 "In the color list:\n"
                 "Left-click on colored square to open color picker,\n"
@@ -4903,9 +5140,7 @@ void ShowStyleEditor(ImPlotStyle* ref) {
             ImGui::PopItemWidth();
             ImGui::Separator();
             ImGui::Text("Colors that are set to Auto (i.e. IMPLOT_AUTO_COL) will\n"
-                        "be automatically deduced from your ImGui style or the\n"
-                        "current ImPlot Colormap. If you want to style individual\n"
-                        "plot items, use Push/PopStyleColor around its function.");
+                        "be automatically deduced from your ImGui style.");
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Colormaps")) {
@@ -5020,7 +5255,7 @@ void ShowUserGuide() {
     ImGui::Indent();
         ImGui::BulletText("Left-click drag on axis labels to pan an individual axis.");
     ImGui::Unindent();
-    ImGui::BulletText("Scroll in the plot area to zoom both X any Y axes.");
+    ImGui::BulletText("Scroll in the plot area to zoom both X and Y axes.");
     ImGui::Indent();
         ImGui::BulletText("Scroll on axis labels to zoom an individual axis.");
     ImGui::Unindent();
@@ -5052,7 +5287,7 @@ void ShowAxisMetrics(const ImPlotPlot& plot, const ImPlotAxis& axis) {
     ImGui::BulletText("Range: [%f,%f]",axis.Range.Min, axis.Range.Max);
     ImGui::BulletText("Pixels: %f", axis.PixelSize());
     ImGui::BulletText("Aspect: %f", axis.GetAspect());
-    ImGui::BulletText(axis.OrthoAxis == NULL ? "OrtherAxis: NULL" : "OrthoAxis: 0x%08X", axis.OrthoAxis->ID);
+    ImGui::BulletText(axis.OrthoAxis == nullptr ? "OrthoAxis: NULL" : "OrthoAxis: 0x%08X", axis.OrthoAxis->ID);
     ImGui::BulletText("LinkedMin: %p", (void*)axis.LinkedMin);
     ImGui::BulletText("LinkedMax: %p", (void*)axis.LinkedMax);
     ImGui::BulletText("HasRange: %s", axis.HasRange ? "true" : "false");
@@ -5082,6 +5317,7 @@ void ShowMetricsWindow(bool* p_popen) {
     static bool show_frame_rects = false;
     static bool show_subplot_frame_rects = false;
     static bool show_subplot_grid_rects = false;
+    static bool show_legend_rects = false;
 
     ImDrawList& fg = *ImGui::GetForegroundDrawList();
 
@@ -5106,6 +5342,7 @@ void ShowMetricsWindow(bool* p_popen) {
         ImGui::Checkbox("Show Axis Rects",  &show_axis_rects);
         ImGui::Checkbox("Show Subplot Frame Rects",  &show_subplot_frame_rects);
         ImGui::Checkbox("Show Subplot Grid Rects",  &show_subplot_grid_rects);
+        ImGui::Checkbox("Show Legend Rects",  &show_legend_rects);
         ImGui::TreePop();
     }
     const int n_plots = gp.Plots.GetBufSize();
@@ -5127,6 +5364,10 @@ void ShowMetricsWindow(bool* p_popen) {
                     fg.AddRect(plot->Axes[i].HoverRect.Min, plot->Axes[i].HoverRect.Max, IM_COL32(0,255,0,255));
             }
         }
+        if (show_legend_rects && plot->Items.GetLegendCount() > 0) {
+            fg.AddRect(plot->Items.Legend.Rect.Min, plot->Items.Legend.Rect.Max, IM_COL32(255,192,0,255));
+            fg.AddRect(plot->Items.Legend.RectClamped.Min, plot->Items.Legend.RectClamped.Max, IM_COL32(255,128,0,255));
+        }
     }
     for (int p = 0; p < n_subplots; ++p) {
         ImPlotSubplot* subplot = gp.Subplots.GetByIndex(p);
@@ -5134,6 +5375,10 @@ void ShowMetricsWindow(bool* p_popen) {
             fg.AddRect(subplot->FrameRect.Min, subplot->FrameRect.Max, IM_COL32(255,0,0,255));
         if (show_subplot_grid_rects)
             fg.AddRect(subplot->GridRect.Min, subplot->GridRect.Max, IM_COL32(0,0,255,255));
+        if (show_legend_rects && subplot->Items.GetLegendCount() > 0) {
+            fg.AddRect(subplot->Items.Legend.Rect.Min, subplot->Items.Legend.Rect.Max, IM_COL32(255,192,0,255));
+            fg.AddRect(subplot->Items.Legend.RectClamped.Min, subplot->Items.Legend.RectClamped.Max, IM_COL32(255,128,0,255));
+        }
     }
     if (ImGui::TreeNode("Plots","Plots (%d)", n_plots)) {
         for (int p = 0; p < n_plots; ++p) {
@@ -5152,7 +5397,7 @@ void ShowMetricsWindow(bool* p_popen) {
                             ImVec4 temp = ImGui::ColorConvertU32ToFloat4(item->Color);
                             if (ImGui::ColorEdit4("Color",&temp.x, ImGuiColorEditFlags_NoInputs))
                                 item->Color = ImGui::ColorConvertFloat4ToU32(temp);
-
+                            ImGui::BulletText("Marker: %s", GetMarkerName(item->Marker));
                             ImGui::BulletText("NameOffset: %d",item->NameOffset);
                             ImGui::BulletText("Name: %s", item->NameOffset != -1 ? plot.Items.Legend.Labels.Buf.Data + item->NameOffset : "N/A");
                             ImGui::BulletText("Hovered: %s",item->LegendHovered ? "true" : "false");
@@ -5296,7 +5541,7 @@ bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime*
 
     // t1 parts
     int t1_mo = 0; int t1_md = 0; int t1_yr = 0;
-    if (t1 != NULL) {
+    if (t1 != nullptr) {
         GetTime(*t1,&Tm);
         t1_mo = Tm.tm_mon;
         t1_md = Tm.tm_mday;
@@ -5305,7 +5550,7 @@ bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime*
 
      // t2 parts
     int t2_mo = 0; int t2_md = 0; int t2_yr = 0;
-    if (t2 != NULL) {
+    if (t2 != nullptr) {
         GetTime(*t2,&Tm);
         t2_mo = Tm.tm_mon;
         t2_md = Tm.tm_mday;
@@ -5366,8 +5611,8 @@ bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime*
                 const int now_md = day;
 
                 const bool off_mo   = mo == 0 || mo == 2;
-                const bool t1_or_t2 = (t1 != NULL && t1_mo == now_mo && t1_yr == now_yr && t1_md == now_md) ||
-                                      (t2 != NULL && t2_mo == now_mo && t2_yr == now_yr && t2_md == now_md);
+                const bool t1_or_t2 = (t1 != nullptr && t1_mo == now_mo && t1_yr == now_yr && t1_md == now_md) ||
+                                      (t2 != nullptr && t2_mo == now_mo && t2_yr == now_yr && t2_md == now_md);
 
                 if (off_mo)
                     ImGui::PushStyleColor(ImGuiCol_Text, col_dis);
@@ -5419,8 +5664,8 @@ bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime*
         int mo = 0;
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 4; ++j) {
-                const bool t1_or_t2 = (t1 != NULL && t1_yr == this_yr && t1_mo == mo) ||
-                                      (t2 != NULL && t2_yr == this_yr && t2_mo == mo);
+                const bool t1_or_t2 = (t1 != nullptr && t1_yr == this_yr && t1_mo == mo) ||
+                                      (t2 != nullptr && t2_yr == this_yr && t2_mo == mo);
                 if (t1_or_t2)
                     ImGui::PushStyleColor(ImGuiCol_Button, col_btn);
                 if (ImGui::Button(MONTH_ABRVS[mo],cell_size) && !clk) {
@@ -5458,7 +5703,7 @@ bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime*
         cell_size.y *= 7.0f/5.0f;
         for (int i = 0; i < 5; ++i) {
             for (int j = 0; j < 4; ++j) {
-                const bool t1_or_t2 = (t1 != NULL && t1_yr == yr) || (t2 != NULL && t2_yr == yr);
+                const bool t1_or_t2 = (t1 != nullptr && t1_yr == yr) || (t2 != nullptr && t2_yr == yr);
                 if (t1_or_t2)
                     ImGui::PushStyleColor(ImGuiCol_Button, col_btn);
                 ImFormatString(buff,32,"%d",yr);
@@ -5485,8 +5730,9 @@ bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime*
 }
 
 bool ShowTimePicker(const char* id, ImPlotTime* t) {
+    ImPlotContext& gp = *GImPlot;
     ImGui::PushID(id);
-    tm& Tm = GImPlot->Tm;
+    tm& Tm = gp.Tm;
     GetTime(*t,&Tm);
 
     static const char* nums[] = { "00","01","02","03","04","05","06","07","08","09",
@@ -5498,7 +5744,7 @@ bool ShowTimePicker(const char* id, ImPlotTime* t) {
 
     static const char* am_pm[] = {"am","pm"};
 
-    bool hour24 = GImPlot->Style.Use24HourClock;
+    bool hour24 = gp.Style.Use24HourClock;
 
     int hr  = hour24 ? Tm.tm_hour : ((Tm.tm_hour == 0 || Tm.tm_hour == 12) ? 12 : Tm.tm_hour % 12);
     int min = Tm.tm_min;
@@ -5586,11 +5832,6 @@ void StyleColorsAuto(ImPlotStyle* dst) {
 
     style->MinorAlpha               = 0.25f;
 
-    colors[ImPlotCol_Line]          = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_Fill]          = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_MarkerOutline] = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_MarkerFill]    = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_ErrorBar]      = IMPLOT_AUTO_COL;
     colors[ImPlotCol_FrameBg]       = IMPLOT_AUTO_COL;
     colors[ImPlotCol_PlotBg]        = IMPLOT_AUTO_COL;
     colors[ImPlotCol_PlotBorder]    = IMPLOT_AUTO_COL;
@@ -5615,12 +5856,7 @@ void StyleColorsClassic(ImPlotStyle* dst) {
     ImVec4* colors                  = style->Colors;
 
     style->MinorAlpha               = 0.5f;
-
-    colors[ImPlotCol_Line]          = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_Fill]          = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_MarkerOutline] = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_MarkerFill]    = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_ErrorBar]      = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    
     colors[ImPlotCol_FrameBg]       = ImVec4(0.43f, 0.43f, 0.43f, 0.39f);
     colors[ImPlotCol_PlotBg]        = ImVec4(0.00f, 0.00f, 0.00f, 0.35f);
     colors[ImPlotCol_PlotBorder]    = ImVec4(0.50f, 0.50f, 0.50f, 0.50f);
@@ -5645,11 +5881,6 @@ void StyleColorsDark(ImPlotStyle* dst) {
 
     style->MinorAlpha               = 0.25f;
 
-    colors[ImPlotCol_Line]          = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_Fill]          = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_MarkerOutline] = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_MarkerFill]    = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_ErrorBar]      = IMPLOT_AUTO_COL;
     colors[ImPlotCol_FrameBg]       = ImVec4(1.00f, 1.00f, 1.00f, 0.07f);
     colors[ImPlotCol_PlotBg]        = ImVec4(0.00f, 0.00f, 0.00f, 0.50f);
     colors[ImPlotCol_PlotBorder]    = ImVec4(0.43f, 0.43f, 0.50f, 0.50f);
@@ -5674,11 +5905,6 @@ void StyleColorsLight(ImPlotStyle* dst) {
 
     style->MinorAlpha               = 1.0f;
 
-    colors[ImPlotCol_Line]          = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_Fill]          = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_MarkerOutline] = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_MarkerFill]    = IMPLOT_AUTO_COL;
-    colors[ImPlotCol_ErrorBar]      = IMPLOT_AUTO_COL;
     colors[ImPlotCol_FrameBg]       = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
     colors[ImPlotCol_PlotBg]        = ImVec4(0.42f, 0.57f, 1.00f, 0.13f);
     colors[ImPlotCol_PlotBorder]    = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
@@ -5703,21 +5929,10 @@ void StyleColorsLight(ImPlotStyle* dst) {
 
 #ifndef IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
 
-bool BeginPlot(const char* title, const char* x_label, const char* y1_label, const ImVec2& size,
-               ImPlotFlags flags, ImPlotAxisFlags x_flags, ImPlotAxisFlags y1_flags, ImPlotAxisFlags y2_flags, ImPlotAxisFlags y3_flags,
-               const char* y2_label, const char* y3_label)
-{
-    if (!BeginPlot(title, size, flags))
-        return false;
-    SetupAxis(ImAxis_X1, x_label, x_flags);
-    SetupAxis(ImAxis_Y1, y1_label, y1_flags);
-    if (ImHasFlag(flags, ImPlotFlags_YAxis2))
-        SetupAxis(ImAxis_Y2, y2_label, y2_flags);
-    if (ImHasFlag(flags, ImPlotFlags_YAxis3))
-        SetupAxis(ImAxis_Y3, y3_label, y3_flags);
-    return true;
-}
+// Deprecated method will go in here
 
 #endif
 
 }  // namespace ImPlot
+
+#endif // #ifndef IMGUI_DISABLE

--- a/lib/implot/implot.h
+++ b/lib/implot/implot.h
@@ -1,0 +1,1286 @@
+// MIT License
+
+// Copyright (c) 2022 Evan Pezent
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ImPlot v0.14
+
+// Table of Contents:
+//
+// [SECTION] Macros and Defines
+// [SECTION] Enums and Types
+// [SECTION] Callbacks
+// [SECTION] Contexts
+// [SECTION] Begin/End Plot
+// [SECTION] Begin/End Subplot
+// [SECTION] Setup
+// [SECTION] SetNext
+// [SECTION] Plot Items
+// [SECTION] Plot Tools
+// [SECTION] Plot Utils
+// [SECTION] Legend Utils
+// [SECTION] Drag and Drop
+// [SECTION] Styling
+// [SECTION] Colormaps
+// [SECTION] Input Mapping
+// [SECTION] Miscellaneous
+// [SECTION] Demo
+// [SECTION] Obsolete API
+
+#pragma once
+#include "imgui.h"
+
+//-----------------------------------------------------------------------------
+// [SECTION] Macros and Defines
+//-----------------------------------------------------------------------------
+
+// Define attributes of all API symbols declarations (e.g. for DLL under Windows)
+// Using ImPlot via a shared library is not recommended, because we don't guarantee
+// backward nor forward ABI compatibility and also function call overhead. If you
+// do use ImPlot as a DLL, be sure to call SetImGuiContext (see Miscellanous section).
+#ifndef IMPLOT_API
+#define IMPLOT_API
+#endif
+
+// ImPlot version string.
+#define IMPLOT_VERSION "0.14"
+// Indicates variable should deduced automatically.
+#define IMPLOT_AUTO -1
+// Special color used to indicate that a color should be deduced automatically.
+#define IMPLOT_AUTO_COL ImVec4(0,0,0,-1)
+// Macro for templated plotting functions; keeps header clean.
+#define IMPLOT_TMP template <typename T> IMPLOT_API
+
+//-----------------------------------------------------------------------------
+// [SECTION] Enums and Types
+//-----------------------------------------------------------------------------
+
+// Forward declarations
+struct ImPlotContext;             // ImPlot context (opaque struct, see implot_internal.h)
+
+// Enums/Flags
+typedef int ImAxis;                   // -> enum ImAxis_
+typedef int ImPlotFlags;              // -> enum ImPlotFlags_
+typedef int ImPlotAxisFlags;          // -> enum ImPlotAxisFlags_
+typedef int ImPlotSubplotFlags;       // -> enum ImPlotSubplotFlags_
+typedef int ImPlotLegendFlags;        // -> enum ImPlotLegendFlags_
+typedef int ImPlotMouseTextFlags;     // -> enum ImPlotMouseTextFlags_
+typedef int ImPlotDragToolFlags;      // -> ImPlotDragToolFlags_
+typedef int ImPlotColormapScaleFlags; // -> ImPlotColormapScaleFlags_
+
+typedef int ImPlotItemFlags;          // -> ImPlotItemFlags_
+typedef int ImPlotLineFlags;          // -> ImPlotLineFlags_
+typedef int ImPlotScatterFlags;       // -> ImPlotScatterFlags
+typedef int ImPlotStairsFlags;        // -> ImPlotStairsFlags_
+typedef int ImPlotShadedFlags;        // -> ImPlotShadedFlags_
+typedef int ImPlotBarsFlags;          // -> ImPlotBarsFlags_
+typedef int ImPlotBarGroupsFlags;     // -> ImPlotBarGroupsFlags_
+typedef int ImPlotErrorBarsFlags;     // -> ImPlotErrorBarsFlags_
+typedef int ImPlotStemsFlags;         // -> ImPlotStemsFlags_
+typedef int ImPlotInfLinesFlags;      // -> ImPlotInfLinesFlags_
+typedef int ImPlotPieChartFlags;      // -> ImPlotPieChartFlags_
+typedef int ImPlotHeatmapFlags;       // -> ImPlotHeatmapFlags_
+typedef int ImPlotHistogramFlags;     // -> ImPlotHistogramFlags_
+typedef int ImPlotDigitalFlags;       // -> ImPlotDigitalFlags_
+typedef int ImPlotImageFlags;         // -> ImPlotImageFlags_
+typedef int ImPlotTextFlags;          // -> ImPlotTextFlags_
+typedef int ImPlotDummyFlags;         // -> ImPlotDummyFlags_
+
+typedef int ImPlotCond;               // -> enum ImPlotCond_
+typedef int ImPlotCol;                // -> enum ImPlotCol_
+typedef int ImPlotStyleVar;           // -> enum ImPlotStyleVar_
+typedef int ImPlotScale;              // -> enum ImPlotScale_
+typedef int ImPlotMarker;             // -> enum ImPlotMarker_
+typedef int ImPlotColormap;           // -> enum ImPlotColormap_
+typedef int ImPlotLocation;           // -> enum ImPlotLocation_
+typedef int ImPlotBin;                // -> enum ImPlotBin_
+
+// Axis indices. The values assigned may change; NEVER hardcode these.
+enum ImAxis_ {
+    // horizontal axes
+    ImAxis_X1 = 0, // enabled by default
+    ImAxis_X2,     // disabled by default
+    ImAxis_X3,     // disabled by default
+    // vertical axes
+    ImAxis_Y1,     // enabled by default
+    ImAxis_Y2,     // disabled by default
+    ImAxis_Y3,     // disabled by default
+    // bookeeping
+    ImAxis_COUNT
+};
+
+// Options for plots (see BeginPlot).
+enum ImPlotFlags_ {
+    ImPlotFlags_None          = 0,       // default
+    ImPlotFlags_NoTitle       = 1 << 0,  // the plot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MyPlot")
+    ImPlotFlags_NoLegend      = 1 << 1,  // the legend will not be displayed
+    ImPlotFlags_NoMouseText   = 1 << 2,  // the mouse position, in plot coordinates, will not be displayed inside of the plot
+    ImPlotFlags_NoInputs      = 1 << 3,  // the user will not be able to interact with the plot
+    ImPlotFlags_NoMenus       = 1 << 4,  // the user will not be able to open context menus
+    ImPlotFlags_NoBoxSelect   = 1 << 5,  // the user will not be able to box-select
+    ImPlotFlags_NoChild       = 1 << 6,  // a child window region will not be used to capture mouse scroll (can boost performance for single ImGui window applications)
+    ImPlotFlags_NoFrame       = 1 << 7,  // the ImGui frame will not be rendered
+    ImPlotFlags_Equal         = 1 << 8,  // x and y axes pairs will be constrained to have the same units/pixel
+    ImPlotFlags_Crosshairs    = 1 << 9,  // the default mouse cursor will be replaced with a crosshair when hovered
+    ImPlotFlags_CanvasOnly    = ImPlotFlags_NoTitle | ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect | ImPlotFlags_NoMouseText
+};
+
+// Options for plot axes (see SetupAxis).
+enum ImPlotAxisFlags_ {
+    ImPlotAxisFlags_None          = 0,       // default
+    ImPlotAxisFlags_NoLabel       = 1 << 0,  // the axis label will not be displayed (axis labels are also hidden if the supplied string name is NULL)
+    ImPlotAxisFlags_NoGridLines   = 1 << 1,  // no grid lines will be displayed
+    ImPlotAxisFlags_NoTickMarks   = 1 << 2,  // no tick marks will be displayed
+    ImPlotAxisFlags_NoTickLabels  = 1 << 3,  // no text labels will be displayed
+    ImPlotAxisFlags_NoInitialFit  = 1 << 4,  // axis will not be initially fit to data extents on the first rendered frame
+    ImPlotAxisFlags_NoMenus       = 1 << 5,  // the user will not be able to open context menus with right-click
+    ImPlotAxisFlags_NoSideSwitch  = 1 << 6,  // the user will not be able to switch the axis side by dragging it
+    ImPlotAxisFlags_NoHighlight   = 1 << 7,  // the axis will not have its background highlighted when hovered or held
+    ImPlotAxisFlags_Opposite      = 1 << 8,  // axis ticks and labels will be rendered on the conventionally opposite side (i.e, right or top)
+    ImPlotAxisFlags_Foreground    = 1 << 9,  // grid lines will be displayed in the foreground (i.e. on top of data) instead of the background
+    ImPlotAxisFlags_Invert        = 1 << 10, // the axis will be inverted
+    ImPlotAxisFlags_AutoFit       = 1 << 11, // axis will be auto-fitting to data extents
+    ImPlotAxisFlags_RangeFit      = 1 << 12, // axis will only fit points if the point is in the visible range of the **orthogonal** axis
+    ImPlotAxisFlags_PanStretch    = 1 << 13, // panning in a locked or constrained state will cause the axis to stretch if possible
+    ImPlotAxisFlags_LockMin       = 1 << 14, // the axis minimum value will be locked when panning/zooming
+    ImPlotAxisFlags_LockMax       = 1 << 15, // the axis maximum value will be locked when panning/zooming
+    ImPlotAxisFlags_Lock          = ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax,
+    ImPlotAxisFlags_NoDecorations = ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoTickLabels,
+    ImPlotAxisFlags_AuxDefault    = ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_Opposite
+};
+
+// Options for subplots (see BeginSubplot)
+enum ImPlotSubplotFlags_ {
+    ImPlotSubplotFlags_None        = 0,       // default
+    ImPlotSubplotFlags_NoTitle     = 1 << 0,  // the subplot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MySubplot")
+    ImPlotSubplotFlags_NoLegend    = 1 << 1,  // the legend will not be displayed (only applicable if ImPlotSubplotFlags_ShareItems is enabled)
+    ImPlotSubplotFlags_NoMenus     = 1 << 2,  // the user will not be able to open context menus with right-click
+    ImPlotSubplotFlags_NoResize    = 1 << 3,  // resize splitters between subplot cells will be not be provided
+    ImPlotSubplotFlags_NoAlign     = 1 << 4,  // subplot edges will not be aligned vertically or horizontally
+    ImPlotSubplotFlags_ShareItems  = 1 << 5,  // items across all subplots will be shared and rendered into a single legend entry
+    ImPlotSubplotFlags_LinkRows    = 1 << 6,  // link the y-axis limits of all plots in each row (does not apply to auxiliary axes)
+    ImPlotSubplotFlags_LinkCols    = 1 << 7,  // link the x-axis limits of all plots in each column (does not apply to auxiliary axes)
+    ImPlotSubplotFlags_LinkAllX    = 1 << 8,  // link the x-axis limits in every plot in the subplot (does not apply to auxiliary axes)
+    ImPlotSubplotFlags_LinkAllY    = 1 << 9,  // link the y-axis limits in every plot in the subplot (does not apply to auxiliary axes)
+    ImPlotSubplotFlags_ColMajor    = 1 << 10  // subplots are added in column major order instead of the default row major order
+};
+
+// Options for legends (see SetupLegend)
+enum ImPlotLegendFlags_ {
+    ImPlotLegendFlags_None            = 0,      // default
+    ImPlotLegendFlags_NoButtons       = 1 << 0, // legend icons will not function as hide/show buttons
+    ImPlotLegendFlags_NoHighlightItem = 1 << 1, // plot items will not be highlighted when their legend entry is hovered
+    ImPlotLegendFlags_NoHighlightAxis = 1 << 2, // axes will not be highlighted when legend entries are hovered (only relevant if x/y-axis count > 1)
+    ImPlotLegendFlags_NoMenus         = 1 << 3, // the user will not be able to open context menus with right-click
+    ImPlotLegendFlags_Outside         = 1 << 4, // legend will be rendered outside of the plot area
+    ImPlotLegendFlags_Horizontal      = 1 << 5, // legend entries will be displayed horizontally
+    ImPlotLegendFlags_Sort            = 1 << 6, // legend entries will be displayed in alphabetical order
+};
+
+// Options for mouse hover text (see SetupMouseText)
+enum ImPlotMouseTextFlags_ {
+    ImPlotMouseTextFlags_None        = 0,      // default
+    ImPlotMouseTextFlags_NoAuxAxes   = 1 << 0, // only show the mouse position for primary axes
+    ImPlotMouseTextFlags_NoFormat    = 1 << 1, // axes label formatters won't be used to render text
+    ImPlotMouseTextFlags_ShowAlways  = 1 << 2, // always display mouse position even if plot not hovered
+};
+
+// Options for DragPoint, DragLine, DragRect
+enum ImPlotDragToolFlags_ {
+    ImPlotDragToolFlags_None      = 0,      // default
+    ImPlotDragToolFlags_NoCursors = 1 << 0, // drag tools won't change cursor icons when hovered or held
+    ImPlotDragToolFlags_NoFit     = 1 << 1, // the drag tool won't be considered for plot fits
+    ImPlotDragToolFlags_NoInputs  = 1 << 2, // lock the tool from user inputs
+    ImPlotDragToolFlags_Delayed   = 1 << 3, // tool rendering will be delayed one frame; useful when applying position-constraints
+};
+
+// Flags for ColormapScale
+enum ImPlotColormapScaleFlags_ {
+    ImPlotColormapScaleFlags_None     = 0,      // default
+    ImPlotColormapScaleFlags_NoLabel  = 1 << 0, // the colormap axis label will not be displayed
+    ImPlotColormapScaleFlags_Opposite = 1 << 1, // render the colormap label and tick labels on the opposite side
+    ImPlotColormapScaleFlags_Invert   = 1 << 2, // invert the colormap bar and axis scale (this only affects rendering; if you only want to reverse the scale mapping, make scale_min > scale_max)
+};
+
+// Flags for ANY PlotX function
+enum ImPlotItemFlags_ {
+    ImPlotItemFlags_None     = 0,
+    ImPlotItemFlags_NoLegend = 1 << 0, // the item won't have a legend entry displayed
+    ImPlotItemFlags_NoFit    = 1 << 1, // the item won't be considered for plot fits
+};
+
+// Flags for PlotLine
+enum ImPlotLineFlags_ {
+    ImPlotLineFlags_None        = 0,       // default
+    ImPlotLineFlags_Segments    = 1 << 10, // a line segment will be rendered from every two consecutive points
+    ImPlotLineFlags_Loop        = 1 << 11, // the last and first point will be connected to form a closed loop
+    ImPlotLineFlags_SkipNaN     = 1 << 12, // NaNs values will be skipped instead of rendered as missing data
+    ImPlotLineFlags_NoClip      = 1 << 13, // markers (if displayed) on the edge of a plot will not be clipped
+    ImPlotLineFlags_Shaded      = 1 << 14, // a filled region between the line and horizontal origin will be rendered; use PlotShaded for more advanced cases
+};
+
+// Flags for PlotScatter
+enum ImPlotScatterFlags_ {
+    ImPlotScatterFlags_None   = 0,       // default
+    ImPlotScatterFlags_NoClip = 1 << 10, // markers on the edge of a plot will not be clipped
+};
+
+// Flags for PlotStairs
+enum ImPlotStairsFlags_ {
+    ImPlotStairsFlags_None     = 0,       // default
+    ImPlotStairsFlags_PreStep  = 1 << 10, // the y value is continued constantly to the left from every x position, i.e. the interval (x[i-1], x[i]] has the value y[i]
+    ImPlotStairsFlags_Shaded   = 1 << 11  // a filled region between the stairs and horizontal origin will be rendered; use PlotShaded for more advanced cases
+};
+
+// Flags for PlotShaded (placeholder)
+enum ImPlotShadedFlags_ {
+    ImPlotShadedFlags_None  = 0 // default
+};
+
+// Flags for PlotBars
+enum ImPlotBarsFlags_ {
+    ImPlotBarsFlags_None         = 0,       // default
+    ImPlotBarsFlags_Horizontal   = 1 << 10, // bars will be rendered horizontally on the current y-axis
+};
+
+// Flags for PlotBarGroups
+enum ImPlotBarGroupsFlags_ {
+    ImPlotBarGroupsFlags_None        = 0,       // default
+    ImPlotBarGroupsFlags_Horizontal  = 1 << 10, // bar groups will be rendered horizontally on the current y-axis
+    ImPlotBarGroupsFlags_Stacked     = 1 << 11, // items in a group will be stacked on top of each other
+};
+
+// Flags for PlotErrorBars
+enum ImPlotErrorBarsFlags_ {
+    ImPlotErrorBarsFlags_None       = 0,       // default
+    ImPlotErrorBarsFlags_Horizontal = 1 << 10, // error bars will be rendered horizontally on the current y-axis
+};
+
+// Flags for PlotStems
+enum ImPlotStemsFlags_ {
+    ImPlotStemsFlags_None       = 0,       // default
+    ImPlotStemsFlags_Horizontal = 1 << 10, // stems will be rendered horizontally on the current y-axis
+};
+
+// Flags for PlotInfLines
+enum ImPlotInfLinesFlags_ {
+    ImPlotInfLinesFlags_None       = 0,      // default
+    ImPlotInfLinesFlags_Horizontal = 1 << 10 // lines will be rendered horizontally on the current y-axis
+};
+
+// Flags for PlotPieChart
+enum ImPlotPieChartFlags_ {
+    ImPlotPieChartFlags_None      = 0,      // default
+    ImPlotPieChartFlags_Normalize = 1 << 10 // force normalization of pie chart values (i.e. always make a full circle if sum < 0)
+};
+
+// Flags for PlotHeatmap
+enum ImPlotHeatmapFlags_ {
+    ImPlotHeatmapFlags_None     = 0,       // default
+    ImPlotHeatmapFlags_ColMajor = 1 << 10, // data will be read in column major order
+};
+
+// Flags for PlotHistogram and PlotHistogram2D
+enum ImPlotHistogramFlags_ {
+    ImPlotHistogramFlags_None       = 0,       // default
+    ImPlotHistogramFlags_Horizontal = 1 << 10, // histogram bars will be rendered horizontally (not supported by PlotHistogram2D)
+    ImPlotHistogramFlags_Cumulative = 1 << 11, // each bin will contain its count plus the counts of all previous bins (not supported by PlotHistogram2D)
+    ImPlotHistogramFlags_Density    = 1 << 12, // counts will be normalized, i.e. the PDF will be visualized, or the CDF will be visualized if Cumulative is also set
+    ImPlotHistogramFlags_NoOutliers = 1 << 13, // exclude values outside the specifed histogram range from the count toward normalizing and cumulative counts
+    ImPlotHistogramFlags_ColMajor   = 1 << 14  // data will be read in column major order (not supported by PlotHistogram)
+};
+
+// Flags for PlotDigital (placeholder)
+enum ImPlotDigitalFlags_ {
+    ImPlotDigitalFlags_None = 0 // default
+};
+
+// Flags for PlotImage (placeholder)
+enum ImPlotImageFlags_ {
+    ImPlotImageFlags_None = 0 // default
+};
+
+// Flags for PlotText
+enum ImPlotTextFlags_ {
+    ImPlotTextFlags_None     = 0,       // default
+    ImPlotTextFlags_Vertical = 1 << 10  // text will be rendered vertically
+};
+
+// Flags for PlotDummy (placeholder)
+enum ImPlotDummyFlags_ {
+    ImPlotDummyFlags_None = 0 // default
+};
+
+// Represents a condition for SetupAxisLimits etc. (same as ImGuiCond, but we only support a subset of those enums)
+enum ImPlotCond_
+{
+    ImPlotCond_None   = ImGuiCond_None,    // No condition (always set the variable), same as _Always
+    ImPlotCond_Always = ImGuiCond_Always,  // No condition (always set the variable)
+    ImPlotCond_Once   = ImGuiCond_Once,    // Set the variable once per runtime session (only the first call will succeed)
+};
+
+// Plot styling colors.
+enum ImPlotCol_ {
+    // item styling colors
+    ImPlotCol_Line,          // plot line/outline color (defaults to next unused color in current colormap)
+    ImPlotCol_Fill,          // plot fill color for bars (defaults to the current line color)
+    ImPlotCol_MarkerOutline, // marker outline color (defaults to the current line color)
+    ImPlotCol_MarkerFill,    // marker fill color (defaults to the current line color)
+    ImPlotCol_ErrorBar,      // error bar color (defaults to ImGuiCol_Text)
+    // plot styling colors
+    ImPlotCol_FrameBg,       // plot frame background color (defaults to ImGuiCol_FrameBg)
+    ImPlotCol_PlotBg,        // plot area background color (defaults to ImGuiCol_WindowBg)
+    ImPlotCol_PlotBorder,    // plot area border color (defaults to ImGuiCol_Border)
+    ImPlotCol_LegendBg,      // legend background color (defaults to ImGuiCol_PopupBg)
+    ImPlotCol_LegendBorder,  // legend border color (defaults to ImPlotCol_PlotBorder)
+    ImPlotCol_LegendText,    // legend text color (defaults to ImPlotCol_InlayText)
+    ImPlotCol_TitleText,     // plot title text color (defaults to ImGuiCol_Text)
+    ImPlotCol_InlayText,     // color of text appearing inside of plots (defaults to ImGuiCol_Text)
+    ImPlotCol_AxisText,      // axis label and tick lables color (defaults to ImGuiCol_Text)
+    ImPlotCol_AxisGrid,      // axis grid color (defaults to 25% ImPlotCol_AxisText)
+    ImPlotCol_AxisTick,      // axis tick color (defaults to AxisGrid)
+    ImPlotCol_AxisBg,        // background color of axis hover region (defaults to transparent)
+    ImPlotCol_AxisBgHovered, // axis hover color (defaults to ImGuiCol_ButtonHovered)
+    ImPlotCol_AxisBgActive,  // axis active color (defaults to ImGuiCol_ButtonActive)
+    ImPlotCol_Selection,     // box-selection color (defaults to yellow)
+    ImPlotCol_Crosshairs,    // crosshairs color (defaults to ImPlotCol_PlotBorder)
+    ImPlotCol_COUNT
+};
+
+// Plot styling variables.
+enum ImPlotStyleVar_ {
+    // item styling variables
+    ImPlotStyleVar_LineWeight,         // float,  plot item line weight in pixels
+    ImPlotStyleVar_Marker,             // int,    marker specification
+    ImPlotStyleVar_MarkerSize,         // float,  marker size in pixels (roughly the marker's "radius")
+    ImPlotStyleVar_MarkerWeight,       // float,  plot outline weight of markers in pixels
+    ImPlotStyleVar_FillAlpha,          // float,  alpha modifier applied to all plot item fills
+    ImPlotStyleVar_ErrorBarSize,       // float,  error bar whisker width in pixels
+    ImPlotStyleVar_ErrorBarWeight,     // float,  error bar whisker weight in pixels
+    ImPlotStyleVar_DigitalBitHeight,   // float,  digital channels bit height (at 1) in pixels
+    ImPlotStyleVar_DigitalBitGap,      // float,  digital channels bit padding gap in pixels
+    // plot styling variables
+    ImPlotStyleVar_PlotBorderSize,     // float,  thickness of border around plot area
+    ImPlotStyleVar_MinorAlpha,         // float,  alpha multiplier applied to minor axis grid lines
+    ImPlotStyleVar_MajorTickLen,       // ImVec2, major tick lengths for X and Y axes
+    ImPlotStyleVar_MinorTickLen,       // ImVec2, minor tick lengths for X and Y axes
+    ImPlotStyleVar_MajorTickSize,      // ImVec2, line thickness of major ticks
+    ImPlotStyleVar_MinorTickSize,      // ImVec2, line thickness of minor ticks
+    ImPlotStyleVar_MajorGridSize,      // ImVec2, line thickness of major grid lines
+    ImPlotStyleVar_MinorGridSize,      // ImVec2, line thickness of minor grid lines
+    ImPlotStyleVar_PlotPadding,        // ImVec2, padding between widget frame and plot area, labels, or outside legends (i.e. main padding)
+    ImPlotStyleVar_LabelPadding,       // ImVec2, padding between axes labels, tick labels, and plot edge
+    ImPlotStyleVar_LegendPadding,      // ImVec2, legend padding from plot edges
+    ImPlotStyleVar_LegendInnerPadding, // ImVec2, legend inner padding from legend edges
+    ImPlotStyleVar_LegendSpacing,      // ImVec2, spacing between legend entries
+    ImPlotStyleVar_MousePosPadding,    // ImVec2, padding between plot edge and interior info text
+    ImPlotStyleVar_AnnotationPadding,  // ImVec2, text padding around annotation labels
+    ImPlotStyleVar_FitPadding,         // ImVec2, additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)
+    ImPlotStyleVar_PlotDefaultSize,    // ImVec2, default size used when ImVec2(0,0) is passed to BeginPlot
+    ImPlotStyleVar_PlotMinSize,        // ImVec2, minimum size plot frame can be when shrunk
+    ImPlotStyleVar_COUNT
+};
+
+// Axis scale
+enum ImPlotScale_ {
+    ImPlotScale_Linear = 0, // default linear scale
+    ImPlotScale_Time,       // date/time scale
+    ImPlotScale_Log10,      // base 10 logartithmic scale
+    ImPlotScale_SymLog,     // symmetric log scale
+};
+
+// Marker specifications.
+enum ImPlotMarker_ {
+    ImPlotMarker_None = -1, // no marker
+    ImPlotMarker_Circle,    // a circle marker (default)
+    ImPlotMarker_Square,    // a square maker
+    ImPlotMarker_Diamond,   // a diamond marker
+    ImPlotMarker_Up,        // an upward-pointing triangle marker
+    ImPlotMarker_Down,      // an downward-pointing triangle marker
+    ImPlotMarker_Left,      // an leftward-pointing triangle marker
+    ImPlotMarker_Right,     // an rightward-pointing triangle marker
+    ImPlotMarker_Cross,     // a cross marker (not fillable)
+    ImPlotMarker_Plus,      // a plus marker (not fillable)
+    ImPlotMarker_Asterisk,  // a asterisk marker (not fillable)
+    ImPlotMarker_COUNT
+};
+
+// Built-in colormaps
+enum ImPlotColormap_ {
+    ImPlotColormap_Deep     = 0,   // a.k.a. seaborn deep             (qual=true,  n=10) (default)
+    ImPlotColormap_Dark     = 1,   // a.k.a. matplotlib "Set1"        (qual=true,  n=9 )
+    ImPlotColormap_Pastel   = 2,   // a.k.a. matplotlib "Pastel1"     (qual=true,  n=9 )
+    ImPlotColormap_Paired   = 3,   // a.k.a. matplotlib "Paired"      (qual=true,  n=12)
+    ImPlotColormap_Viridis  = 4,   // a.k.a. matplotlib "viridis"     (qual=false, n=11)
+    ImPlotColormap_Plasma   = 5,   // a.k.a. matplotlib "plasma"      (qual=false, n=11)
+    ImPlotColormap_Hot      = 6,   // a.k.a. matplotlib/MATLAB "hot"  (qual=false, n=11)
+    ImPlotColormap_Cool     = 7,   // a.k.a. matplotlib/MATLAB "cool" (qual=false, n=11)
+    ImPlotColormap_Pink     = 8,   // a.k.a. matplotlib/MATLAB "pink" (qual=false, n=11)
+    ImPlotColormap_Jet      = 9,   // a.k.a. MATLAB "jet"             (qual=false, n=11)
+    ImPlotColormap_Twilight = 10,  // a.k.a. matplotlib "twilight"    (qual=false, n=11)
+    ImPlotColormap_RdBu     = 11,  // red/blue, Color Brewer          (qual=false, n=11)
+    ImPlotColormap_BrBG     = 12,  // brown/blue-green, Color Brewer  (qual=false, n=11)
+    ImPlotColormap_PiYG     = 13,  // pink/yellow-green, Color Brewer (qual=false, n=11)
+    ImPlotColormap_Spectral = 14,  // color spectrum, Color Brewer    (qual=false, n=11)
+    ImPlotColormap_Greys    = 15,  // white/black                     (qual=false, n=2 )
+};
+
+// Used to position items on a plot (e.g. legends, labels, etc.)
+enum ImPlotLocation_ {
+    ImPlotLocation_Center    = 0,                                          // center-center
+    ImPlotLocation_North     = 1 << 0,                                     // top-center
+    ImPlotLocation_South     = 1 << 1,                                     // bottom-center
+    ImPlotLocation_West      = 1 << 2,                                     // center-left
+    ImPlotLocation_East      = 1 << 3,                                     // center-right
+    ImPlotLocation_NorthWest = ImPlotLocation_North | ImPlotLocation_West, // top-left
+    ImPlotLocation_NorthEast = ImPlotLocation_North | ImPlotLocation_East, // top-right
+    ImPlotLocation_SouthWest = ImPlotLocation_South | ImPlotLocation_West, // bottom-left
+    ImPlotLocation_SouthEast = ImPlotLocation_South | ImPlotLocation_East  // bottom-right
+};
+
+// Enums for different automatic histogram binning methods (k = bin count or w = bin width)
+enum ImPlotBin_ {
+    ImPlotBin_Sqrt    = -1, // k = sqrt(n)
+    ImPlotBin_Sturges = -2, // k = 1 + log2(n)
+    ImPlotBin_Rice    = -3, // k = 2 * cbrt(n)
+    ImPlotBin_Scott   = -4, // w = 3.49 * sigma / cbrt(n)
+};
+
+// Double precision version of ImVec2 used by ImPlot. Extensible by end users.
+struct ImPlotPoint {
+    double x, y;
+    ImPlotPoint()                         { x = y = 0.0;      }
+    ImPlotPoint(double _x, double _y)     { x = _x; y = _y;   }
+    ImPlotPoint(const ImVec2& p)          { x = p.x; y = p.y; }
+    double  operator[] (size_t idx) const { return (&x)[idx]; }
+    double& operator[] (size_t idx)       { return (&x)[idx]; }
+#ifdef IMPLOT_POINT_CLASS_EXTRA
+    IMPLOT_POINT_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h
+                                 // to convert back and forth between your math types and ImPlotPoint.
+#endif
+};
+
+// Range defined by a min/max value.
+struct ImPlotRange {
+    double Min, Max;
+    ImPlotRange()                         { Min = 0; Max = 0;                                         }
+    ImPlotRange(double _min, double _max) { Min = _min; Max = _max;                                   }
+    bool Contains(double value) const     { return value >= Min && value <= Max;                      }
+    double Size() const                   { return Max - Min;                                         }
+    double Clamp(double value) const      { return (value < Min) ? Min : (value > Max) ? Max : value; }
+};
+
+// Combination of two range limits for X and Y axes. Also an AABB defined by Min()/Max().
+struct ImPlotRect {
+    ImPlotRange X, Y;
+    ImPlotRect()                                                       {                                                               }
+    ImPlotRect(double x_min, double x_max, double y_min, double y_max) { X.Min = x_min; X.Max = x_max; Y.Min = y_min; Y.Max = y_max;   }
+    bool Contains(const ImPlotPoint& p) const                          { return Contains(p.x, p.y);                                    }
+    bool Contains(double x, double y) const                            { return X.Contains(x) && Y.Contains(y);                        }
+    ImPlotPoint Size() const                                           { return ImPlotPoint(X.Size(), Y.Size());                       }
+    ImPlotPoint Clamp(const ImPlotPoint& p)                            { return Clamp(p.x, p.y);                                       }
+    ImPlotPoint Clamp(double x, double y)                              { return ImPlotPoint(X.Clamp(x),Y.Clamp(y));                    }
+    ImPlotPoint Min() const                                            { return ImPlotPoint(X.Min, Y.Min);                             }
+    ImPlotPoint Max() const                                            { return ImPlotPoint(X.Max, Y.Max);                             }
+};
+
+// Plot style structure
+struct ImPlotStyle {
+    // item styling variables
+    float   LineWeight;              // = 1,      item line weight in pixels
+    int     Marker;                  // = ImPlotMarker_None, marker specification
+    float   MarkerSize;              // = 4,      marker size in pixels (roughly the marker's "radius")
+    float   MarkerWeight;            // = 1,      outline weight of markers in pixels
+    float   FillAlpha;               // = 1,      alpha modifier applied to plot fills
+    float   ErrorBarSize;            // = 5,      error bar whisker width in pixels
+    float   ErrorBarWeight;          // = 1.5,    error bar whisker weight in pixels
+    float   DigitalBitHeight;        // = 8,      digital channels bit height (at y = 1.0f) in pixels
+    float   DigitalBitGap;           // = 4,      digital channels bit padding gap in pixels
+    // plot styling variables
+    float   PlotBorderSize;          // = 1,      line thickness of border around plot area
+    float   MinorAlpha;              // = 0.25    alpha multiplier applied to minor axis grid lines
+    ImVec2  MajorTickLen;            // = 10,10   major tick lengths for X and Y axes
+    ImVec2  MinorTickLen;            // = 5,5     minor tick lengths for X and Y axes
+    ImVec2  MajorTickSize;           // = 1,1     line thickness of major ticks
+    ImVec2  MinorTickSize;           // = 1,1     line thickness of minor ticks
+    ImVec2  MajorGridSize;           // = 1,1     line thickness of major grid lines
+    ImVec2  MinorGridSize;           // = 1,1     line thickness of minor grid lines
+    ImVec2  PlotPadding;             // = 10,10   padding between widget frame and plot area, labels, or outside legends (i.e. main padding)
+    ImVec2  LabelPadding;            // = 5,5     padding between axes labels, tick labels, and plot edge
+    ImVec2  LegendPadding;           // = 10,10   legend padding from plot edges
+    ImVec2  LegendInnerPadding;      // = 5,5     legend inner padding from legend edges
+    ImVec2  LegendSpacing;           // = 5,0     spacing between legend entries
+    ImVec2  MousePosPadding;         // = 10,10   padding between plot edge and interior mouse location text
+    ImVec2  AnnotationPadding;       // = 2,2     text padding around annotation labels
+    ImVec2  FitPadding;              // = 0,0     additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)
+    ImVec2  PlotDefaultSize;         // = 400,300 default size used when ImVec2(0,0) is passed to BeginPlot
+    ImVec2  PlotMinSize;             // = 200,150 minimum size plot frame can be when shrunk
+    // style colors
+    ImVec4  Colors[ImPlotCol_COUNT]; // Array of styling colors. Indexable with ImPlotCol_ enums.
+    // colormap
+    ImPlotColormap Colormap;         // The current colormap. Set this to either an ImPlotColormap_ enum or an index returned by AddColormap.
+    // settings/flags
+    bool    UseLocalTime;            // = false,  axis labels will be formatted for your timezone when ImPlotAxisFlag_Time is enabled
+    bool    UseISO8601;              // = false,  dates will be formatted according to ISO 8601 where applicable (e.g. YYYY-MM-DD, YYYY-MM, --MM-DD, etc.)
+    bool    Use24HourClock;          // = false,  times will be formatted using a 24 hour clock
+    IMPLOT_API ImPlotStyle();
+};
+
+#if (IMGUI_VERSION_NUM < 18716) // Renamed in 1.88
+#define ImGuiModFlags       ImGuiKeyModFlags
+#define ImGuiModFlags_None  ImGuiKeyModFlags_None
+#define ImGuiModFlags_Ctrl  ImGuiKeyModFlags_Ctrl
+#define ImGuiModFlags_Shift ImGuiKeyModFlags_Shift
+#define ImGuiModFlags_Alt   ImGuiKeyModFlags_Alt
+#define ImGuiModFlags_Super ImGuiKeyModFlags_Super
+#endif
+
+// Input mapping structure. Default values listed. See also MapInputDefault, MapInputReverse.
+struct ImPlotInputMap {
+    ImGuiMouseButton Pan;           // LMB    enables panning when held,
+    ImGuiModFlags    PanMod;        // none   optional modifier that must be held for panning/fitting
+    ImGuiMouseButton Fit;           // LMB    initiates fit when double clicked
+    ImGuiMouseButton Select;        // RMB    begins box selection when pressed and confirms selection when released
+    ImGuiMouseButton SelectCancel;  // LMB    cancels active box selection when pressed; cannot be same as Select
+    ImGuiModFlags    SelectMod;     // none   optional modifier that must be held for box selection
+    ImGuiModFlags    SelectHorzMod; // Alt    expands active box selection horizontally to plot edge when held
+    ImGuiModFlags    SelectVertMod; // Shift  expands active box selection vertically to plot edge when held
+    ImGuiMouseButton Menu;          // RMB    opens context menus (if enabled) when clicked
+    ImGuiModFlags    OverrideMod;   // Ctrl   when held, all input is ignored; used to enable axis/plots as DND sources
+    ImGuiModFlags    ZoomMod;       // none   optional modifier that must be held for scroll wheel zooming
+    float            ZoomRate;      // 0.1f   zoom rate for scroll (e.g. 0.1f = 10% plot range every scroll click); make negative to invert
+    IMPLOT_API ImPlotInputMap();
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Callbacks
+//-----------------------------------------------------------------------------
+
+// Callback signature for axis tick label formatter.
+typedef int (*ImPlotFormatter)(double value, char* buff, int size, void* user_data);
+
+// Callback signature for data getter.
+typedef ImPlotPoint (*ImPlotGetter)(int idx, void* user_data);
+
+// Callback signature for axis transform.
+typedef double (*ImPlotTransform)(double value, void* user_data);
+
+namespace ImPlot {
+
+//-----------------------------------------------------------------------------
+// [SECTION] Contexts
+//-----------------------------------------------------------------------------
+
+// Creates a new ImPlot context. Call this after ImGui::CreateContext.
+IMPLOT_API ImPlotContext* CreateContext();
+// Destroys an ImPlot context. Call this before ImGui::DestroyContext. NULL = destroy current context.
+IMPLOT_API void DestroyContext(ImPlotContext* ctx = NULL);
+// Returns the current ImPlot context. NULL if no context has ben set.
+IMPLOT_API ImPlotContext* GetCurrentContext();
+// Sets the current ImPlot context.
+IMPLOT_API void SetCurrentContext(ImPlotContext* ctx);
+
+// Sets the current **ImGui** context. This is ONLY necessary if you are compiling
+// ImPlot as a DLL (not recommended) separate from your ImGui compilation. It
+// sets the global variable GImGui, which is not shared across DLL boundaries.
+// See GImGui documentation in imgui.cpp for more details.
+IMPLOT_API void SetImGuiContext(ImGuiContext* ctx);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Begin/End Plot
+//-----------------------------------------------------------------------------
+
+// Starts a 2D plotting context. If this function returns true, EndPlot() MUST
+// be called! You are encouraged to use the following convention:
+//
+// if (BeginPlot(...)) {
+//     PlotLine(...);
+//     ...
+//     EndPlot();
+// }
+//
+// Important notes:
+//
+// - #title_id must be unique to the current ImGui ID scope. If you need to avoid ID
+//   collisions or don't want to display a title in the plot, use double hashes
+//   (e.g. "MyPlot##HiddenIdText" or "##NoTitle").
+// - #size is the **frame** size of the plot widget, not the plot area. The default
+//   size of plots (i.e. when ImVec2(0,0)) can be modified in your ImPlotStyle.
+IMPLOT_API bool BeginPlot(const char* title_id, const ImVec2& size=ImVec2(-1,0), ImPlotFlags flags=0);
+
+// Only call EndPlot() if BeginPlot() returns true! Typically called at the end
+// of an if statement conditioned on BeginPlot(). See example above.
+IMPLOT_API void EndPlot();
+
+//-----------------------------------------------------------------------------
+// [SECTION] Begin/End Subplots
+//-----------------------------------------------------------------------------
+
+// Starts a subdivided plotting context. If the function returns true,
+// EndSubplots() MUST be called! Call BeginPlot/EndPlot AT MOST [rows*cols]
+// times in  between the begining and end of the subplot context. Plots are
+// added in row major order.
+//
+// Example:
+//
+// if (BeginSubplots("My Subplot",2,3,ImVec2(800,400)) {
+//     for (int i = 0; i < 6; ++i) {
+//         if (BeginPlot(...)) {
+//             ImPlot::PlotLine(...);
+//             ...
+//             EndPlot();
+//         }
+//     }
+//     EndSubplots();
+// }
+//
+// Produces:
+//
+// [0] | [1] | [2]
+// ----|-----|----
+// [3] | [4] | [5]
+//
+// Important notes:
+//
+// - #title_id must be unique to the current ImGui ID scope. If you need to avoid ID
+//   collisions or don't want to display a title in the plot, use double hashes
+//   (e.g. "MySubplot##HiddenIdText" or "##NoTitle").
+// - #rows and #cols must be greater than 0.
+// - #size is the size of the entire grid of subplots, not the individual plots
+// - #row_ratios and #col_ratios must have AT LEAST #rows and #cols elements,
+//   respectively. These are the sizes of the rows and columns expressed in ratios.
+//   If the user adjusts the dimensions, the arrays are updated with new ratios.
+//
+// Important notes regarding BeginPlot from inside of BeginSubplots:
+//
+// - The #title_id parameter of _BeginPlot_ (see above) does NOT have to be
+//   unique when called inside of a subplot context. Subplot IDs are hashed
+//   for your convenience so you don't have call PushID or generate unique title
+//   strings. Simply pass an empty string to BeginPlot unless you want to title
+//   each subplot.
+// - The #size parameter of _BeginPlot_ (see above) is ignored when inside of a
+//   subplot context. The actual size of the subplot will be based on the
+//   #size value you pass to _BeginSubplots_ and #row/#col_ratios if provided.
+
+IMPLOT_API bool BeginSubplots(const char* title_id,
+                             int rows,
+                             int cols,
+                             const ImVec2& size,
+                             ImPlotSubplotFlags flags = 0,
+                             float* row_ratios        = NULL,
+                             float* col_ratios        = NULL);
+
+// Only call EndSubplots() if BeginSubplots() returns true! Typically called at the end
+// of an if statement conditioned on BeginSublots(). See example above.
+IMPLOT_API void EndSubplots();
+
+//-----------------------------------------------------------------------------
+// [SECTION] Setup
+//-----------------------------------------------------------------------------
+
+// The following API allows you to setup and customize various aspects of the
+// current plot. The functions should be called immediately after BeginPlot
+// and before any other API calls. Typical usage is as follows:
+
+// if (BeginPlot(...)) {                     1) begin a new plot
+//     SetupAxis(ImAxis_X1, "My X-Axis");    2) make Setup calls
+//     SetupAxis(ImAxis_Y1, "My Y-Axis");
+//     SetupLegend(ImPlotLocation_North);
+//     ...
+//     SetupFinish();                        3) [optional] explicitly finish setup
+//     PlotLine(...);                        4) plot items
+//     ...
+//     EndPlot();                            5) end the plot
+// }
+//
+// Important notes:
+//
+// - Always call Setup code at the top of your BeginPlot conditional statement.
+// - Setup is locked once you start plotting or explicitly call SetupFinish.
+//   Do NOT call Setup code after you begin plotting or after you make
+//   any non-Setup API calls (e.g. utils like PlotToPixels also lock Setup)
+// - Calling SetupFinish is OPTIONAL, but probably good practice. If you do not
+//   call it yourself, then the first subsequent plotting or utility function will
+//   call it for you.
+
+// Enables an axis or sets the label and/or flags for an existing axis. Leave #label = NULL for no label.
+IMPLOT_API void SetupAxis(ImAxis axis, const char* label=NULL, ImPlotAxisFlags flags=0);
+// Sets an axis range limits. If ImPlotCond_Always is used, the axes limits will be locked.
+IMPLOT_API void SetupAxisLimits(ImAxis axis, double v_min, double v_max, ImPlotCond cond = ImPlotCond_Once);
+// Links an axis range limits to external values. Set to NULL for no linkage. The pointer data must remain valid until EndPlot.
+IMPLOT_API void SetupAxisLinks(ImAxis axis, double* link_min, double* link_max);
+// Sets the format of numeric axis labels via formater specifier (default="%g"). Formated values will be double (i.e. use %f).
+IMPLOT_API void SetupAxisFormat(ImAxis axis, const char* fmt);
+// Sets the format of numeric axis labels via formatter callback. Given #value, write a label into #buff. Optionally pass user data.
+IMPLOT_API void SetupAxisFormat(ImAxis axis, ImPlotFormatter formatter, void* data=NULL);
+// Sets an axis' ticks and optionally the labels. To keep the default ticks, set #keep_default=true.
+IMPLOT_API void SetupAxisTicks(ImAxis axis, const double* values, int n_ticks, const char* const labels[]=NULL, bool keep_default=false);
+// Sets an axis' ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true.
+IMPLOT_API void SetupAxisTicks(ImAxis axis, double v_min, double v_max, int n_ticks, const char* const labels[]=NULL, bool keep_default=false);
+// Sets an axis' scale using built-in options.
+IMPLOT_API void SetupAxisScale(ImAxis axis, ImPlotScale scale);
+// Sets an axis' scale using user supplied forward and inverse transfroms.
+IMPLOT_API void SetupAxisScale(ImAxis axis, ImPlotTransform forward, ImPlotTransform inverse, void* data=NULL);
+// Sets an axis' limits constraints.
+IMPLOT_API void SetupAxisLimitsConstraints(ImAxis axis, double v_min, double v_max);
+// Sets an axis' zoom constraints.
+IMPLOT_API void SetupAxisZoomConstraints(ImAxis axis, double z_min, double z_max);
+
+// Sets the label and/or flags for primary X and Y axes (shorthand for two calls to SetupAxis).
+IMPLOT_API void SetupAxes(const char* x_label, const char* y_label, ImPlotAxisFlags x_flags=0, ImPlotAxisFlags y_flags=0);
+// Sets the primary X and Y axes range limits. If ImPlotCond_Always is used, the axes limits will be locked (shorthand for two calls to SetupAxisLimits).
+IMPLOT_API void SetupAxesLimits(double x_min, double x_max, double y_min, double y_max, ImPlotCond cond = ImPlotCond_Once);
+
+// Sets up the plot legend.
+IMPLOT_API void SetupLegend(ImPlotLocation location, ImPlotLegendFlags flags=0);
+// Set the location of the current plot's mouse position text (default = South|East).
+IMPLOT_API void SetupMouseText(ImPlotLocation location, ImPlotMouseTextFlags flags=0);
+
+// Explicitly finalize plot setup. Once you call this, you cannot make anymore Setup calls for the current plot!
+// Note that calling this function is OPTIONAL; it will be called by the first subsequent setup-locking API call.
+IMPLOT_API void SetupFinish();
+
+//-----------------------------------------------------------------------------
+// [SECTION] SetNext
+//-----------------------------------------------------------------------------
+
+// Though you should default to the `Setup` API above, there are some scenarios
+// where (re)configuring a plot or axis before `BeginPlot` is needed (e.g. if
+// using a preceding button or slider widget to change the plot limits). In
+// this case, you can use the `SetNext` API below. While this is not as feature
+// rich as the Setup API, most common needs are provided. These functions can be
+// called anwhere except for inside of `Begin/EndPlot`. For example:
+
+// if (ImGui::Button("Center Plot"))
+//     ImPlot::SetNextPlotLimits(-1,1,-1,1);
+// if (ImPlot::BeginPlot(...)) {
+//     ...
+//     ImPlot::EndPlot();
+// }
+//
+// Important notes:
+//
+// - You must still enable non-default axes with SetupAxis for these functions
+//   to work properly.
+
+// Sets an upcoming axis range limits. If ImPlotCond_Always is used, the axes limits will be locked.
+IMPLOT_API void SetNextAxisLimits(ImAxis axis, double v_min, double v_max, ImPlotCond cond = ImPlotCond_Once);
+// Links an upcoming axis range limits to external values. Set to NULL for no linkage. The pointer data must remain valid until EndPlot!
+IMPLOT_API void SetNextAxisLinks(ImAxis axis, double* link_min, double* link_max);
+// Set an upcoming axis to auto fit to its data.
+IMPLOT_API void SetNextAxisToFit(ImAxis axis);
+
+// Sets the upcoming primary X and Y axes range limits. If ImPlotCond_Always is used, the axes limits will be locked (shorthand for two calls to SetupAxisLimits).
+IMPLOT_API void SetNextAxesLimits(double x_min, double x_max, double y_min, double y_max, ImPlotCond cond = ImPlotCond_Once);
+// Sets all upcoming axes to auto fit to their data.
+IMPLOT_API void SetNextAxesToFit();
+
+//-----------------------------------------------------------------------------
+// [SECTION] Plot Items
+//-----------------------------------------------------------------------------
+
+// The main plotting API is provied below. Call these functions between
+// Begin/EndPlot and after any Setup API calls. Each plots data on the current
+// x and y axes, which can be changed with `SetAxis/Axes`.
+//
+// The templated functions are explicitly instantiated in implot_items.cpp.
+// They are not intended to be used generically with custom types. You will get
+// a linker error if you try! All functions support the following scalar types:
+//
+// float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64
+//
+//
+// If you need to plot custom or non-homogenous data you have a few options:
+//
+// 1. If your data is a simple struct/class (e.g. Vector2f), you can use striding.
+//    This is the most performant option if applicable.
+//
+//    struct Vector2f { float X, Y; };
+//    ...
+//    Vector2f data[42];
+//    ImPlot::PlotLine("line", &data[0].x, &data[0].y, 42, 0, 0, sizeof(Vector2f));
+//
+// 2. Write a custom getter C function or C++ lambda and pass it and optionally your data to
+//    an ImPlot function post-fixed with a G (e.g. PlotScatterG). This has a slight performance
+//    cost, but probably not enough to worry about unless your data is very large. Examples:
+//
+//    ImPlotPoint MyDataGetter(void* data, int idx) {
+//        MyData* my_data = (MyData*)data;
+//        ImPlotPoint p;
+//        p.x = my_data->GetTime(idx);
+//        p.y = my_data->GetValue(idx);
+//        return p
+//    }
+//    ...
+//    auto my_lambda = [](int idx, void*) {
+//        double t = idx / 999.0;
+//        return ImPlotPoint(t, 0.5+0.5*std::sin(2*PI*10*t));
+//    };
+//    ...
+//    if (ImPlot::BeginPlot("MyPlot")) {
+//        MyData my_data;
+//        ImPlot::PlotScatterG("scatter", MyDataGetter, &my_data, my_data.Size());
+//        ImPlot::PlotLineG("line", my_lambda, nullptr, 1000);
+//        ImPlot::EndPlot();
+//    }
+//
+// NB: All types are converted to double before plotting. You may lose information
+// if you try plotting extremely large 64-bit integral types. Proceed with caution!
+
+// Plots a standard 2D line plot.
+IMPLOT_TMP void PlotLine(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotLineFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotLine(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_API void PlotLineG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotLineFlags flags=0);
+
+// Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
+IMPLOT_TMP void PlotScatter(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotScatterFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_API void PlotScatterG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotScatterFlags flags=0);
+
+// Plots a a stairstep graph. The y value is continued constantly to the right from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i]
+IMPLOT_TMP void PlotStairs(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotStairsFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_API void PlotStairsG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotStairsFlags flags=0);
+
+// Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set yref to +/-INFINITY for infinite fill extents.
+IMPLOT_TMP void PlotShaded(const char* label_id, const T* values, int count, double yref=0, double xscale=1, double xstart=0, ImPlotShadedFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double yref=0, ImPlotShadedFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_API void PlotShadedG(const char* label_id, ImPlotGetter getter1, void* data1, ImPlotGetter getter2, void* data2, int count, ImPlotShadedFlags flags=0);
+
+// Plots a bar graph. Vertical by default. #bar_size and #shift are in plot units.
+IMPLOT_TMP void PlotBars(const char* label_id, const T* values, int count, double bar_size=0.67, double shift=0, ImPlotBarsFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_API void PlotBarsG(const char* label_id, ImPlotGetter getter, void* data, int count, double bar_size, ImPlotBarsFlags flags=0);
+
+// Plots a group of bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
+IMPLOT_TMP void PlotBarGroups(const char* const label_ids[], const T* values, int item_count, int group_count, double group_size=0.67, double shift=0, ImPlotBarGroupsFlags flags=0);
+
+// Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
+IMPLOT_TMP void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags=0, int offset=0, int stride=sizeof(T));
+
+// Plots stems. Vertical by default.
+IMPLOT_TMP void PlotStems(const char* label_id, const T* values, int count, double ref=0, double scale=1, double start=0, ImPlotStemsFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double ref=0, ImPlotStemsFlags flags=0, int offset=0, int stride=sizeof(T));
+
+// Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
+IMPLOT_TMP void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLinesFlags flags=0, int offset=0, int stride=sizeof(T));
+
+// Plots a pie chart. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+IMPLOT_TMP void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* label_fmt="%.1f", double angle0=90, ImPlotPieChartFlags flags=0);
+
+// Plots a 2D heatmap chart. Values are expected to be in row-major order by default. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
+IMPLOT_TMP void PlotHeatmap(const char* label_id, const T* values, int rows, int cols, double scale_min=0, double scale_max=0, const char* label_fmt="%.1f", const ImPlotPoint& bounds_min=ImPlotPoint(0,0), const ImPlotPoint& bounds_max=ImPlotPoint(1,1), ImPlotHeatmapFlags flags=0);
+
+// Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #range is left unspecified, the min/max of #values will be used as the range.
+// Otherwise, outlier values outside of the range are not binned. The largest bin count or density is returned.
+IMPLOT_TMP double PlotHistogram(const char* label_id, const T* values, int count, int bins=ImPlotBin_Sturges, double bar_scale=1.0, ImPlotRange range=ImPlotRange(), ImPlotHistogramFlags flags=0);
+
+// Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #range is left unspecified, the min/max of
+// #xs an #ys will be used as the ranges. Otherwise, outlier values outside of range are not binned. The largest bin count or density is returned.
+IMPLOT_TMP double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count, int x_bins=ImPlotBin_Sturges, int y_bins=ImPlotBin_Sturges, ImPlotRect range=ImPlotRect(), ImPlotHistogramFlags flags=0);
+
+// Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
+IMPLOT_TMP void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotDigitalFlags flags=0);
+
+// Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
+IMPLOT_API void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1), ImPlotImageFlags flags=0);
+
+// Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
+IMPLOT_API void PlotText(const char* text, double x, double y, const ImVec2& pix_offset=ImVec2(0,0), ImPlotTextFlags flags=0);
+
+// Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)
+IMPLOT_API void PlotDummy(const char* label_id, ImPlotDummyFlags flags=0);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Plot Tools
+//-----------------------------------------------------------------------------
+
+// The following can be used to render interactive elements and/or annotations.
+// Like the item plotting functions above, they apply to the current x and y
+// axes, which can be changed with `SetAxis/SetAxes`.
+
+// Shows a draggable point at x,y. #col defaults to ImGuiCol_Text.
+IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags=0);
+// Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text.
+IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags=0);
+// Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text.
+IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags=0);
+// Shows a draggable and resizeable rectangle.
+IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags=0);
+
+// Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area. Annotations are always rendered on top.
+IMPLOT_API void Annotation(double x, double y, const ImVec4& col, const ImVec2& pix_offset, bool clamp, bool round = false);
+IMPLOT_API void Annotation(double x, double y, const ImVec4& col, const ImVec2& pix_offset, bool clamp, const char* fmt, ...)           IM_FMTARGS(6);
+IMPLOT_API void AnnotationV(double x, double y, const ImVec4& col, const ImVec2& pix_offset, bool clamp, const char* fmt, va_list args) IM_FMTLIST(6);
+
+// Shows a x-axis tag at the specified coordinate value.
+IMPLOT_API void TagX(double x, const ImVec4& col, bool round = false);
+IMPLOT_API void TagX(double x, const ImVec4& col, const char* fmt, ...)           IM_FMTARGS(3);
+IMPLOT_API void TagXV(double x, const ImVec4& col, const char* fmt, va_list args) IM_FMTLIST(3);
+
+// Shows a y-axis tag at the specified coordinate value.
+IMPLOT_API void TagY(double y, const ImVec4& col, bool round = false);
+IMPLOT_API void TagY(double y, const ImVec4& col, const char* fmt, ...)           IM_FMTARGS(3);
+IMPLOT_API void TagYV(double y, const ImVec4& col, const char* fmt, va_list args) IM_FMTLIST(3);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Plot Utils
+//-----------------------------------------------------------------------------
+
+// Select which axis/axes will be used for subsequent plot elements.
+IMPLOT_API void SetAxis(ImAxis axis);
+IMPLOT_API void SetAxes(ImAxis x_axis, ImAxis y_axis);
+
+// Convert pixels to a position in the current plot's coordinate system. Passing IMPLOT_AUTO uses the current axes.
+IMPLOT_API ImPlotPoint PixelsToPlot(const ImVec2& pix, ImAxis x_axis = IMPLOT_AUTO, ImAxis y_axis = IMPLOT_AUTO);
+IMPLOT_API ImPlotPoint PixelsToPlot(float x, float y, ImAxis x_axis = IMPLOT_AUTO, ImAxis y_axis = IMPLOT_AUTO);
+
+// Convert a position in the current plot's coordinate system to pixels. Passing IMPLOT_AUTO uses the current axes.
+IMPLOT_API ImVec2 PlotToPixels(const ImPlotPoint& plt, ImAxis x_axis = IMPLOT_AUTO, ImAxis y_axis = IMPLOT_AUTO);
+IMPLOT_API ImVec2 PlotToPixels(double x, double y, ImAxis x_axis = IMPLOT_AUTO, ImAxis y_axis = IMPLOT_AUTO);
+
+// Get the current Plot position (top-left) in pixels.
+IMPLOT_API ImVec2 GetPlotPos();
+// Get the curent Plot size in pixels.
+IMPLOT_API ImVec2 GetPlotSize();
+
+// Returns the mouse position in x,y coordinates of the current plot. Passing IMPLOT_AUTO uses the current axes.
+IMPLOT_API ImPlotPoint GetPlotMousePos(ImAxis x_axis = IMPLOT_AUTO, ImAxis y_axis = IMPLOT_AUTO);
+// Returns the current plot axis range.
+IMPLOT_API ImPlotRect GetPlotLimits(ImAxis x_axis = IMPLOT_AUTO, ImAxis y_axis = IMPLOT_AUTO);
+
+// Returns true if the plot area in the current plot is hovered.
+IMPLOT_API bool IsPlotHovered();
+// Returns true if the axis label area in the current plot is hovered.
+IMPLOT_API bool IsAxisHovered(ImAxis axis);
+// Returns true if the bounding frame of a subplot is hovered.
+IMPLOT_API bool IsSubplotsHovered();
+
+// Returns true if the current plot is being box selected.
+IMPLOT_API bool IsPlotSelected();
+// Returns the current plot box selection bounds. Passing IMPLOT_AUTO uses the current axes.
+IMPLOT_API ImPlotRect GetPlotSelection(ImAxis x_axis = IMPLOT_AUTO, ImAxis y_axis = IMPLOT_AUTO);
+// Cancels a the current plot box selection.
+IMPLOT_API void CancelPlotSelection();
+
+// Hides or shows the next plot item (i.e. as if it were toggled from the legend).
+// Use ImPlotCond_Always if you need to forcefully set this every frame.
+IMPLOT_API void HideNextItem(bool hidden = true, ImPlotCond cond = ImPlotCond_Once);
+
+// Use the following around calls to Begin/EndPlot to align l/r/t/b padding.
+// Consider using Begin/EndSubplots first. They are more feature rich and
+// accomplish the same behaviour by default. The functions below offer lower
+// level control of plot alignment.
+
+// Align axis padding over multiple plots in a single row or column. #group_id must
+// be unique. If this function returns true, EndAlignedPlots() must be called.
+IMPLOT_API bool BeginAlignedPlots(const char* group_id, bool vertical = true);
+// Only call EndAlignedPlots() if BeginAlignedPlots() returns true!
+IMPLOT_API void EndAlignedPlots();
+
+//-----------------------------------------------------------------------------
+// [SECTION] Legend Utils
+//-----------------------------------------------------------------------------
+
+// Begin a popup for a legend entry.
+IMPLOT_API bool BeginLegendPopup(const char* label_id, ImGuiMouseButton mouse_button=1);
+// End a popup for a legend entry.
+IMPLOT_API void EndLegendPopup();
+// Returns true if a plot item legend entry is hovered.
+IMPLOT_API bool IsLegendEntryHovered(const char* label_id);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Drag and Drop
+//-----------------------------------------------------------------------------
+
+// Turns the current plot's plotting area into a drag and drop target. Don't forget to call EndDragDropTarget!
+IMPLOT_API bool BeginDragDropTargetPlot();
+// Turns the current plot's X-axis into a drag and drop target. Don't forget to call EndDragDropTarget!
+IMPLOT_API bool BeginDragDropTargetAxis(ImAxis axis);
+// Turns the current plot's legend into a drag and drop target. Don't forget to call EndDragDropTarget!
+IMPLOT_API bool BeginDragDropTargetLegend();
+// Ends a drag and drop target (currently just an alias for ImGui::EndDragDropTarget).
+IMPLOT_API void EndDragDropTarget();
+
+// NB: By default, plot and axes drag and drop *sources* require holding the Ctrl modifier to initiate the drag.
+// You can change the modifier if desired. If ImGuiModFlags_None is provided, the axes will be locked from panning.
+
+// Turns the current plot's plotting area into a drag and drop source. You must hold Ctrl. Don't forget to call EndDragDropSource!
+IMPLOT_API bool BeginDragDropSourcePlot(ImGuiDragDropFlags flags=0);
+// Turns the current plot's X-axis into a drag and drop source. You must hold Ctrl. Don't forget to call EndDragDropSource!
+IMPLOT_API bool BeginDragDropSourceAxis(ImAxis axis, ImGuiDragDropFlags flags=0);
+// Turns an item in the current plot's legend into drag and drop source. Don't forget to call EndDragDropSource!
+IMPLOT_API bool BeginDragDropSourceItem(const char* label_id, ImGuiDragDropFlags flags=0);
+// Ends a drag and drop source (currently just an alias for ImGui::EndDragDropSource).
+IMPLOT_API void EndDragDropSource();
+
+//-----------------------------------------------------------------------------
+// [SECTION] Styling
+//-----------------------------------------------------------------------------
+
+// Styling colors in ImPlot works similarly to styling colors in ImGui, but
+// with one important difference. Like ImGui, all style colors are stored in an
+// indexable array in ImPlotStyle. You can permanently modify these values through
+// GetStyle().Colors, or temporarily modify them with Push/Pop functions below.
+// However, by default all style colors in ImPlot default to a special color
+// IMPLOT_AUTO_COL. The behavior of this color depends upon the style color to
+// which it as applied:
+//
+//     1) For style colors associated with plot items (e.g. ImPlotCol_Line),
+//        IMPLOT_AUTO_COL tells ImPlot to color the item with the next unused
+//        color in the current colormap. Thus, every item will have a different
+//        color up to the number of colors in the colormap, at which point the
+//        colormap will roll over. For most use cases, you should not need to
+//        set these style colors to anything but IMPLOT_COL_AUTO; you are
+//        probably better off changing the current colormap. However, if you
+//        need to explicitly color a particular item you may either Push/Pop
+//        the style color around the item in question, or use the SetNextXXXStyle
+//        API below. If you permanently set one of these style colors to a specific
+//        color, or forget to call Pop, then all subsequent items will be styled
+//        with the color you set.
+//
+//     2) For style colors associated with plot styling (e.g. ImPlotCol_PlotBg),
+//        IMPLOT_AUTO_COL tells ImPlot to set that color from color data in your
+//        **ImGuiStyle**. The ImGuiCol_ that these style colors default to are
+//        detailed above, and in general have been mapped to produce plots visually
+//        consistent with your current ImGui style. Of course, you are free to
+//        manually set these colors to whatever you like, and further can Push/Pop
+//        them around individual plots for plot-specific styling (e.g. coloring axes).
+
+// Provides access to plot style structure for permanant modifications to colors, sizes, etc.
+IMPLOT_API ImPlotStyle& GetStyle();
+
+// Style plot colors for current ImGui style (default).
+IMPLOT_API void StyleColorsAuto(ImPlotStyle* dst = NULL);
+// Style plot colors for ImGui "Classic".
+IMPLOT_API void StyleColorsClassic(ImPlotStyle* dst = NULL);
+// Style plot colors for ImGui "Dark".
+IMPLOT_API void StyleColorsDark(ImPlotStyle* dst = NULL);
+// Style plot colors for ImGui "Light".
+IMPLOT_API void StyleColorsLight(ImPlotStyle* dst = NULL);
+
+// Use PushStyleX to temporarily modify your ImPlotStyle. The modification
+// will last until the matching call to PopStyleX. You MUST call a pop for
+// every push, otherwise you will leak memory! This behaves just like ImGui.
+
+// Temporarily modify a style color. Don't forget to call PopStyleColor!
+IMPLOT_API void PushStyleColor(ImPlotCol idx, ImU32 col);
+IMPLOT_API void PushStyleColor(ImPlotCol idx, const ImVec4& col);
+// Undo temporary style color modification(s). Undo multiple pushes at once by increasing count.
+IMPLOT_API void PopStyleColor(int count = 1);
+
+// Temporarily modify a style variable of float type. Don't forget to call PopStyleVar!
+IMPLOT_API void PushStyleVar(ImPlotStyleVar idx, float val);
+// Temporarily modify a style variable of int type. Don't forget to call PopStyleVar!
+IMPLOT_API void PushStyleVar(ImPlotStyleVar idx, int val);
+// Temporarily modify a style variable of ImVec2 type. Don't forget to call PopStyleVar!
+IMPLOT_API void PushStyleVar(ImPlotStyleVar idx, const ImVec2& val);
+// Undo temporary style variable modification(s). Undo multiple pushes at once by increasing count.
+IMPLOT_API void PopStyleVar(int count = 1);
+
+// The following can be used to modify the style of the next plot item ONLY. They do
+// NOT require calls to PopStyleX. Leave style attributes you don't want modified to
+// IMPLOT_AUTO or IMPLOT_AUTO_COL. Automatic styles will be deduced from the current
+// values in your ImPlotStyle or from Colormap data.
+
+// Set the line color and weight for the next item only.
+IMPLOT_API void SetNextLineStyle(const ImVec4& col = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO);
+// Set the fill color for the next item only.
+IMPLOT_API void SetNextFillStyle(const ImVec4& col = IMPLOT_AUTO_COL, float alpha_mod = IMPLOT_AUTO);
+// Set the marker style for the next item only.
+IMPLOT_API void SetNextMarkerStyle(ImPlotMarker marker = IMPLOT_AUTO, float size = IMPLOT_AUTO, const ImVec4& fill = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO, const ImVec4& outline = IMPLOT_AUTO_COL);
+// Set the error bar style for the next item only.
+IMPLOT_API void SetNextErrorBarStyle(const ImVec4& col = IMPLOT_AUTO_COL, float size = IMPLOT_AUTO, float weight = IMPLOT_AUTO);
+
+// Gets the last item primary color (i.e. its legend icon color)
+IMPLOT_API ImVec4 GetLastItemColor();
+
+// Returns the null terminated string name for an ImPlotCol.
+IMPLOT_API const char* GetStyleColorName(ImPlotCol idx);
+// Returns the null terminated string name for an ImPlotMarker.
+IMPLOT_API const char* GetMarkerName(ImPlotMarker idx);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Colormaps
+//-----------------------------------------------------------------------------
+
+// Item styling is based on colormaps when the relevant ImPlotCol_XXX is set to
+// IMPLOT_AUTO_COL (default). Several built-in colormaps are available. You can
+// add and then push/pop your own colormaps as well. To permanently set a colormap,
+// modify the Colormap index member of your ImPlotStyle.
+
+// Colormap data will be ignored and a custom color will be used if you have done one of the following:
+//     1) Modified an item style color in your ImPlotStyle to anything other than IMPLOT_AUTO_COL.
+//     2) Pushed an item style color using PushStyleColor().
+//     3) Set the next item style with a SetNextXXXStyle function.
+
+// Add a new colormap. The color data will be copied. The colormap can be used by pushing either the returned index or the
+// string name with PushColormap. The colormap name must be unique and the size must be greater than 1. You will receive
+// an assert otherwise! By default colormaps are considered to be qualitative (i.e. discrete). If you want to create a
+// continuous colormap, set #qual=false. This will treat the colors you provide as keys, and ImPlot will build a linearly
+// interpolated lookup table. The memory footprint of this table will be exactly ((size-1)*255+1)*4 bytes.
+IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImVec4* cols, int size, bool qual=true);
+IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImU32*  cols, int size, bool qual=true);
+
+// Returns the number of available colormaps (i.e. the built-in + user-added count).
+IMPLOT_API int GetColormapCount();
+// Returns a null terminated string name for a colormap given an index. Returns NULL if index is invalid.
+IMPLOT_API const char* GetColormapName(ImPlotColormap cmap);
+// Returns an index number for a colormap given a valid string name. Returns -1 if name is invalid.
+IMPLOT_API ImPlotColormap GetColormapIndex(const char* name);
+
+// Temporarily switch to one of the built-in (i.e. ImPlotColormap_XXX) or user-added colormaps (i.e. a return value of AddColormap). Don't forget to call PopColormap!
+IMPLOT_API void PushColormap(ImPlotColormap cmap);
+// Push a colormap by string name. Use built-in names such as "Default", "Deep", "Jet", etc. or a string you provided to AddColormap. Don't forget to call PopColormap!
+IMPLOT_API void PushColormap(const char* name);
+// Undo temporary colormap modification(s). Undo multiple pushes at once by increasing count.
+IMPLOT_API void PopColormap(int count = 1);
+
+// Returns the next color from the current colormap and advances the colormap for the current plot.
+// Can also be used with no return value to skip colors if desired. You need to call this between Begin/EndPlot!
+IMPLOT_API ImVec4 NextColormapColor();
+
+// Colormap utils. If cmap = IMPLOT_AUTO (default), the current colormap is assumed.
+// Pass an explicit colormap index (built-in or user-added) to specify otherwise.
+
+// Returns the size of a colormap.
+IMPLOT_API int GetColormapSize(ImPlotColormap cmap = IMPLOT_AUTO);
+// Returns a color from a colormap given an index >= 0 (modulo will be performed).
+IMPLOT_API ImVec4 GetColormapColor(int idx, ImPlotColormap cmap = IMPLOT_AUTO);
+// Sample a color from the current colormap given t between 0 and 1.
+IMPLOT_API ImVec4 SampleColormap(float t, ImPlotColormap cmap = IMPLOT_AUTO);
+
+// Shows a vertical color scale with linear spaced ticks using the specified color map. Use double hashes to hide label (e.g. "##NoLabel"). If scale_min > scale_max, the scale to color mapping will be reversed.
+IMPLOT_API void ColormapScale(const char* label, double scale_min, double scale_max, const ImVec2& size = ImVec2(0,0), const char* format = "%g", ImPlotColormapScaleFlags flags = 0, ImPlotColormap cmap = IMPLOT_AUTO);
+// Shows a horizontal slider with a colormap gradient background. Optionally returns the color sampled at t in [0 1].
+IMPLOT_API bool ColormapSlider(const char* label, float* t, ImVec4* out = NULL, const char* format = "", ImPlotColormap cmap = IMPLOT_AUTO);
+// Shows a button with a colormap gradient brackground.
+IMPLOT_API bool ColormapButton(const char* label, const ImVec2& size = ImVec2(0,0), ImPlotColormap cmap = IMPLOT_AUTO);
+
+// When items in a plot sample their color from a colormap, the color is cached and does not change
+// unless explicitly overriden. Therefore, if you change the colormap after the item has already been plotted,
+// item colors will NOT update. If you need item colors to resample the new colormap, then use this
+// function to bust the cached colors. If #plot_title_id is NULL, then every item in EVERY existing plot
+// will be cache busted. Otherwise only the plot specified by #plot_title_id will be busted. For the
+// latter, this function must be called in the same ImGui ID scope that the plot is in. You should rarely if ever
+// need this function, but it is available for applications that require runtime colormap swaps (e.g. Heatmaps demo).
+IMPLOT_API void BustColorCache(const char* plot_title_id = NULL);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Input Mapping
+//-----------------------------------------------------------------------------
+
+// Provides access to input mapping structure for permanant modifications to controls for pan, select, etc.
+IMPLOT_API ImPlotInputMap& GetInputMap();
+
+// Default input mapping: pan = LMB drag, box select = RMB drag, fit = LMB double click, context menu = RMB click, zoom = scroll.
+IMPLOT_API void MapInputDefault(ImPlotInputMap* dst = NULL);
+// Reverse input mapping: pan = RMB drag, box select = LMB drag, fit = LMB double click, context menu = RMB click, zoom = scroll.
+IMPLOT_API void MapInputReverse(ImPlotInputMap* dst = NULL);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Miscellaneous
+//-----------------------------------------------------------------------------
+
+// Render icons similar to those that appear in legends (nifty for data lists).
+IMPLOT_API void ItemIcon(const ImVec4& col);
+IMPLOT_API void ItemIcon(ImU32 col);
+IMPLOT_API void ColormapIcon(ImPlotColormap cmap);
+
+// Get the plot draw list for custom rendering to the current plot area. Call between Begin/EndPlot.
+IMPLOT_API ImDrawList* GetPlotDrawList();
+// Push clip rect for rendering to current plot area. The rect can be expanded or contracted by #expand pixels. Call between Begin/EndPlot.
+IMPLOT_API void PushPlotClipRect(float expand=0);
+// Pop plot clip rect. Call between Begin/EndPlot.
+IMPLOT_API void PopPlotClipRect();
+
+// Shows ImPlot style selector dropdown menu.
+IMPLOT_API bool ShowStyleSelector(const char* label);
+// Shows ImPlot colormap selector dropdown menu.
+IMPLOT_API bool ShowColormapSelector(const char* label);
+// Shows ImPlot input map selector dropdown menu.
+IMPLOT_API bool ShowInputMapSelector(const char* label);
+// Shows ImPlot style editor block (not a window).
+IMPLOT_API void ShowStyleEditor(ImPlotStyle* ref = NULL);
+// Add basic help/info block for end users (not a window).
+IMPLOT_API void ShowUserGuide();
+// Shows ImPlot metrics/debug information window.
+IMPLOT_API void ShowMetricsWindow(bool* p_popen = NULL);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Demo
+//-----------------------------------------------------------------------------
+
+// Shows the ImPlot demo window (add implot_demo.cpp to your sources!)
+IMPLOT_API void ShowDemoWindow(bool* p_open = NULL);
+
+}  // namespace ImPlot
+
+//-----------------------------------------------------------------------------
+// [SECTION] Obsolete API
+//-----------------------------------------------------------------------------
+
+// The following functions will be removed! Keep your copy of implot up to date!
+// Occasionally set '#define IMPLOT_DISABLE_OBSOLETE_FUNCTIONS' to stay ahead.
+// If you absolutely must use these functions and do not want to receive compiler
+// warnings, set '#define IMPLOT_DISABLE_OBSOLETE_WARNINGS'.
+
+#ifndef IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
+
+#ifndef IMPLOT_DISABLE_DEPRECATED_WARNINGS
+#if __cplusplus > 201402L
+#define IMPLOT_DEPRECATED(method) [[deprecated]] method
+#elif defined( __GNUC__ ) && !defined( __INTEL_COMPILER ) && ( __GNUC__ > 3 || ( __GNUC__ == 3 && __GNUC_MINOR__ >= 1 ) )
+#define IMPLOT_DEPRECATED(method) method __attribute__( ( deprecated ) )
+#elif defined( _MSC_VER )
+#define IMPLOT_DEPRECATED(method) __declspec(deprecated) method
+#else
+#define IMPLOT_DEPRECATED(method) method
+#endif
+#else
+#define IMPLOT_DEPRECATED(method) method
+#endif
+
+enum ImPlotFlagsObsolete_ {
+    ImPlotFlags_YAxis2 = 1 << 20,
+    ImPlotFlags_YAxis3 = 1 << 21,
+};
+
+namespace ImPlot {
+
+// OBSOLETED in v0.13 -> PLANNED REMOVAL in v1.0
+IMPLOT_DEPRECATED( IMPLOT_API bool BeginPlot(const char* title_id,
+                                             const char* x_label,  // = NULL,
+                                             const char* y_label,  // = NULL,
+                                             const ImVec2& size       = ImVec2(-1,0),
+                                             ImPlotFlags flags        = ImPlotFlags_None,
+                                             ImPlotAxisFlags x_flags  = 0,
+                                             ImPlotAxisFlags y_flags  = 0,
+                                             ImPlotAxisFlags y2_flags = ImPlotAxisFlags_AuxDefault,
+                                             ImPlotAxisFlags y3_flags = ImPlotAxisFlags_AuxDefault,
+                                             const char* y2_label     = NULL,
+                                             const char* y3_label     = NULL) );
+
+} // namespace ImPlot
+
+#endif

--- a/lib/implot/implot.h
+++ b/lib/implot/implot.h
@@ -1,6 +1,7 @@
 // MIT License
 
-// Copyright (c) 2022 Evan Pezent
+// Copyright (c) 2020-2024 Evan Pezent
+// Copyright (c) 2025-2026 Breno Cunha Queiroz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// ImPlot v0.14
+// ImPlot v1.1 WIP
 
 // Table of Contents:
 //
@@ -46,6 +47,7 @@
 
 #pragma once
 #include "imgui.h"
+#ifndef IMGUI_DISABLE
 
 //-----------------------------------------------------------------------------
 // [SECTION] Macros and Defines
@@ -54,19 +56,22 @@
 // Define attributes of all API symbols declarations (e.g. for DLL under Windows)
 // Using ImPlot via a shared library is not recommended, because we don't guarantee
 // backward nor forward ABI compatibility and also function call overhead. If you
-// do use ImPlot as a DLL, be sure to call SetImGuiContext (see Miscellanous section).
+// do use ImPlot as a DLL, be sure to call SetImGuiContext (see Miscellaneous section).
 #ifndef IMPLOT_API
 #define IMPLOT_API
 #endif
 
 // ImPlot version string.
-#define IMPLOT_VERSION "0.14"
-// Indicates variable should deduced automatically.
-#define IMPLOT_AUTO -1
-// Special color used to indicate that a color should be deduced automatically.
-#define IMPLOT_AUTO_COL ImVec4(0,0,0,-1)
+#define IMPLOT_VERSION "1.1 WIP"
+// ImPlot version integer encoded as XYYZZ (X=major, YY=minor, ZZ=patch).
+#define IMPLOT_VERSION_NUM 10100
 // Macro for templated plotting functions; keeps header clean.
 #define IMPLOT_TMP template <typename T> IMPLOT_API
+
+// Indicates variable should deduced automatically.
+constexpr int IMPLOT_AUTO = -1;
+// Special color used to indicate that a color should be deduced automatically.
+constexpr ImVec4 IMPLOT_AUTO_COL = ImVec4(0,0,0,-1);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Enums and Types
@@ -77,6 +82,7 @@ struct ImPlotContext;             // ImPlot context (opaque struct, see implot_i
 
 // Enums/Flags
 typedef int ImAxis;                   // -> enum ImAxis_
+typedef int ImPlotProp;               // -> enum ImPlotProp_
 typedef int ImPlotFlags;              // -> enum ImPlotFlags_
 typedef int ImPlotAxisFlags;          // -> enum ImPlotAxisFlags_
 typedef int ImPlotSubplotFlags;       // -> enum ImPlotSubplotFlags_
@@ -88,6 +94,8 @@ typedef int ImPlotColormapScaleFlags; // -> ImPlotColormapScaleFlags_
 typedef int ImPlotItemFlags;          // -> ImPlotItemFlags_
 typedef int ImPlotLineFlags;          // -> ImPlotLineFlags_
 typedef int ImPlotScatterFlags;       // -> ImPlotScatterFlags
+typedef int ImPlotBubblesFlags;       // -> ImPlotBubblesFlags
+typedef int ImPlotPolygonFlags;       // -> ImPlotPolygonFlags_
 typedef int ImPlotStairsFlags;        // -> ImPlotStairsFlags_
 typedef int ImPlotShadedFlags;        // -> ImPlotShadedFlags_
 typedef int ImPlotBarsFlags;          // -> ImPlotBarsFlags_
@@ -112,6 +120,7 @@ typedef int ImPlotColormap;           // -> enum ImPlotColormap_
 typedef int ImPlotLocation;           // -> enum ImPlotLocation_
 typedef int ImPlotBin;                // -> enum ImPlotBin_
 
+
 // Axis indices. The values assigned may change; NEVER hardcode these.
 enum ImAxis_ {
     // horizontal axes
@@ -122,30 +131,50 @@ enum ImAxis_ {
     ImAxis_Y1,     // enabled by default
     ImAxis_Y2,     // disabled by default
     ImAxis_Y3,     // disabled by default
-    // bookeeping
+    // bookkeeping
     ImAxis_COUNT
+};
+
+// Plotting properties. These provide syntactic sugar for creating ImPlotSpecs from (ImPlotProp,value) pairs. See ImPlotSpec documentation.
+enum ImPlotProp_ {
+    ImPlotProp_LineColor,       // line color (applies to lines, bar edges); IMPLOT_AUTO_COL will use next Colormap color or current item color
+    ImPlotProp_LineColors,      // array of colors for each line; if nullptr, use LineColor for all lines
+    ImPlotProp_LineWeight,      // line weight in pixels (applies to lines, bar edges, marker edges)
+    ImPlotProp_FillColor,       // fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color
+    ImPlotProp_FillColors,      // array of colors for each fill; if nullptr, use FillColor for all fills
+    ImPlotProp_FillAlpha,       // alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
+    ImPlotProp_Marker,          // marker type; specify ImPlotMarker_Auto to use the next unused marker
+    ImPlotProp_MarkerSize,      // size of markers (radius) *in pixels*
+    ImPlotProp_MarkerSizes,     // array of sizes for each marker; if nullptr, use MarkerSize for all markers
+    ImPlotProp_MarkerLineColor, // marker edge color; IMPLOT_AUTO_COL will use LineColor
+    ImPlotProp_MarkerLineColors, // array of colors for each marker edge; if nullptr, use MarkerLineColor for all markers
+    ImPlotProp_MarkerFillColor, // marker face color; IMPLOT_AUTO_COL will use LineColor
+    ImPlotProp_MarkerFillColors, // array of colors for each marker face; if nullptr, use MarkerFillColor for all markers
+    ImPlotProp_Size,            // size of error bar whiskers (width or height), and digital bars (height) *in pixels*
+    ImPlotProp_Offset,          // data index offset
+    ImPlotProp_Stride,          // data stride in bytes; IMPLOT_AUTO will result in sizeof(T) where T is the type passed to PlotX
+    ImPlotProp_Flags            // optional item flags; can be composed from common ImPlotItemFlags and/or specialized ImPlotXFlags
 };
 
 // Options for plots (see BeginPlot).
 enum ImPlotFlags_ {
     ImPlotFlags_None          = 0,       // default
-    ImPlotFlags_NoTitle       = 1 << 0,  // the plot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MyPlot")
+    ImPlotFlags_NoTitle       = 1 << 0,  // the plot title will not be displayed (titles are also hidden if preceded by double hashes, e.g. "##MyPlot")
     ImPlotFlags_NoLegend      = 1 << 1,  // the legend will not be displayed
     ImPlotFlags_NoMouseText   = 1 << 2,  // the mouse position, in plot coordinates, will not be displayed inside of the plot
     ImPlotFlags_NoInputs      = 1 << 3,  // the user will not be able to interact with the plot
     ImPlotFlags_NoMenus       = 1 << 4,  // the user will not be able to open context menus
     ImPlotFlags_NoBoxSelect   = 1 << 5,  // the user will not be able to box-select
-    ImPlotFlags_NoChild       = 1 << 6,  // a child window region will not be used to capture mouse scroll (can boost performance for single ImGui window applications)
-    ImPlotFlags_NoFrame       = 1 << 7,  // the ImGui frame will not be rendered
-    ImPlotFlags_Equal         = 1 << 8,  // x and y axes pairs will be constrained to have the same units/pixel
-    ImPlotFlags_Crosshairs    = 1 << 9,  // the default mouse cursor will be replaced with a crosshair when hovered
+    ImPlotFlags_NoFrame       = 1 << 6,  // the ImGui frame will not be rendered
+    ImPlotFlags_Equal         = 1 << 7,  // x and y axes pairs will be constrained to have the same units/pixel
+    ImPlotFlags_Crosshairs    = 1 << 8,  // the default mouse cursor will be replaced with a crosshair when hovered
     ImPlotFlags_CanvasOnly    = ImPlotFlags_NoTitle | ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect | ImPlotFlags_NoMouseText
 };
 
 // Options for plot axes (see SetupAxis).
 enum ImPlotAxisFlags_ {
     ImPlotAxisFlags_None          = 0,       // default
-    ImPlotAxisFlags_NoLabel       = 1 << 0,  // the axis label will not be displayed (axis labels are also hidden if the supplied string name is NULL)
+    ImPlotAxisFlags_NoLabel       = 1 << 0,  // the axis label will not be displayed (axis labels are also hidden if the supplied string name is nullptr)
     ImPlotAxisFlags_NoGridLines   = 1 << 1,  // no grid lines will be displayed
     ImPlotAxisFlags_NoTickMarks   = 1 << 2,  // no tick marks will be displayed
     ImPlotAxisFlags_NoTickLabels  = 1 << 3,  // no text labels will be displayed
@@ -169,7 +198,7 @@ enum ImPlotAxisFlags_ {
 // Options for subplots (see BeginSubplot)
 enum ImPlotSubplotFlags_ {
     ImPlotSubplotFlags_None        = 0,       // default
-    ImPlotSubplotFlags_NoTitle     = 1 << 0,  // the subplot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MySubplot")
+    ImPlotSubplotFlags_NoTitle     = 1 << 0,  // the subplot title will not be displayed (titles are also hidden if preceded by double hashes, e.g. "##MySubplot")
     ImPlotSubplotFlags_NoLegend    = 1 << 1,  // the legend will not be displayed (only applicable if ImPlotSubplotFlags_ShareItems is enabled)
     ImPlotSubplotFlags_NoMenus     = 1 << 2,  // the user will not be able to open context menus with right-click
     ImPlotSubplotFlags_NoResize    = 1 << 3,  // resize splitters between subplot cells will be not be provided
@@ -192,6 +221,7 @@ enum ImPlotLegendFlags_ {
     ImPlotLegendFlags_Outside         = 1 << 4, // legend will be rendered outside of the plot area
     ImPlotLegendFlags_Horizontal      = 1 << 5, // legend entries will be displayed horizontally
     ImPlotLegendFlags_Sort            = 1 << 6, // legend entries will be displayed in alphabetical order
+    ImPlotLegendFlags_Reverse         = 1 << 7, // legend entries will be displayed in reverse order
 };
 
 // Options for mouse hover text (see SetupMouseText)
@@ -219,14 +249,14 @@ enum ImPlotColormapScaleFlags_ {
     ImPlotColormapScaleFlags_Invert   = 1 << 2, // invert the colormap bar and axis scale (this only affects rendering; if you only want to reverse the scale mapping, make scale_min > scale_max)
 };
 
-// Flags for ANY PlotX function
+// Flags for ANY PlotX function. Used by setting ImPlotSpec::Flags.
 enum ImPlotItemFlags_ {
     ImPlotItemFlags_None     = 0,
     ImPlotItemFlags_NoLegend = 1 << 0, // the item won't have a legend entry displayed
     ImPlotItemFlags_NoFit    = 1 << 1, // the item won't be considered for plot fits
 };
 
-// Flags for PlotLine
+// Flags for PlotLine. Used by setting ImPlotSpec::Flags.
 enum ImPlotLineFlags_ {
     ImPlotLineFlags_None        = 0,       // default
     ImPlotLineFlags_Segments    = 1 << 10, // a line segment will be rendered from every two consecutive points
@@ -236,94 +266,108 @@ enum ImPlotLineFlags_ {
     ImPlotLineFlags_Shaded      = 1 << 14, // a filled region between the line and horizontal origin will be rendered; use PlotShaded for more advanced cases
 };
 
-// Flags for PlotScatter
+// Flags for PlotScatter. Used by setting ImPlotSpec::Flags.
 enum ImPlotScatterFlags_ {
     ImPlotScatterFlags_None   = 0,       // default
     ImPlotScatterFlags_NoClip = 1 << 10, // markers on the edge of a plot will not be clipped
 };
 
-// Flags for PlotStairs
+// Flags for PlotBubbles. Used by setting ImPlotSpec::Flags.
+enum ImPlotBubblesFlags_ {
+  ImPlotBubblesFlags_None = 0, // default
+};
+
+// Flags for PlotPolygon. Used by setting ImPlotSpec::Flags.
+enum ImPlotPolygonFlags_ {
+  ImPlotPolygonFlags_None     = 0,       // default (closed, convex polygon)
+  ImPlotPolygonFlags_Concave  = 1 << 10, // use concave polygon filling (slower but supports concave shapes)
+};
+
+// Flags for PlotStairs. Used by setting ImPlotSpec::Flags.
 enum ImPlotStairsFlags_ {
     ImPlotStairsFlags_None     = 0,       // default
     ImPlotStairsFlags_PreStep  = 1 << 10, // the y value is continued constantly to the left from every x position, i.e. the interval (x[i-1], x[i]] has the value y[i]
     ImPlotStairsFlags_Shaded   = 1 << 11  // a filled region between the stairs and horizontal origin will be rendered; use PlotShaded for more advanced cases
 };
 
-// Flags for PlotShaded (placeholder)
+// Flags for PlotShaded (placeholder). Used by setting ImPlotSpec::Flags.
 enum ImPlotShadedFlags_ {
     ImPlotShadedFlags_None  = 0 // default
 };
 
-// Flags for PlotBars
+// Flags for PlotBars. Used by setting ImPlotSpec::Flags.
 enum ImPlotBarsFlags_ {
     ImPlotBarsFlags_None         = 0,       // default
     ImPlotBarsFlags_Horizontal   = 1 << 10, // bars will be rendered horizontally on the current y-axis
 };
 
-// Flags for PlotBarGroups
+// Flags for PlotBarGroups. Used by setting ImPlotSpec::Flags.
 enum ImPlotBarGroupsFlags_ {
     ImPlotBarGroupsFlags_None        = 0,       // default
     ImPlotBarGroupsFlags_Horizontal  = 1 << 10, // bar groups will be rendered horizontally on the current y-axis
     ImPlotBarGroupsFlags_Stacked     = 1 << 11, // items in a group will be stacked on top of each other
 };
 
-// Flags for PlotErrorBars
+// Flags for PlotErrorBars. Used by setting ImPlotSpec::Flags.
 enum ImPlotErrorBarsFlags_ {
     ImPlotErrorBarsFlags_None       = 0,       // default
     ImPlotErrorBarsFlags_Horizontal = 1 << 10, // error bars will be rendered horizontally on the current y-axis
 };
 
-// Flags for PlotStems
+// Flags for PlotStems. Used by setting ImPlotSpec::Flags.
 enum ImPlotStemsFlags_ {
     ImPlotStemsFlags_None       = 0,       // default
     ImPlotStemsFlags_Horizontal = 1 << 10, // stems will be rendered horizontally on the current y-axis
 };
 
-// Flags for PlotInfLines
+// Flags for PlotInfLines. Used by setting ImPlotSpec::Flags.
 enum ImPlotInfLinesFlags_ {
     ImPlotInfLinesFlags_None       = 0,      // default
     ImPlotInfLinesFlags_Horizontal = 1 << 10 // lines will be rendered horizontally on the current y-axis
 };
 
-// Flags for PlotPieChart
+// Flags for PlotPieChart. Used by setting ImPlotSpec::Flags.
 enum ImPlotPieChartFlags_ {
-    ImPlotPieChartFlags_None      = 0,      // default
-    ImPlotPieChartFlags_Normalize = 1 << 10 // force normalization of pie chart values (i.e. always make a full circle if sum < 0)
+    ImPlotPieChartFlags_None          = 0,       // default
+    ImPlotPieChartFlags_Normalize     = 1 << 10, // force normalization of pie chart values (i.e. always make a full circle if sum < 0)
+    ImPlotPieChartFlags_IgnoreHidden  = 1 << 11, // ignore hidden slices when drawing the pie chart (as if they were not there)
+    ImPlotPieChartFlags_Exploding     = 1 << 12, // explode legend-hovered slice
+    ImPlotPieChartFlags_NoSliceBorder = 1 << 13  // do not draw slice borders
 };
 
-// Flags for PlotHeatmap
+// Flags for PlotHeatmap. Used by setting ImPlotSpec::Flags.
 enum ImPlotHeatmapFlags_ {
     ImPlotHeatmapFlags_None     = 0,       // default
     ImPlotHeatmapFlags_ColMajor = 1 << 10, // data will be read in column major order
 };
 
-// Flags for PlotHistogram and PlotHistogram2D
+// Flags for PlotHistogram and PlotHistogram2D. Used by setting ImPlotSpec::Flags.
 enum ImPlotHistogramFlags_ {
     ImPlotHistogramFlags_None       = 0,       // default
     ImPlotHistogramFlags_Horizontal = 1 << 10, // histogram bars will be rendered horizontally (not supported by PlotHistogram2D)
     ImPlotHistogramFlags_Cumulative = 1 << 11, // each bin will contain its count plus the counts of all previous bins (not supported by PlotHistogram2D)
     ImPlotHistogramFlags_Density    = 1 << 12, // counts will be normalized, i.e. the PDF will be visualized, or the CDF will be visualized if Cumulative is also set
-    ImPlotHistogramFlags_NoOutliers = 1 << 13, // exclude values outside the specifed histogram range from the count toward normalizing and cumulative counts
+    ImPlotHistogramFlags_NoOutliers = 1 << 13, // exclude values outside the specified histogram range from the count toward normalizing and cumulative counts
     ImPlotHistogramFlags_ColMajor   = 1 << 14  // data will be read in column major order (not supported by PlotHistogram)
 };
 
-// Flags for PlotDigital (placeholder)
+// Flags for PlotDigital (placeholder). Used by setting ImPlotSpec::Flags.
 enum ImPlotDigitalFlags_ {
     ImPlotDigitalFlags_None = 0 // default
 };
 
-// Flags for PlotImage (placeholder)
+// Flags for PlotImage (placeholder). Used by setting ImPlotSpec::Flags.
 enum ImPlotImageFlags_ {
     ImPlotImageFlags_None = 0 // default
 };
 
-// Flags for PlotText
+// Flags for PlotText. Used by setting ImPlotSpec::Flags.
 enum ImPlotTextFlags_ {
     ImPlotTextFlags_None     = 0,       // default
     ImPlotTextFlags_Vertical = 1 << 10  // text will be rendered vertically
 };
 
-// Flags for PlotDummy (placeholder)
+// Flags for PlotDummy (placeholder). Used by setting ImPlotSpec::Flags.
 enum ImPlotDummyFlags_ {
     ImPlotDummyFlags_None = 0 // default
 };
@@ -338,13 +382,6 @@ enum ImPlotCond_
 
 // Plot styling colors.
 enum ImPlotCol_ {
-    // item styling colors
-    ImPlotCol_Line,          // plot line/outline color (defaults to next unused color in current colormap)
-    ImPlotCol_Fill,          // plot fill color for bars (defaults to the current line color)
-    ImPlotCol_MarkerOutline, // marker outline color (defaults to the current line color)
-    ImPlotCol_MarkerFill,    // marker fill color (defaults to the current line color)
-    ImPlotCol_ErrorBar,      // error bar color (defaults to ImGuiCol_Text)
-    // plot styling colors
     ImPlotCol_FrameBg,       // plot frame background color (defaults to ImGuiCol_FrameBg)
     ImPlotCol_PlotBg,        // plot area background color (defaults to ImGuiCol_WindowBg)
     ImPlotCol_PlotBorder,    // plot area border color (defaults to ImGuiCol_Border)
@@ -353,7 +390,7 @@ enum ImPlotCol_ {
     ImPlotCol_LegendText,    // legend text color (defaults to ImPlotCol_InlayText)
     ImPlotCol_TitleText,     // plot title text color (defaults to ImGuiCol_Text)
     ImPlotCol_InlayText,     // color of text appearing inside of plots (defaults to ImGuiCol_Text)
-    ImPlotCol_AxisText,      // axis label and tick lables color (defaults to ImGuiCol_Text)
+    ImPlotCol_AxisText,      // axis label and tick labels color (defaults to ImGuiCol_Text)
     ImPlotCol_AxisGrid,      // axis grid color (defaults to 25% ImPlotCol_AxisText)
     ImPlotCol_AxisTick,      // axis tick color (defaults to AxisGrid)
     ImPlotCol_AxisBg,        // background color of axis hover region (defaults to transparent)
@@ -366,17 +403,8 @@ enum ImPlotCol_ {
 
 // Plot styling variables.
 enum ImPlotStyleVar_ {
-    // item styling variables
-    ImPlotStyleVar_LineWeight,         // float,  plot item line weight in pixels
-    ImPlotStyleVar_Marker,             // int,    marker specification
-    ImPlotStyleVar_MarkerSize,         // float,  marker size in pixels (roughly the marker's "radius")
-    ImPlotStyleVar_MarkerWeight,       // float,  plot outline weight of markers in pixels
-    ImPlotStyleVar_FillAlpha,          // float,  alpha modifier applied to all plot item fills
-    ImPlotStyleVar_ErrorBarSize,       // float,  error bar whisker width in pixels
-    ImPlotStyleVar_ErrorBarWeight,     // float,  error bar whisker weight in pixels
-    ImPlotStyleVar_DigitalBitHeight,   // float,  digital channels bit height (at 1) in pixels
-    ImPlotStyleVar_DigitalBitGap,      // float,  digital channels bit padding gap in pixels
-    // plot styling variables
+    ImPlotStyleVar_PlotDefaultSize,    // ImVec2, default size used when ImVec2(0,0) is passed to BeginPlot
+    ImPlotStyleVar_PlotMinSize,        // ImVec2, minimum size plot frame can be when shrunk
     ImPlotStyleVar_PlotBorderSize,     // float,  thickness of border around plot area
     ImPlotStyleVar_MinorAlpha,         // float,  alpha multiplier applied to minor axis grid lines
     ImPlotStyleVar_MajorTickLen,       // ImVec2, major tick lengths for X and Y axes
@@ -393,8 +421,8 @@ enum ImPlotStyleVar_ {
     ImPlotStyleVar_MousePosPadding,    // ImVec2, padding between plot edge and interior info text
     ImPlotStyleVar_AnnotationPadding,  // ImVec2, text padding around annotation labels
     ImPlotStyleVar_FitPadding,         // ImVec2, additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)
-    ImPlotStyleVar_PlotDefaultSize,    // ImVec2, default size used when ImVec2(0,0) is passed to BeginPlot
-    ImPlotStyleVar_PlotMinSize,        // ImVec2, minimum size plot frame can be when shrunk
+    ImPlotStyleVar_DigitalPadding,     // float,  digital plot padding from bottom in pixels
+    ImPlotStyleVar_DigitalSpacing,     // float,  digital plot spacing gap in pixels
     ImPlotStyleVar_COUNT
 };
 
@@ -402,13 +430,14 @@ enum ImPlotStyleVar_ {
 enum ImPlotScale_ {
     ImPlotScale_Linear = 0, // default linear scale
     ImPlotScale_Time,       // date/time scale
-    ImPlotScale_Log10,      // base 10 logartithmic scale
+    ImPlotScale_Log10,      // base 10 logarithmic scale
     ImPlotScale_SymLog,     // symmetric log scale
 };
 
 // Marker specifications.
 enum ImPlotMarker_ {
-    ImPlotMarker_None = -1, // no marker
+    ImPlotMarker_None = -2, // no marker
+    ImPlotMarker_Auto = -1, // automatic marker selection
     ImPlotMarker_Circle,    // a circle marker (default)
     ImPlotMarker_Square,    // a square maker
     ImPlotMarker_Diamond,   // a diamond marker
@@ -416,9 +445,11 @@ enum ImPlotMarker_ {
     ImPlotMarker_Down,      // an downward-pointing triangle marker
     ImPlotMarker_Left,      // an leftward-pointing triangle marker
     ImPlotMarker_Right,     // an rightward-pointing triangle marker
-    ImPlotMarker_Cross,     // a cross marker (not fillable)
-    ImPlotMarker_Plus,      // a plus marker (not fillable)
-    ImPlotMarker_Asterisk,  // a asterisk marker (not fillable)
+    ImPlotMarker_Cross,     // a cross marker (not fill-able)
+    ImPlotMarker_Plus,      // a plus marker (not fill-able)
+    ImPlotMarker_Asterisk,  // a asterisk marker (not fill-able)
+    ImPlotMarker_Vertical,   // a vertical line marker (not fill-able)
+    ImPlotMarker_Horizontal, // a horizontal line marker (not fill-able)
     ImPlotMarker_COUNT
 };
 
@@ -463,57 +494,162 @@ enum ImPlotBin_ {
     ImPlotBin_Scott   = -4, // w = 3.49 * sigma / cbrt(n)
 };
 
+// Plot item styling specification. Provide these to PlotX functions to override styling, specify
+// offsetting or stride, or set optional flags. This struct can be used in the following ways:
+//
+// 1. By declaring and defining a struct instance:
+//
+//    ImPlotSpec spec;
+//    spec.LineColor = ImVec4(1,0,0,1);
+//    spec.LineWeight = 2.0f;
+//    spec.Marker = ImPlotMarker_Circle;
+//    spec.Flags = ImPlotItemFlags_NoLegend | ImPlotLineFlags_Segments;
+//    ImPlot::PlotLine("MyLine", xs, ys, 100, spec);
+//
+// 2. Inline using (ImPlotProp,value) pairs (order does NOT matter):
+//
+//    ImPlot::PlotLine("MyLine", xs, ys, 100, {
+//      ImPlotProp_LineColor, ImVec4(1,0,0,1),
+//      ImPlotProp_LineWeight, 2.0f,
+//      ImPlotProp_Marker, ImPlotMarker_Circle,
+//      ImPlotProp_Flags, ImPlotItemFlags_NoLegend | ImPlotLineFlags_Segments
+//    });
+struct ImPlotSpec {
+    ImVec4          LineColor       = IMPLOT_AUTO_COL;       // line color (applies to lines, bar edges); IMPLOT_AUTO_COL will use next Colormap color or current item color
+    ImU32*          LineColors      = nullptr;               // array of colors for each line; if nullptr, use LineColor for all lines
+    float           LineWeight      = 1.0f;                  // line weight in pixels (applies to lines, bar edges, marker edges)
+    ImVec4          FillColor       = IMPLOT_AUTO_COL;       // fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color
+    ImU32*          FillColors      = nullptr;               // array of colors for each fill; if nullptr, use FillColor for all fills
+    float           FillAlpha       = 1.0f;                  // alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
+    ImPlotMarker    Marker          = ImPlotMarker_None;     // marker type; specify ImPlotMarker_Auto to use the next unused marker
+    float           MarkerSize      = 4;                     // size of markers (radius) *in pixels*
+    float*          MarkerSizes     = nullptr;               // array of sizes for each marker; if nullptr, use MarkerSize for all markers
+    ImVec4          MarkerLineColor = IMPLOT_AUTO_COL;       // marker edge color; IMPLOT_AUTO_COL will use LineColor
+    ImU32*          MarkerLineColors = nullptr;              // array of colors for each marker edge; if nullptr, use MarkerLineColor for all markers
+    ImVec4          MarkerFillColor = IMPLOT_AUTO_COL;       // marker face color; IMPLOT_AUTO_COL will use LineColor
+    ImU32*          MarkerFillColors = nullptr;              // array of colors for each marker face; if nullptr, use MarkerFillColor for all markers
+    float           Size            = 4;                     // size of error bar whiskers (width or height), and digital bars (height) *in pixels*
+    int             Offset          = 0;                     // data index offset
+    int             Stride          = IMPLOT_AUTO;           // data stride in bytes; IMPLOT_AUTO will result in sizeof(T) where T is the type passed to PlotX
+    ImPlotItemFlags Flags           = ImPlotItemFlags_None;  // optional item flags; can be composed from common ImPlotItemFlags and/or specialized ImPlotXFlags
+
+    ImPlotSpec() { }
+
+    // Construct a plot item specification from (ImPlotProp,value) pairs in any order, e.g. ImPlotSpec(ImPlotProp_LineColor, my_color, ImPlotProp_Marker, 4.0f)
+    template <typename ...Args>
+    ImPlotSpec(Args... args) {
+        static_assert((sizeof ...(Args)) % 2 == 0, "Odd number of arguments! You must provide (ImPlotProp, value) pairs!");
+        SetProp(args...);
+    }
+
+    // Set properties from (ImPlotProp,value) pairs in any order, e.g. SetProp(ImPlotProp_LineColor, my_color, ImPlotProp_Marker, 4.0f)
+    template <typename Arg, typename ...Args>
+    void SetProp(ImPlotProp prop, Arg arg, Args... args) {
+        static_assert((sizeof ...(Args)) % 2 == 0, "Odd number of arguments! You must provide (ImPlotProp,value) pairs!");
+        SetProp(prop, arg);
+        SetProp(args...);
+    }
+
+    // Set a property from a scalar value.
+    template <typename T>
+    void SetProp(ImPlotProp prop, T v) {
+        switch (prop) {
+        case ImPlotProp_LineColor       : LineColor       = ImGui::ColorConvertU32ToFloat4((ImU32)v); return;
+        case ImPlotProp_LineWeight      : LineWeight      = (float)v;                                 return;
+        case ImPlotProp_FillColor       : FillColor       = ImGui::ColorConvertU32ToFloat4((ImU32)v); return;
+        case ImPlotProp_FillAlpha       : FillAlpha       = (float)v;                                 return;
+        case ImPlotProp_Marker          : Marker          = (ImPlotMarker)v;                          return;
+        case ImPlotProp_MarkerSize      : MarkerSize      = (float)v;                                 return;
+        case ImPlotProp_MarkerLineColor : MarkerLineColor = ImGui::ColorConvertU32ToFloat4((ImU32)v); return;
+        case ImPlotProp_MarkerFillColor : MarkerFillColor = ImGui::ColorConvertU32ToFloat4((ImU32)v); return;
+        case ImPlotProp_Size            : Size            = (float)v;                                 return;
+        case ImPlotProp_Offset          : Offset          = (int)v;                                   return;
+        case ImPlotProp_Stride          : Stride          = (int)v;                                   return;
+        case ImPlotProp_Flags           : Flags           = (ImPlotItemFlags)v;                       return;
+        default: break;
+        }
+        IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from scalar value!");
+    }
+
+    // Set a property from a pointer value.
+    void SetProp(ImPlotProp prop, ImU32* v) {
+        switch (prop) {
+        case ImPlotProp_LineColors       : LineColors       = v;  return;
+        case ImPlotProp_FillColors       : FillColors       = v;  return;
+        case ImPlotProp_MarkerLineColors : MarkerLineColors = v;  return;
+        case ImPlotProp_MarkerFillColors : MarkerFillColors = v;  return;
+        default: break;
+        }
+        IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from pointer value!");
+    }
+
+    // Set a property from a float pointer value.
+    void SetProp(ImPlotProp prop, float* v) {
+        switch (prop) {
+        case ImPlotProp_MarkerSizes : MarkerSizes = v; return;
+        default: break;
+        }
+        IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from float pointer value!");
+    }
+
+    // Set a property from an ImVec4 value.
+    void SetProp(ImPlotProp prop, const ImVec4& v) {
+        switch (prop) {
+        case ImPlotProp_LineColor       : LineColor       = v; return;
+        case ImPlotProp_FillColor       : FillColor       = v; return;
+        case ImPlotProp_MarkerLineColor : MarkerLineColor = v; return;
+        case ImPlotProp_MarkerFillColor : MarkerFillColor = v; return;
+        default: break;
+        }
+        IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from ImVec4 value!");
+    }
+};
+
 // Double precision version of ImVec2 used by ImPlot. Extensible by end users.
+IM_MSVC_RUNTIME_CHECKS_OFF
 struct ImPlotPoint {
     double x, y;
-    ImPlotPoint()                         { x = y = 0.0;      }
-    ImPlotPoint(double _x, double _y)     { x = _x; y = _y;   }
-    ImPlotPoint(const ImVec2& p)          { x = p.x; y = p.y; }
-    double  operator[] (size_t idx) const { return (&x)[idx]; }
-    double& operator[] (size_t idx)       { return (&x)[idx]; }
+    IMPLOT_API constexpr ImPlotPoint()                     : x(0.0), y(0.0) { }
+    IMPLOT_API constexpr ImPlotPoint(double _x, double _y) : x(_x), y(_y) { }
+    IMPLOT_API constexpr ImPlotPoint(const ImVec2& p)      : x((double)p.x), y((double)p.y) { }
+    IMPLOT_API double& operator[] (size_t idx)             { IM_ASSERT(idx == 0 || idx == 1); return ((double*)(void*)(char*)this)[idx]; }
+    IMPLOT_API double  operator[] (size_t idx) const       { IM_ASSERT(idx == 0 || idx == 1); return ((const double*)(const void*)(const char*)this)[idx]; }
 #ifdef IMPLOT_POINT_CLASS_EXTRA
     IMPLOT_POINT_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h
                                  // to convert back and forth between your math types and ImPlotPoint.
 #endif
 };
+IM_MSVC_RUNTIME_CHECKS_RESTORE
 
 // Range defined by a min/max value.
 struct ImPlotRange {
     double Min, Max;
-    ImPlotRange()                         { Min = 0; Max = 0;                                         }
-    ImPlotRange(double _min, double _max) { Min = _min; Max = _max;                                   }
-    bool Contains(double value) const     { return value >= Min && value <= Max;                      }
-    double Size() const                   { return Max - Min;                                         }
-    double Clamp(double value) const      { return (value < Min) ? Min : (value > Max) ? Max : value; }
+    IMPLOT_API constexpr ImPlotRange()                         : Min(0.0), Max(0.0) { }
+    IMPLOT_API constexpr ImPlotRange(double _min, double _max) : Min(_min), Max(_max) { }
+    IMPLOT_API bool Contains(double value) const               { return value >= Min && value <= Max;                      }
+    IMPLOT_API double Size() const                             { return Max - Min;                                         }
+    IMPLOT_API double Clamp(double value) const                { return (value < Min) ? Min : (value > Max) ? Max : value; }
 };
 
 // Combination of two range limits for X and Y axes. Also an AABB defined by Min()/Max().
 struct ImPlotRect {
     ImPlotRange X, Y;
-    ImPlotRect()                                                       {                                                               }
-    ImPlotRect(double x_min, double x_max, double y_min, double y_max) { X.Min = x_min; X.Max = x_max; Y.Min = y_min; Y.Max = y_max;   }
-    bool Contains(const ImPlotPoint& p) const                          { return Contains(p.x, p.y);                                    }
-    bool Contains(double x, double y) const                            { return X.Contains(x) && Y.Contains(y);                        }
-    ImPlotPoint Size() const                                           { return ImPlotPoint(X.Size(), Y.Size());                       }
-    ImPlotPoint Clamp(const ImPlotPoint& p)                            { return Clamp(p.x, p.y);                                       }
-    ImPlotPoint Clamp(double x, double y)                              { return ImPlotPoint(X.Clamp(x),Y.Clamp(y));                    }
-    ImPlotPoint Min() const                                            { return ImPlotPoint(X.Min, Y.Min);                             }
-    ImPlotPoint Max() const                                            { return ImPlotPoint(X.Max, Y.Max);                             }
+    IMPLOT_API constexpr ImPlotRect()                                                       : X(0.0,0.0), Y(0.0,0.0) { }
+    IMPLOT_API constexpr ImPlotRect(double x_min, double x_max, double y_min, double y_max) : X(x_min, x_max), Y(y_min, y_max) { }
+    IMPLOT_API bool Contains(const ImPlotPoint& p) const                                    { return Contains(p.x, p.y);                 }
+    IMPLOT_API bool Contains(double x, double y) const                                      { return X.Contains(x) && Y.Contains(y);     }
+    IMPLOT_API ImPlotPoint Size() const                                                     { return ImPlotPoint(X.Size(), Y.Size());    }
+    IMPLOT_API ImPlotPoint Clamp(const ImPlotPoint& p) const                                { return Clamp(p.x, p.y);                    }
+    IMPLOT_API ImPlotPoint Clamp(double x, double y) const                                  { return ImPlotPoint(X.Clamp(x),Y.Clamp(y)); }
+    IMPLOT_API ImPlotPoint Min() const                                                      { return ImPlotPoint(X.Min, Y.Min);          }
+    IMPLOT_API ImPlotPoint Max() const                                                      { return ImPlotPoint(X.Max, Y.Max);          }
 };
 
 // Plot style structure
 struct ImPlotStyle {
-    // item styling variables
-    float   LineWeight;              // = 1,      item line weight in pixels
-    int     Marker;                  // = ImPlotMarker_None, marker specification
-    float   MarkerSize;              // = 4,      marker size in pixels (roughly the marker's "radius")
-    float   MarkerWeight;            // = 1,      outline weight of markers in pixels
-    float   FillAlpha;               // = 1,      alpha modifier applied to plot fills
-    float   ErrorBarSize;            // = 5,      error bar whisker width in pixels
-    float   ErrorBarWeight;          // = 1.5,    error bar whisker weight in pixels
-    float   DigitalBitHeight;        // = 8,      digital channels bit height (at y = 1.0f) in pixels
-    float   DigitalBitGap;           // = 4,      digital channels bit padding gap in pixels
-    // plot styling variables
+    // plot styling
+    ImVec2  PlotDefaultSize;         // = 400,300 default size used when ImVec2(0,0) is passed to BeginPlot
+    ImVec2  PlotMinSize;             // = 200,150 minimum size plot frame can be when shrunk
     float   PlotBorderSize;          // = 1,      line thickness of border around plot area
     float   MinorAlpha;              // = 0.25    alpha multiplier applied to minor axis grid lines
     ImVec2  MajorTickLen;            // = 10,10   major tick lengths for X and Y axes
@@ -522,6 +658,7 @@ struct ImPlotStyle {
     ImVec2  MinorTickSize;           // = 1,1     line thickness of minor ticks
     ImVec2  MajorGridSize;           // = 1,1     line thickness of major grid lines
     ImVec2  MinorGridSize;           // = 1,1     line thickness of minor grid lines
+    // plot padding
     ImVec2  PlotPadding;             // = 10,10   padding between widget frame and plot area, labels, or outside legends (i.e. main padding)
     ImVec2  LabelPadding;            // = 5,5     padding between axes labels, tick labels, and plot edge
     ImVec2  LegendPadding;           // = 10,10   legend padding from plot edges
@@ -530,8 +667,8 @@ struct ImPlotStyle {
     ImVec2  MousePosPadding;         // = 10,10   padding between plot edge and interior mouse location text
     ImVec2  AnnotationPadding;       // = 2,2     text padding around annotation labels
     ImVec2  FitPadding;              // = 0,0     additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)
-    ImVec2  PlotDefaultSize;         // = 400,300 default size used when ImVec2(0,0) is passed to BeginPlot
-    ImVec2  PlotMinSize;             // = 200,150 minimum size plot frame can be when shrunk
+    float   DigitalPadding;          // = 20,     digital plot padding from bottom in pixels
+    float   DigitalSpacing;          // = 4,      digital plot spacing gap in pixels
     // style colors
     ImVec4  Colors[ImPlotCol_COUNT]; // Array of styling colors. Indexable with ImPlotCol_ enums.
     // colormap
@@ -543,28 +680,34 @@ struct ImPlotStyle {
     IMPLOT_API ImPlotStyle();
 };
 
+// Support for legacy versions
 #if (IMGUI_VERSION_NUM < 18716) // Renamed in 1.88
-#define ImGuiModFlags       ImGuiKeyModFlags
-#define ImGuiModFlags_None  ImGuiKeyModFlags_None
-#define ImGuiModFlags_Ctrl  ImGuiKeyModFlags_Ctrl
-#define ImGuiModFlags_Shift ImGuiKeyModFlags_Shift
-#define ImGuiModFlags_Alt   ImGuiKeyModFlags_Alt
-#define ImGuiModFlags_Super ImGuiKeyModFlags_Super
+#define ImGuiMod_None       0
+#define ImGuiMod_Ctrl       ImGuiKeyModFlags_Ctrl
+#define ImGuiMod_Shift      ImGuiKeyModFlags_Shift
+#define ImGuiMod_Alt        ImGuiKeyModFlags_Alt
+#define ImGuiMod_Super      ImGuiKeyModFlags_Super
+#elif (IMGUI_VERSION_NUM < 18823) // Renamed in 1.89, sorry
+#define ImGuiMod_None       0
+#define ImGuiMod_Ctrl       ImGuiModFlags_Ctrl
+#define ImGuiMod_Shift      ImGuiModFlags_Shift
+#define ImGuiMod_Alt        ImGuiModFlags_Alt
+#define ImGuiMod_Super      ImGuiModFlags_Super
 #endif
 
 // Input mapping structure. Default values listed. See also MapInputDefault, MapInputReverse.
 struct ImPlotInputMap {
     ImGuiMouseButton Pan;           // LMB    enables panning when held,
-    ImGuiModFlags    PanMod;        // none   optional modifier that must be held for panning/fitting
+    int              PanMod;        // none   optional modifier that must be held for panning/fitting
     ImGuiMouseButton Fit;           // LMB    initiates fit when double clicked
     ImGuiMouseButton Select;        // RMB    begins box selection when pressed and confirms selection when released
     ImGuiMouseButton SelectCancel;  // LMB    cancels active box selection when pressed; cannot be same as Select
-    ImGuiModFlags    SelectMod;     // none   optional modifier that must be held for box selection
-    ImGuiModFlags    SelectHorzMod; // Alt    expands active box selection horizontally to plot edge when held
-    ImGuiModFlags    SelectVertMod; // Shift  expands active box selection vertically to plot edge when held
+    int              SelectMod;     // none   optional modifier that must be held for box selection
+    int              SelectHorzMod; // Alt    expands active box selection horizontally to plot edge when held
+    int              SelectVertMod; // Shift  expands active box selection vertically to plot edge when held
     ImGuiMouseButton Menu;          // RMB    opens context menus (if enabled) when clicked
-    ImGuiModFlags    OverrideMod;   // Ctrl   when held, all input is ignored; used to enable axis/plots as DND sources
-    ImGuiModFlags    ZoomMod;       // none   optional modifier that must be held for scroll wheel zooming
+    int              OverrideMod;   // Ctrl   when held, all input is ignored; used to enable axis/plots as DND sources
+    int              ZoomMod;       // none   optional modifier that must be held for scroll wheel zooming
     float            ZoomRate;      // 0.1f   zoom rate for scroll (e.g. 0.1f = 10% plot range every scroll click); make negative to invert
     IMPLOT_API ImPlotInputMap();
 };
@@ -590,9 +733,9 @@ namespace ImPlot {
 
 // Creates a new ImPlot context. Call this after ImGui::CreateContext.
 IMPLOT_API ImPlotContext* CreateContext();
-// Destroys an ImPlot context. Call this before ImGui::DestroyContext. NULL = destroy current context.
-IMPLOT_API void DestroyContext(ImPlotContext* ctx = NULL);
-// Returns the current ImPlot context. NULL if no context has ben set.
+// Destroys an ImPlot context. Call this before ImGui::DestroyContext. nullptr = destroy current context.
+IMPLOT_API void DestroyContext(ImPlotContext* ctx = nullptr);
+// Returns the current ImPlot context. nullptr if no context has ben set.
 IMPLOT_API ImPlotContext* GetCurrentContext();
 // Sets the current ImPlot context.
 IMPLOT_API void SetCurrentContext(ImPlotContext* ctx);
@@ -635,7 +778,7 @@ IMPLOT_API void EndPlot();
 
 // Starts a subdivided plotting context. If the function returns true,
 // EndSubplots() MUST be called! Call BeginPlot/EndPlot AT MOST [rows*cols]
-// times in  between the begining and end of the subplot context. Plots are
+// times in  between the beginning and end of the subplot context. Plots are
 // added in row major order.
 //
 // Example:
@@ -684,11 +827,11 @@ IMPLOT_API bool BeginSubplots(const char* title_id,
                              int cols,
                              const ImVec2& size,
                              ImPlotSubplotFlags flags = 0,
-                             float* row_ratios        = NULL,
-                             float* col_ratios        = NULL);
+                             float* row_ratios        = nullptr,
+                             float* col_ratios        = nullptr);
 
 // Only call EndSubplots() if BeginSubplots() returns true! Typically called at the end
-// of an if statement conditioned on BeginSublots(). See example above.
+// of an if statement conditioned on BeginSubplots(). See example above.
 IMPLOT_API void EndSubplots();
 
 //-----------------------------------------------------------------------------
@@ -720,24 +863,24 @@ IMPLOT_API void EndSubplots();
 //   call it yourself, then the first subsequent plotting or utility function will
 //   call it for you.
 
-// Enables an axis or sets the label and/or flags for an existing axis. Leave #label = NULL for no label.
-IMPLOT_API void SetupAxis(ImAxis axis, const char* label=NULL, ImPlotAxisFlags flags=0);
-// Sets an axis range limits. If ImPlotCond_Always is used, the axes limits will be locked.
+// Enables an axis or sets the label and/or flags for an existing axis. Leave #label = nullptr for no label.
+IMPLOT_API void SetupAxis(ImAxis axis, const char* label=nullptr, ImPlotAxisFlags flags=0);
+// Sets an axis range limits. If ImPlotCond_Always is used, the axes limits will be locked. Inversion with v_min > v_max is not supported; use SetupAxisLimits instead.
 IMPLOT_API void SetupAxisLimits(ImAxis axis, double v_min, double v_max, ImPlotCond cond = ImPlotCond_Once);
-// Links an axis range limits to external values. Set to NULL for no linkage. The pointer data must remain valid until EndPlot.
+// Links an axis range limits to external values. Set to nullptr for no linkage. The pointer data must remain valid until EndPlot.
 IMPLOT_API void SetupAxisLinks(ImAxis axis, double* link_min, double* link_max);
-// Sets the format of numeric axis labels via formater specifier (default="%g"). Formated values will be double (i.e. use %f).
+// Sets the format of numeric axis labels via formatter specifier (default="%g"). Formatted values will be double (i.e. use %f).
 IMPLOT_API void SetupAxisFormat(ImAxis axis, const char* fmt);
 // Sets the format of numeric axis labels via formatter callback. Given #value, write a label into #buff. Optionally pass user data.
-IMPLOT_API void SetupAxisFormat(ImAxis axis, ImPlotFormatter formatter, void* data=NULL);
+IMPLOT_API void SetupAxisFormat(ImAxis axis, ImPlotFormatter formatter, void* data=nullptr);
 // Sets an axis' ticks and optionally the labels. To keep the default ticks, set #keep_default=true.
-IMPLOT_API void SetupAxisTicks(ImAxis axis, const double* values, int n_ticks, const char* const labels[]=NULL, bool keep_default=false);
+IMPLOT_API void SetupAxisTicks(ImAxis axis, const double* values, int n_ticks, const char* const labels[]=nullptr, bool keep_default=false);
 // Sets an axis' ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true.
-IMPLOT_API void SetupAxisTicks(ImAxis axis, double v_min, double v_max, int n_ticks, const char* const labels[]=NULL, bool keep_default=false);
+IMPLOT_API void SetupAxisTicks(ImAxis axis, double v_min, double v_max, int n_ticks, const char* const labels[]=nullptr, bool keep_default=false);
 // Sets an axis' scale using built-in options.
 IMPLOT_API void SetupAxisScale(ImAxis axis, ImPlotScale scale);
-// Sets an axis' scale using user supplied forward and inverse transfroms.
-IMPLOT_API void SetupAxisScale(ImAxis axis, ImPlotTransform forward, ImPlotTransform inverse, void* data=NULL);
+// Sets an axis' scale using user supplied forward and inverse transforms.
+IMPLOT_API void SetupAxisScale(ImAxis axis, ImPlotTransform forward, ImPlotTransform inverse, void* data=nullptr);
 // Sets an axis' limits constraints.
 IMPLOT_API void SetupAxisLimitsConstraints(ImAxis axis, double v_min, double v_max);
 // Sets an axis' zoom constraints.
@@ -748,7 +891,7 @@ IMPLOT_API void SetupAxes(const char* x_label, const char* y_label, ImPlotAxisFl
 // Sets the primary X and Y axes range limits. If ImPlotCond_Always is used, the axes limits will be locked (shorthand for two calls to SetupAxisLimits).
 IMPLOT_API void SetupAxesLimits(double x_min, double x_max, double y_min, double y_max, ImPlotCond cond = ImPlotCond_Once);
 
-// Sets up the plot legend.
+// Sets up the plot legend. This can also be called immediately after BeginSubplots when using ImPlotSubplotFlags_ShareItems.
 IMPLOT_API void SetupLegend(ImPlotLocation location, ImPlotLegendFlags flags=0);
 // Set the location of the current plot's mouse position text (default = South|East).
 IMPLOT_API void SetupMouseText(ImPlotLocation location, ImPlotMouseTextFlags flags=0);
@@ -766,7 +909,7 @@ IMPLOT_API void SetupFinish();
 // using a preceding button or slider widget to change the plot limits). In
 // this case, you can use the `SetNext` API below. While this is not as feature
 // rich as the Setup API, most common needs are provided. These functions can be
-// called anwhere except for inside of `Begin/EndPlot`. For example:
+// called anywhere except for inside of `Begin/EndPlot`. For example:
 
 // if (ImGui::Button("Center Plot"))
 //     ImPlot::SetNextPlotLimits(-1,1,-1,1);
@@ -782,7 +925,7 @@ IMPLOT_API void SetupFinish();
 
 // Sets an upcoming axis range limits. If ImPlotCond_Always is used, the axes limits will be locked.
 IMPLOT_API void SetNextAxisLimits(ImAxis axis, double v_min, double v_max, ImPlotCond cond = ImPlotCond_Once);
-// Links an upcoming axis range limits to external values. Set to NULL for no linkage. The pointer data must remain valid until EndPlot!
+// Links an upcoming axis range limits to external values. Set to nullptr for no linkage. The pointer data must remain valid until EndPlot!
 IMPLOT_API void SetNextAxisLinks(ImAxis axis, double* link_min, double* link_max);
 // Set an upcoming axis to auto fit to its data.
 IMPLOT_API void SetNextAxisToFit(ImAxis axis);
@@ -796,7 +939,7 @@ IMPLOT_API void SetNextAxesToFit();
 // [SECTION] Plot Items
 //-----------------------------------------------------------------------------
 
-// The main plotting API is provied below. Call these functions between
+// The main plotting API is provided below. Call these functions between
 // Begin/EndPlot and after any Setup API calls. Each plots data on the current
 // x and y axes, which can be changed with `SetAxis/Axes`.
 //
@@ -809,19 +952,19 @@ IMPLOT_API void SetNextAxesToFit();
 //
 // If you need to plot custom or non-homogenous data you have a few options:
 //
-// 1. If your data is a simple struct/class (e.g. Vector2f), you can use striding.
+// 1. If your data is a simple struct/class (e.g. Vector2f), you can use striding in your ImPlotSpec.
 //    This is the most performant option if applicable.
 //
 //    struct Vector2f { float X, Y; };
 //    ...
 //    Vector2f data[42];
-//    ImPlot::PlotLine("line", &data[0].x, &data[0].y, 42, 0, 0, sizeof(Vector2f));
+//    ImPlot::PlotLine("line", &data[0].x, &data[0].y, 42, {ImPlotProp_Stride, sizeof(Vector2f});
 //
 // 2. Write a custom getter C function or C++ lambda and pass it and optionally your data to
 //    an ImPlot function post-fixed with a G (e.g. PlotScatterG). This has a slight performance
 //    cost, but probably not enough to worry about unless your data is very large. Examples:
 //
-//    ImPlotPoint MyDataGetter(void* data, int idx) {
+//    ImPlotPoint MyDataGetter(int idx, void* data) {
 //        MyData* my_data = (MyData*)data;
 //        ImPlotPoint p;
 //        p.x = my_data->GetTime(idx);
@@ -845,71 +988,83 @@ IMPLOT_API void SetNextAxesToFit();
 // if you try plotting extremely large 64-bit integral types. Proceed with caution!
 
 // Plots a standard 2D line plot.
-IMPLOT_TMP void PlotLine(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotLineFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_TMP void PlotLine(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_API void PlotLineG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotLineFlags flags=0);
+IMPLOT_TMP void PlotLine(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotLine(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_API void PlotLineG(const char* label_id, ImPlotGetter getter, void* data, int count, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
-IMPLOT_TMP void PlotScatter(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotScatterFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_TMP void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_API void PlotScatterG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotScatterFlags flags=0);
+IMPLOT_TMP void PlotScatter(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_API void PlotScatterG(const char* label_id, ImPlotGetter getter, void* data, int count, const ImPlotSpec& spec=ImPlotSpec());
+
+// Plots a bubble graph. #szs are the radius of each bubble in plot units.
+IMPLOT_TMP void PlotBubbles(const char* label_id, const T* values, const T* szs, int count, double xscale=1, double xstart=0, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotBubbles(const char* label_id, const T* xs, const T* ys, const T* szs, int count, const ImPlotSpec& spec=ImPlotSpec());
+
+// Plots a polygon. Points are specified in counter-clockwise order. If concave, make sure to set the Concave flag.
+IMPLOT_TMP void PlotPolygon(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots a a stairstep graph. The y value is continued constantly to the right from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i]
-IMPLOT_TMP void PlotStairs(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotStairsFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_TMP void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_API void PlotStairsG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotStairsFlags flags=0);
+IMPLOT_TMP void PlotStairs(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_API void PlotStairsG(const char* label_id, ImPlotGetter getter, void* data, int count, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set yref to +/-INFINITY for infinite fill extents.
-IMPLOT_TMP void PlotShaded(const char* label_id, const T* values, int count, double yref=0, double xscale=1, double xstart=0, ImPlotShadedFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_TMP void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double yref=0, ImPlotShadedFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_TMP void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_API void PlotShadedG(const char* label_id, ImPlotGetter getter1, void* data1, ImPlotGetter getter2, void* data2, int count, ImPlotShadedFlags flags=0);
+IMPLOT_TMP void PlotShaded(const char* label_id, const T* values, int count, double yref=0, double xscale=1, double xstart=0, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double yref=0, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_API void PlotShadedG(const char* label_id, ImPlotGetter getter1, void* data1, ImPlotGetter getter2, void* data2, int count, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots a bar graph. Vertical by default. #bar_size and #shift are in plot units.
-IMPLOT_TMP void PlotBars(const char* label_id, const T* values, int count, double bar_size=0.67, double shift=0, ImPlotBarsFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_TMP void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_API void PlotBarsG(const char* label_id, ImPlotGetter getter, void* data, int count, double bar_size, ImPlotBarsFlags flags=0);
+IMPLOT_TMP void PlotBars(const char* label_id, const T* values, int count, double bar_size=0.67, double shift=0, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double bar_size, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_API void PlotBarsG(const char* label_id, ImPlotGetter getter, void* data, int count, double bar_size, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots a group of bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
-IMPLOT_TMP void PlotBarGroups(const char* const label_ids[], const T* values, int item_count, int group_count, double group_size=0.67, double shift=0, ImPlotBarGroupsFlags flags=0);
+IMPLOT_TMP void PlotBarGroups(const char* const label_ids[], const T* values, int item_count, int group_count, double group_size=0.67, double shift=0, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
-IMPLOT_TMP void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_TMP void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots stems. Vertical by default.
-IMPLOT_TMP void PlotStems(const char* label_id, const T* values, int count, double ref=0, double scale=1, double start=0, ImPlotStemsFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_TMP void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double ref=0, ImPlotStemsFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotStems(const char* label_id, const T* values, int count, double ref=0, double scale=1, double start=0, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double ref=0, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
-IMPLOT_TMP void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLinesFlags flags=0, int offset=0, int stride=sizeof(T));
+IMPLOT_TMP void PlotInfLines(const char* label_id, const T* values, int count, const ImPlotSpec& spec=ImPlotSpec());
 
-// Plots a pie chart. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
-IMPLOT_TMP void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* label_fmt="%.1f", double angle0=90, ImPlotPieChartFlags flags=0);
+// Plots a pie chart. Center and radius are in plot units. #label_fmt can be set to nullptr for no labels.
+IMPLOT_TMP void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, ImPlotFormatter fmt, void* fmt_data=nullptr, double angle0=90, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_TMP void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* label_fmt="%.1f", double angle0=90, const ImPlotSpec& spec=ImPlotSpec());
 
-// Plots a 2D heatmap chart. Values are expected to be in row-major order by default. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
-IMPLOT_TMP void PlotHeatmap(const char* label_id, const T* values, int rows, int cols, double scale_min=0, double scale_max=0, const char* label_fmt="%.1f", const ImPlotPoint& bounds_min=ImPlotPoint(0,0), const ImPlotPoint& bounds_max=ImPlotPoint(1,1), ImPlotHeatmapFlags flags=0);
+// Plots a 2D heatmap chart. Values are expected to be in row-major order by default. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to nullptr for no labels.
+IMPLOT_TMP void PlotHeatmap(const char* label_id, const T* values, int rows, int cols, double scale_min=0, double scale_max=0, const char* label_fmt="%.1f", const ImPlotPoint& bounds_min=ImPlotPoint(0,0), const ImPlotPoint& bounds_max=ImPlotPoint(1,1), const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #range is left unspecified, the min/max of #values will be used as the range.
 // Otherwise, outlier values outside of the range are not binned. The largest bin count or density is returned.
-IMPLOT_TMP double PlotHistogram(const char* label_id, const T* values, int count, int bins=ImPlotBin_Sturges, double bar_scale=1.0, ImPlotRange range=ImPlotRange(), ImPlotHistogramFlags flags=0);
+IMPLOT_TMP double PlotHistogram(const char* label_id, const T* values, int count, int bins=ImPlotBin_Sturges, double bar_scale=1.0, ImPlotRange range=ImPlotRange(), const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #range is left unspecified, the min/max of
 // #xs an #ys will be used as the ranges. Otherwise, outlier values outside of range are not binned. The largest bin count or density is returned.
-IMPLOT_TMP double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count, int x_bins=ImPlotBin_Sturges, int y_bins=ImPlotBin_Sturges, ImPlotRect range=ImPlotRect(), ImPlotHistogramFlags flags=0);
+IMPLOT_TMP double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count, int x_bins=ImPlotBin_Sturges, int y_bins=ImPlotBin_Sturges, ImPlotRect range=ImPlotRect(), const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
-IMPLOT_TMP void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags=0, int offset=0, int stride=sizeof(T));
-IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotDigitalFlags flags=0);
+IMPLOT_TMP void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec=ImPlotSpec());
+IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotGetter getter, void* data, int count, const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
-IMPLOT_API void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1), ImPlotImageFlags flags=0);
+#ifdef IMGUI_HAS_TEXTURES
+IMPLOT_API void PlotImage(const char* label_id, ImTextureRef tex_ref, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1, 1), const ImVec4& tint_col = ImVec4(1, 1, 1, 1), const ImPlotSpec& spec=ImPlotSpec());
+#else
+IMPLOT_API void PlotImage(const char* label_id, ImTextureID tex_ref, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1), const ImPlotSpec& spec=ImPlotSpec());
+#endif
 
 // Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
-IMPLOT_API void PlotText(const char* text, double x, double y, const ImVec2& pix_offset=ImVec2(0,0), ImPlotTextFlags flags=0);
+IMPLOT_API void PlotText(const char* text, double x, double y, const ImVec2& pix_offset=ImVec2(0,0), const ImPlotSpec& spec=ImPlotSpec());
 
 // Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)
-IMPLOT_API void PlotDummy(const char* label_id, ImPlotDummyFlags flags=0);
+IMPLOT_API void PlotDummy(const char* label_id, const ImPlotSpec& spec=ImPlotSpec());
 
 //-----------------------------------------------------------------------------
 // [SECTION] Plot Tools
@@ -917,16 +1072,18 @@ IMPLOT_API void PlotDummy(const char* label_id, ImPlotDummyFlags flags=0);
 
 // The following can be used to render interactive elements and/or annotations.
 // Like the item plotting functions above, they apply to the current x and y
-// axes, which can be changed with `SetAxis/SetAxes`.
+// axes, which can be changed with `SetAxis/SetAxes`. These functions return true
+// when user interaction causes the provided coordinates to change. Additional
+// user interactions can be retrieved through the optional output parameters.
 
 // Shows a draggable point at x,y. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags=0);
+IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags=0);
+IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags=0);
+IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable and resizeable rectangle.
-IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags=0);
+IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 
 // Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area. Annotations are always rendered on top.
 IMPLOT_API void Annotation(double x, double y, const ImVec4& col, const ImVec2& pix_offset, bool clamp, bool round = false);
@@ -961,7 +1118,7 @@ IMPLOT_API ImVec2 PlotToPixels(double x, double y, ImAxis x_axis = IMPLOT_AUTO, 
 
 // Get the current Plot position (top-left) in pixels.
 IMPLOT_API ImVec2 GetPlotPos();
-// Get the curent Plot size in pixels.
+// Get the current Plot size in pixels.
 IMPLOT_API ImVec2 GetPlotSize();
 
 // Returns the mouse position in x,y coordinates of the current plot. Passing IMPLOT_AUTO uses the current axes.
@@ -1023,7 +1180,7 @@ IMPLOT_API bool BeginDragDropTargetLegend();
 IMPLOT_API void EndDragDropTarget();
 
 // NB: By default, plot and axes drag and drop *sources* require holding the Ctrl modifier to initiate the drag.
-// You can change the modifier if desired. If ImGuiModFlags_None is provided, the axes will be locked from panning.
+// You can change the modifier if desired. If ImGuiMod_None is provided, the axes will be locked from panning.
 
 // Turns the current plot's plotting area into a drag and drop source. You must hold Ctrl. Don't forget to call EndDragDropSource!
 IMPLOT_API bool BeginDragDropSourcePlot(ImGuiDragDropFlags flags=0);
@@ -1037,47 +1194,30 @@ IMPLOT_API void EndDragDropSource();
 //-----------------------------------------------------------------------------
 // [SECTION] Styling
 //-----------------------------------------------------------------------------
-
+    
 // Styling colors in ImPlot works similarly to styling colors in ImGui, but
 // with one important difference. Like ImGui, all style colors are stored in an
 // indexable array in ImPlotStyle. You can permanently modify these values through
 // GetStyle().Colors, or temporarily modify them with Push/Pop functions below.
 // However, by default all style colors in ImPlot default to a special color
-// IMPLOT_AUTO_COL. The behavior of this color depends upon the style color to
-// which it as applied:
-//
-//     1) For style colors associated with plot items (e.g. ImPlotCol_Line),
-//        IMPLOT_AUTO_COL tells ImPlot to color the item with the next unused
-//        color in the current colormap. Thus, every item will have a different
-//        color up to the number of colors in the colormap, at which point the
-//        colormap will roll over. For most use cases, you should not need to
-//        set these style colors to anything but IMPLOT_COL_AUTO; you are
-//        probably better off changing the current colormap. However, if you
-//        need to explicitly color a particular item you may either Push/Pop
-//        the style color around the item in question, or use the SetNextXXXStyle
-//        API below. If you permanently set one of these style colors to a specific
-//        color, or forget to call Pop, then all subsequent items will be styled
-//        with the color you set.
-//
-//     2) For style colors associated with plot styling (e.g. ImPlotCol_PlotBg),
-//        IMPLOT_AUTO_COL tells ImPlot to set that color from color data in your
-//        **ImGuiStyle**. The ImGuiCol_ that these style colors default to are
-//        detailed above, and in general have been mapped to produce plots visually
-//        consistent with your current ImGui style. Of course, you are free to
-//        manually set these colors to whatever you like, and further can Push/Pop
-//        them around individual plots for plot-specific styling (e.g. coloring axes).
+// IMPLOT_AUTO_COL. IMPLOT_AUTO_COL tells ImPlot to set that color from color data
+// in your **ImGuiStyle**. The ImGuiCol_ that these style colors default to are
+// detailed above, and in general have been mapped to produce plots visually
+// consistent with your current ImGui style. Of course, you are free to
+// manually set these colors to whatever you like, and further can Push/Pop
+// them around individual plots for plot-specific styling (e.g. coloring axes).
 
-// Provides access to plot style structure for permanant modifications to colors, sizes, etc.
+// Provides access to plot style structure for permanent modifications to colors, sizes, etc.
 IMPLOT_API ImPlotStyle& GetStyle();
 
 // Style plot colors for current ImGui style (default).
-IMPLOT_API void StyleColorsAuto(ImPlotStyle* dst = NULL);
+IMPLOT_API void StyleColorsAuto(ImPlotStyle* dst = nullptr);
 // Style plot colors for ImGui "Classic".
-IMPLOT_API void StyleColorsClassic(ImPlotStyle* dst = NULL);
+IMPLOT_API void StyleColorsClassic(ImPlotStyle* dst = nullptr);
 // Style plot colors for ImGui "Dark".
-IMPLOT_API void StyleColorsDark(ImPlotStyle* dst = NULL);
+IMPLOT_API void StyleColorsDark(ImPlotStyle* dst = nullptr);
 // Style plot colors for ImGui "Light".
-IMPLOT_API void StyleColorsLight(ImPlotStyle* dst = NULL);
+IMPLOT_API void StyleColorsLight(ImPlotStyle* dst = nullptr);
 
 // Use PushStyleX to temporarily modify your ImPlotStyle. The modification
 // will last until the matching call to PopStyleX. You MUST call a pop for
@@ -1098,20 +1238,6 @@ IMPLOT_API void PushStyleVar(ImPlotStyleVar idx, const ImVec2& val);
 // Undo temporary style variable modification(s). Undo multiple pushes at once by increasing count.
 IMPLOT_API void PopStyleVar(int count = 1);
 
-// The following can be used to modify the style of the next plot item ONLY. They do
-// NOT require calls to PopStyleX. Leave style attributes you don't want modified to
-// IMPLOT_AUTO or IMPLOT_AUTO_COL. Automatic styles will be deduced from the current
-// values in your ImPlotStyle or from Colormap data.
-
-// Set the line color and weight for the next item only.
-IMPLOT_API void SetNextLineStyle(const ImVec4& col = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO);
-// Set the fill color for the next item only.
-IMPLOT_API void SetNextFillStyle(const ImVec4& col = IMPLOT_AUTO_COL, float alpha_mod = IMPLOT_AUTO);
-// Set the marker style for the next item only.
-IMPLOT_API void SetNextMarkerStyle(ImPlotMarker marker = IMPLOT_AUTO, float size = IMPLOT_AUTO, const ImVec4& fill = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO, const ImVec4& outline = IMPLOT_AUTO_COL);
-// Set the error bar style for the next item only.
-IMPLOT_API void SetNextErrorBarStyle(const ImVec4& col = IMPLOT_AUTO_COL, float size = IMPLOT_AUTO, float weight = IMPLOT_AUTO);
-
 // Gets the last item primary color (i.e. its legend icon color)
 IMPLOT_API ImVec4 GetLastItemColor();
 
@@ -1119,6 +1245,9 @@ IMPLOT_API ImVec4 GetLastItemColor();
 IMPLOT_API const char* GetStyleColorName(ImPlotCol idx);
 // Returns the null terminated string name for an ImPlotMarker.
 IMPLOT_API const char* GetMarkerName(ImPlotMarker idx);
+
+// Returns the next marker and advances the marker for the current plot. You need to call this between Begin/EndPlot!
+IMPLOT_API ImPlotMarker NextMarker();
 
 //-----------------------------------------------------------------------------
 // [SECTION] Colormaps
@@ -1144,7 +1273,7 @@ IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImU32*  cols, int 
 
 // Returns the number of available colormaps (i.e. the built-in + user-added count).
 IMPLOT_API int GetColormapCount();
-// Returns a null terminated string name for a colormap given an index. Returns NULL if index is invalid.
+// Returns a null terminated string name for a colormap given an index. Returns nullptr if index is invalid.
 IMPLOT_API const char* GetColormapName(ImPlotColormap cmap);
 // Returns an index number for a colormap given a valid string name. Returns -1 if name is invalid.
 IMPLOT_API ImPlotColormap GetColormapIndex(const char* name);
@@ -1173,30 +1302,30 @@ IMPLOT_API ImVec4 SampleColormap(float t, ImPlotColormap cmap = IMPLOT_AUTO);
 // Shows a vertical color scale with linear spaced ticks using the specified color map. Use double hashes to hide label (e.g. "##NoLabel"). If scale_min > scale_max, the scale to color mapping will be reversed.
 IMPLOT_API void ColormapScale(const char* label, double scale_min, double scale_max, const ImVec2& size = ImVec2(0,0), const char* format = "%g", ImPlotColormapScaleFlags flags = 0, ImPlotColormap cmap = IMPLOT_AUTO);
 // Shows a horizontal slider with a colormap gradient background. Optionally returns the color sampled at t in [0 1].
-IMPLOT_API bool ColormapSlider(const char* label, float* t, ImVec4* out = NULL, const char* format = "", ImPlotColormap cmap = IMPLOT_AUTO);
-// Shows a button with a colormap gradient brackground.
+IMPLOT_API bool ColormapSlider(const char* label, float* t, ImVec4* out = nullptr, const char* format = "", ImPlotColormap cmap = IMPLOT_AUTO);
+// Shows a button with a colormap gradient background.
 IMPLOT_API bool ColormapButton(const char* label, const ImVec2& size = ImVec2(0,0), ImPlotColormap cmap = IMPLOT_AUTO);
 
 // When items in a plot sample their color from a colormap, the color is cached and does not change
-// unless explicitly overriden. Therefore, if you change the colormap after the item has already been plotted,
+// unless explicitly overridden. Therefore, if you change the colormap after the item has already been plotted,
 // item colors will NOT update. If you need item colors to resample the new colormap, then use this
-// function to bust the cached colors. If #plot_title_id is NULL, then every item in EVERY existing plot
+// function to bust the cached colors. If #plot_title_id is nullptr, then every item in EVERY existing plot
 // will be cache busted. Otherwise only the plot specified by #plot_title_id will be busted. For the
 // latter, this function must be called in the same ImGui ID scope that the plot is in. You should rarely if ever
 // need this function, but it is available for applications that require runtime colormap swaps (e.g. Heatmaps demo).
-IMPLOT_API void BustColorCache(const char* plot_title_id = NULL);
+IMPLOT_API void BustColorCache(const char* plot_title_id = nullptr);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Input Mapping
 //-----------------------------------------------------------------------------
 
-// Provides access to input mapping structure for permanant modifications to controls for pan, select, etc.
+// Provides access to input mapping structure for permanent modifications to controls for pan, select, etc.
 IMPLOT_API ImPlotInputMap& GetInputMap();
 
 // Default input mapping: pan = LMB drag, box select = RMB drag, fit = LMB double click, context menu = RMB click, zoom = scroll.
-IMPLOT_API void MapInputDefault(ImPlotInputMap* dst = NULL);
+IMPLOT_API void MapInputDefault(ImPlotInputMap* dst = nullptr);
 // Reverse input mapping: pan = RMB drag, box select = LMB drag, fit = LMB double click, context menu = RMB click, zoom = scroll.
-IMPLOT_API void MapInputReverse(ImPlotInputMap* dst = NULL);
+IMPLOT_API void MapInputReverse(ImPlotInputMap* dst = nullptr);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Miscellaneous
@@ -1221,18 +1350,18 @@ IMPLOT_API bool ShowColormapSelector(const char* label);
 // Shows ImPlot input map selector dropdown menu.
 IMPLOT_API bool ShowInputMapSelector(const char* label);
 // Shows ImPlot style editor block (not a window).
-IMPLOT_API void ShowStyleEditor(ImPlotStyle* ref = NULL);
+IMPLOT_API void ShowStyleEditor(ImPlotStyle* ref = nullptr);
 // Add basic help/info block for end users (not a window).
 IMPLOT_API void ShowUserGuide();
 // Shows ImPlot metrics/debug information window.
-IMPLOT_API void ShowMetricsWindow(bool* p_popen = NULL);
+IMPLOT_API void ShowMetricsWindow(bool* p_popen = nullptr);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Demo
 //-----------------------------------------------------------------------------
 
 // Shows the ImPlot demo window (add implot_demo.cpp to your sources!)
-IMPLOT_API void ShowDemoWindow(bool* p_open = NULL);
+IMPLOT_API void ShowDemoWindow(bool* p_open = nullptr);
 
 }  // namespace ImPlot
 
@@ -1261,26 +1390,19 @@ IMPLOT_API void ShowDemoWindow(bool* p_open = NULL);
 #define IMPLOT_DEPRECATED(method) method
 #endif
 
-enum ImPlotFlagsObsolete_ {
-    ImPlotFlags_YAxis2 = 1 << 20,
-    ImPlotFlags_YAxis3 = 1 << 21,
-};
-
 namespace ImPlot {
 
-// OBSOLETED in v0.13 -> PLANNED REMOVAL in v1.0
-IMPLOT_DEPRECATED( IMPLOT_API bool BeginPlot(const char* title_id,
-                                             const char* x_label,  // = NULL,
-                                             const char* y_label,  // = NULL,
-                                             const ImVec2& size       = ImVec2(-1,0),
-                                             ImPlotFlags flags        = ImPlotFlags_None,
-                                             ImPlotAxisFlags x_flags  = 0,
-                                             ImPlotAxisFlags y_flags  = 0,
-                                             ImPlotAxisFlags y2_flags = ImPlotAxisFlags_AuxDefault,
-                                             ImPlotAxisFlags y3_flags = ImPlotAxisFlags_AuxDefault,
-                                             const char* y2_label     = NULL,
-                                             const char* y3_label     = NULL) );
+// OBSOLETED in v1.0 (from February 2026)
+// IMPLOT_API void SetNextLineStyle(const ImVec4& col = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO); // OBSOLETED IN v1.0 // Set ImPlotSpec.LineColor/LineWeight or construct ImPlotSpec with { ImPlotSpec_LineColor, color, ImPlotSpec_LineWeight, weight }.
+
+// IMPLOT_API void SetNextFillStyle(const ImVec4& col = IMPLOT_AUTO_COL, float alpha_mod = IMPLOT_AUTO);// OBSOLETED IN v1.0 // Set ImPlotSpec.FillColor/FillAlpha or construct ImPlotSpec with { ImPlotSpec_FillColor, color, ImPlotSpec_FillAlpha, alpha }.
+
+// IMPLOT_API void SetNextMarkerStyle(ImPlotMarker marker = IMPLOT_AUTO, float size = IMPLOT_AUTO, const ImVec4& fill = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO, const ImVec4& outline = IMPLOT_AUTO_COL); // OBSOLETED IN v1.0 // Set ImPlotSpec.Marker/MarkerSize/MarkerFillColor/LineWeight/MarkerLineColor or construct ImPlotSpec with { ImPlotSpec_Marker, marker, ImPlotSpec_MarkerSize, size, ImPlotSpec_MarkerFillColor, fill_color, ImPlotSpec_LineWeight, weight, ImPlotSpec_MarkerLineColor, outline }.
+
+// IMPLOT_API void SetNextErrorBarStyle(const ImVec4& col = IMPLOT_AUTO_COL, float size = IMPLOT_AUTO, float weight = IMPLOT_AUTO); // OBSOLETED IN v1.0 // Set ImPlotSpec.LineColor/Size/LineWeight or construct ImPlotSpec with { ImPlotSpec_LineColor, col, ImPlotSpec_Size, size, ImPlotSpec_LineWeight, weight }.
+
 
 } // namespace ImPlot
 
-#endif
+#endif // #ifndef IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
+#endif // #ifndef IMGUI_DISABLE

--- a/lib/implot/implot_internal.h
+++ b/lib/implot/implot_internal.h
@@ -1,0 +1,1670 @@
+// MIT License
+
+// Copyright (c) 2022 Evan Pezent
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ImPlot v0.14
+
+// You may use this file to debug, understand or extend ImPlot features but we
+// don't provide any guarantee of forward compatibility!
+
+//-----------------------------------------------------------------------------
+// [SECTION] Header Mess
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
+
+#include <time.h>
+#include "imgui_internal.h"
+
+#ifndef IMPLOT_VERSION
+#error Must include implot.h before implot_internal.h
+#endif
+
+
+// Support for pre-1.84 versions. ImPool's GetSize() -> GetBufSize()
+#if (IMGUI_VERSION_NUM < 18303)
+#define GetBufSize GetSize
+#endif
+
+//-----------------------------------------------------------------------------
+// [SECTION] Constants
+//-----------------------------------------------------------------------------
+
+// Constants can be changed unless stated otherwise. We may move some of these
+// to ImPlotStyleVar_ over time.
+
+// Mimimum allowable timestamp value 01/01/1970 @ 12:00am (UTC) (DO NOT DECREASE THIS)
+#define IMPLOT_MIN_TIME  0
+// Maximum allowable timestamp value 01/01/3000 @ 12:00am (UTC) (DO NOT INCREASE THIS)
+#define IMPLOT_MAX_TIME  32503680000
+// Default label format for axis labels
+#define IMPLOT_LABEL_FORMAT "%g"
+// Max character size for tick labels
+#define IMPLOT_LABEL_MAX_SIZE 32
+
+//-----------------------------------------------------------------------------
+// [SECTION] Macros
+//-----------------------------------------------------------------------------
+
+#define IMPLOT_NUM_X_AXES ImAxis_Y1
+#define IMPLOT_NUM_Y_AXES (ImAxis_COUNT - IMPLOT_NUM_X_AXES)
+
+// Split ImU32 color into RGB components [0 255]
+#define IM_COL32_SPLIT_RGB(col,r,g,b) \
+    ImU32 r = ((col >> IM_COL32_R_SHIFT) & 0xFF); \
+    ImU32 g = ((col >> IM_COL32_G_SHIFT) & 0xFF); \
+    ImU32 b = ((col >> IM_COL32_B_SHIFT) & 0xFF);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Forward Declarations
+//-----------------------------------------------------------------------------
+
+struct ImPlotTick;
+struct ImPlotAxis;
+struct ImPlotAxisColor;
+struct ImPlotItem;
+struct ImPlotLegend;
+struct ImPlotPlot;
+struct ImPlotNextPlotData;
+struct ImPlotTicker;
+
+//-----------------------------------------------------------------------------
+// [SECTION] Context Pointer
+//-----------------------------------------------------------------------------
+
+#ifndef GImPlot
+extern IMPLOT_API ImPlotContext* GImPlot; // Current implicit context pointer
+#endif
+
+//-----------------------------------------------------------------------------
+// [SECTION] Generic Helpers
+//-----------------------------------------------------------------------------
+
+// Computes the common (base-10) logarithm
+static inline float  ImLog10(float x)  { return log10f(x); }
+static inline double ImLog10(double x) { return log10(x);  }
+static inline float  ImSinh(float x)   { return sinhf(x);  }
+static inline double ImSinh(double x)  { return sinh(x);   }
+static inline float  ImAsinh(float x)  { return asinhf(x); }
+static inline double ImAsinh(double x) { return asinh(x);  }
+// Returns true if a flag is set
+template <typename TSet, typename TFlag>
+static inline bool ImHasFlag(TSet set, TFlag flag) { return (set & flag) == flag; }
+// Flips a flag in a flagset
+template <typename TSet, typename TFlag>
+static inline void ImFlipFlag(TSet& set, TFlag flag) { ImHasFlag(set, flag) ? set &= ~flag : set |= flag; }
+// Linearly remaps x from [x0 x1] to [y0 y1].
+template <typename T>
+static inline T ImRemap(T x, T x0, T x1, T y0, T y1) { return y0 + (x - x0) * (y1 - y0) / (x1 - x0); }
+// Linear rempas x from [x0 x1] to [0 1]
+template <typename T>
+static inline T ImRemap01(T x, T x0, T x1) { return (x - x0) / (x1 - x0); }
+// Returns always positive modulo (assumes r != 0)
+static inline int ImPosMod(int l, int r) { return (l % r + r) % r; }
+// Returns true if val is NAN
+static inline bool ImNan(double val) { return isnan(val); }
+// Returns true if val is NAN or INFINITY
+static inline bool ImNanOrInf(double val) { return !(val >= -DBL_MAX && val <= DBL_MAX) || ImNan(val); }
+// Turns NANs to 0s
+static inline double ImConstrainNan(double val) { return ImNan(val) ? 0 : val; }
+// Turns infinity to floating point maximums
+static inline double ImConstrainInf(double val) { return val >= DBL_MAX ?  DBL_MAX : val <= -DBL_MAX ? - DBL_MAX : val; }
+// Turns numbers less than or equal to 0 to 0.001 (sort of arbitrary, is there a better way?)
+static inline double ImConstrainLog(double val) { return val <= 0 ? 0.001f : val; }
+// Turns numbers less than 0 to zero
+static inline double ImConstrainTime(double val) { return val < IMPLOT_MIN_TIME ? IMPLOT_MIN_TIME : (val > IMPLOT_MAX_TIME ? IMPLOT_MAX_TIME : val); }
+// True if two numbers are approximately equal using units in the last place.
+static inline bool ImAlmostEqual(double v1, double v2, int ulp = 2) { return ImAbs(v1-v2) < DBL_EPSILON * ImAbs(v1+v2) * ulp || ImAbs(v1-v2) < DBL_MIN; }
+// Finds min value in an unsorted array
+template <typename T>
+static inline T ImMinArray(const T* values, int count) { T m = values[0]; for (int i = 1; i < count; ++i) { if (values[i] < m) { m = values[i]; } } return m; }
+// Finds the max value in an unsorted array
+template <typename T>
+static inline T ImMaxArray(const T* values, int count) { T m = values[0]; for (int i = 1; i < count; ++i) { if (values[i] > m) { m = values[i]; } } return m; }
+// Finds the min and max value in an unsorted array
+template <typename T>
+static inline void ImMinMaxArray(const T* values, int count, T* min_out, T* max_out) {
+    T Min = values[0]; T Max = values[0];
+    for (int i = 1; i < count; ++i) {
+        if (values[i] < Min) { Min = values[i]; }
+        if (values[i] > Max) { Max = values[i]; }
+    }
+    *min_out = Min; *max_out = Max;
+}
+// Finds the sim of an array
+template <typename T>
+static inline T ImSum(const T* values, int count) {
+    T sum  = 0;
+    for (int i = 0; i < count; ++i)
+        sum += values[i];
+    return sum;
+}
+// Finds the mean of an array
+template <typename T>
+static inline double ImMean(const T* values, int count) {
+    double den = 1.0 / count;
+    double mu  = 0;
+    for (int i = 0; i < count; ++i)
+        mu += (double)values[i] * den;
+    return mu;
+}
+// Finds the sample standard deviation of an array
+template <typename T>
+static inline double ImStdDev(const T* values, int count) {
+    double den = 1.0 / (count - 1.0);
+    double mu  = ImMean(values, count);
+    double x   = 0;
+    for (int i = 0; i < count; ++i)
+        x += ((double)values[i] - mu) * ((double)values[i] - mu) * den;
+    return sqrt(x);
+}
+// Mix color a and b by factor s in [0 256]
+static inline ImU32 ImMixU32(ImU32 a, ImU32 b, ImU32 s) {
+#ifdef IMPLOT_MIX64
+    const ImU32 af = 256-s;
+    const ImU32 bf = s;
+    const ImU64 al = (a & 0x00ff00ff) | (((ImU64)(a & 0xff00ff00)) << 24);
+    const ImU64 bl = (b & 0x00ff00ff) | (((ImU64)(b & 0xff00ff00)) << 24);
+    const ImU64 mix = (al * af + bl * bf);
+    return ((mix >> 32) & 0xff00ff00) | ((mix & 0xff00ff00) >> 8);
+#else
+    const ImU32 af = 256-s;
+    const ImU32 bf = s;
+    const ImU32 al = (a & 0x00ff00ff);
+    const ImU32 ah = (a & 0xff00ff00) >> 8;
+    const ImU32 bl = (b & 0x00ff00ff);
+    const ImU32 bh = (b & 0xff00ff00) >> 8;
+    const ImU32 ml = (al * af + bl * bf);
+    const ImU32 mh = (ah * af + bh * bf);
+    return (mh & 0xff00ff00) | ((ml & 0xff00ff00) >> 8);
+#endif
+}
+
+// Lerp across an array of 32-bit collors given t in [0.0 1.0]
+static inline ImU32 ImLerpU32(const ImU32* colors, int size, float t) {
+    int i1 = (int)((size - 1 ) * t);
+    int i2 = i1 + 1;
+    if (i2 == size || size == 1)
+        return colors[i1];
+    float den = 1.0f / (size - 1);
+    float t1 = i1 * den;
+    float t2 = i2 * den;
+    float tr = ImRemap01(t, t1, t2);
+    return ImMixU32(colors[i1], colors[i2], (ImU32)(tr*256));
+}
+
+// Set alpha channel of 32-bit color from float in range [0.0 1.0]
+static inline ImU32 ImAlphaU32(ImU32 col, float alpha) {
+    return col & ~((ImU32)((1.0f-alpha)*255)<<IM_COL32_A_SHIFT);
+}
+
+// Returns true of two ranges overlap
+template <typename T>
+static inline bool ImOverlaps(T min_a, T max_a, T min_b, T max_b) {
+    return min_a <= max_b && min_b <= max_a;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] ImPlot Enums
+//-----------------------------------------------------------------------------
+
+typedef int ImPlotTimeUnit;    // -> enum ImPlotTimeUnit_
+typedef int ImPlotDateFmt;     // -> enum ImPlotDateFmt_
+typedef int ImPlotTimeFmt;     // -> enum ImPlotTimeFmt_
+
+enum ImPlotTimeUnit_ {
+    ImPlotTimeUnit_Us,  // microsecond
+    ImPlotTimeUnit_Ms,  // millisecond
+    ImPlotTimeUnit_S,   // second
+    ImPlotTimeUnit_Min, // minute
+    ImPlotTimeUnit_Hr,  // hour
+    ImPlotTimeUnit_Day, // day
+    ImPlotTimeUnit_Mo,  // month
+    ImPlotTimeUnit_Yr,  // year
+    ImPlotTimeUnit_COUNT
+};
+
+enum ImPlotDateFmt_ {              // default        [ ISO 8601     ]
+    ImPlotDateFmt_None = 0,
+    ImPlotDateFmt_DayMo,           // 10/3           [ --10-03      ]
+    ImPlotDateFmt_DayMoYr,         // 10/3/91        [ 1991-10-03   ]
+    ImPlotDateFmt_MoYr,            // Oct 1991       [ 1991-10      ]
+    ImPlotDateFmt_Mo,              // Oct            [ --10         ]
+    ImPlotDateFmt_Yr               // 1991           [ 1991         ]
+};
+
+enum ImPlotTimeFmt_ {              // default        [ 24 Hour Clock ]
+    ImPlotTimeFmt_None = 0,
+    ImPlotTimeFmt_Us,              // .428 552       [ .428 552     ]
+    ImPlotTimeFmt_SUs,             // :29.428 552    [ :29.428 552  ]
+    ImPlotTimeFmt_SMs,             // :29.428        [ :29.428      ]
+    ImPlotTimeFmt_S,               // :29            [ :29          ]
+    ImPlotTimeFmt_MinSMs,          // 21:29.428      [ 21:29.428    ]
+    ImPlotTimeFmt_HrMinSMs,        // 7:21:29.428pm  [ 19:21:29.428 ]
+    ImPlotTimeFmt_HrMinS,          // 7:21:29pm      [ 19:21:29     ]
+    ImPlotTimeFmt_HrMin,           // 7:21pm         [ 19:21        ]
+    ImPlotTimeFmt_Hr               // 7pm            [ 19:00        ]
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Callbacks
+//-----------------------------------------------------------------------------
+
+typedef void (*ImPlotLocator)(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Structs
+//-----------------------------------------------------------------------------
+
+// Combined date/time format spec
+struct ImPlotDateTimeSpec {
+    ImPlotDateTimeSpec() {}
+    ImPlotDateTimeSpec(ImPlotDateFmt date_fmt, ImPlotTimeFmt time_fmt, bool use_24_hr_clk = false, bool use_iso_8601 = false) {
+        Date           = date_fmt;
+        Time           = time_fmt;
+        UseISO8601     = use_iso_8601;
+        Use24HourClock = use_24_hr_clk;
+    }
+    ImPlotDateFmt Date;
+    ImPlotTimeFmt Time;
+    bool UseISO8601;
+    bool Use24HourClock;
+};
+
+// Two part timestamp struct.
+struct ImPlotTime {
+    time_t S;  // second part
+    int    Us; // microsecond part
+    ImPlotTime() { S = 0; Us = 0; }
+    ImPlotTime(time_t s, int us = 0) { S  = s + us / 1000000; Us = us % 1000000; }
+    void RollOver() { S  = S + Us / 1000000;  Us = Us % 1000000; }
+    double ToDouble() const { return (double)S + (double)Us / 1000000.0; }
+    static ImPlotTime FromDouble(double t) { return ImPlotTime((time_t)t, (int)(t * 1000000 - floor(t) * 1000000)); }
+};
+
+static inline ImPlotTime operator+(const ImPlotTime& lhs, const ImPlotTime& rhs)
+{ return ImPlotTime(lhs.S + rhs.S, lhs.Us + rhs.Us); }
+static inline ImPlotTime operator-(const ImPlotTime& lhs, const ImPlotTime& rhs)
+{ return ImPlotTime(lhs.S - rhs.S, lhs.Us - rhs.Us); }
+static inline bool operator==(const ImPlotTime& lhs, const ImPlotTime& rhs)
+{ return lhs.S == rhs.S && lhs.Us == rhs.Us; }
+static inline bool operator<(const ImPlotTime& lhs, const ImPlotTime& rhs)
+{ return lhs.S == rhs.S ? lhs.Us < rhs.Us : lhs.S < rhs.S; }
+static inline bool operator>(const ImPlotTime& lhs, const ImPlotTime& rhs)
+{ return rhs < lhs; }
+static inline bool operator<=(const ImPlotTime& lhs, const ImPlotTime& rhs)
+{ return lhs < rhs || lhs == rhs; }
+static inline bool operator>=(const ImPlotTime& lhs, const ImPlotTime& rhs)
+{ return lhs > rhs || lhs == rhs; }
+
+// Colormap data storage
+struct ImPlotColormapData {
+    ImVector<ImU32> Keys;
+    ImVector<int>   KeyCounts;
+    ImVector<int>   KeyOffsets;
+    ImVector<ImU32> Tables;
+    ImVector<int>   TableSizes;
+    ImVector<int>   TableOffsets;
+    ImGuiTextBuffer Text;
+    ImVector<int>   TextOffsets;
+    ImVector<bool>  Quals;
+    ImGuiStorage    Map;
+    int             Count;
+
+    ImPlotColormapData() { Count = 0; }
+
+    int Append(const char* name, const ImU32* keys, int count, bool qual) {
+        if (GetIndex(name) != -1)
+            return -1;
+        KeyOffsets.push_back(Keys.size());
+        KeyCounts.push_back(count);
+        Keys.reserve(Keys.size()+count);
+        for (int i = 0; i < count; ++i)
+            Keys.push_back(keys[i]);
+        TextOffsets.push_back(Text.size());
+        Text.append(name, name + strlen(name) + 1);
+        Quals.push_back(qual);
+        ImGuiID id = ImHashStr(name);
+        int idx = Count++;
+        Map.SetInt(id,idx);
+        _AppendTable(idx);
+        return idx;
+    }
+
+    void _AppendTable(ImPlotColormap cmap) {
+        int key_count     = GetKeyCount(cmap);
+        const ImU32* keys = GetKeys(cmap);
+        int off = Tables.size();
+        TableOffsets.push_back(off);
+        if (IsQual(cmap)) {
+            Tables.reserve(key_count);
+            for (int i = 0; i < key_count; ++i)
+                Tables.push_back(keys[i]);
+            TableSizes.push_back(key_count);
+        }
+        else {
+            int max_size = 255 * (key_count-1) + 1;
+            Tables.reserve(off + max_size);
+            // ImU32 last = keys[0];
+            // Tables.push_back(last);
+            // int n = 1;
+            for (int i = 0; i < key_count-1; ++i) {
+                for (int s = 0; s < 255; ++s) {
+                    ImU32 a = keys[i];
+                    ImU32 b = keys[i+1];
+                    ImU32 c = ImMixU32(a,b,s);
+                    // if (c != last) {
+                        Tables.push_back(c);
+                        // last = c;
+                        // n++;
+                    // }
+                }
+            }
+            ImU32 c = keys[key_count-1];
+            // if (c != last) {
+                Tables.push_back(c);
+                // n++;
+            // }
+            // TableSizes.push_back(n);
+            TableSizes.push_back(max_size);
+        }
+    }
+
+    void RebuildTables() {
+        Tables.resize(0);
+        TableSizes.resize(0);
+        TableOffsets.resize(0);
+        for (int i = 0; i < Count; ++i)
+            _AppendTable(i);
+    }
+
+    inline bool           IsQual(ImPlotColormap cmap) const                      { return Quals[cmap];                                             }
+    inline const char*    GetName(ImPlotColormap cmap) const                     { return cmap < Count ? Text.Buf.Data + TextOffsets[cmap] : NULL; }
+    inline ImPlotColormap GetIndex(const char* name) const                       { ImGuiID key = ImHashStr(name); return Map.GetInt(key,-1);       }
+
+    inline const ImU32*   GetKeys(ImPlotColormap cmap) const                     { return &Keys[KeyOffsets[cmap]];                                 }
+    inline int            GetKeyCount(ImPlotColormap cmap) const                 { return KeyCounts[cmap];                                         }
+    inline ImU32          GetKeyColor(ImPlotColormap cmap, int idx) const        { return Keys[KeyOffsets[cmap]+idx];                              }
+    inline void           SetKeyColor(ImPlotColormap cmap, int idx, ImU32 value) { Keys[KeyOffsets[cmap]+idx] = value; RebuildTables();            }
+
+    inline const ImU32*   GetTable(ImPlotColormap cmap) const                    { return &Tables[TableOffsets[cmap]];                             }
+    inline int            GetTableSize(ImPlotColormap cmap) const                { return TableSizes[cmap];                                        }
+    inline ImU32          GetTableColor(ImPlotColormap cmap, int idx) const      { return Tables[TableOffsets[cmap]+idx];                          }
+
+    inline ImU32 LerpTable(ImPlotColormap cmap, float t) const {
+        int off = TableOffsets[cmap];
+        int siz = TableSizes[cmap];
+        int idx = Quals[cmap] ? ImClamp((int)(siz*t),0,siz-1) : (int)((siz - 1) * t + 0.5f);
+        return Tables[off + idx];
+    }
+};
+
+// ImPlotPoint with positive/negative error values
+struct ImPlotPointError {
+    double X, Y, Neg, Pos;
+    ImPlotPointError(double x, double y, double neg, double pos) {
+        X = x; Y = y; Neg = neg; Pos = pos;
+    }
+};
+
+// Interior plot label/annotation
+struct ImPlotAnnotation {
+    ImVec2 Pos;
+    ImVec2 Offset;
+    ImU32  ColorBg;
+    ImU32  ColorFg;
+    int    TextOffset;
+    bool   Clamp;
+    ImPlotAnnotation() {
+        ColorBg = ColorFg = 0;
+        TextOffset = 0;
+        Clamp = false;
+    }
+};
+
+// Collection of plot labels
+struct ImPlotAnnotationCollection {
+
+    ImVector<ImPlotAnnotation> Annotations;
+    ImGuiTextBuffer            TextBuffer;
+    int                        Size;
+
+    ImPlotAnnotationCollection() { Reset(); }
+
+    void AppendV(const ImVec2& pos, const ImVec2& off, ImU32 bg, ImU32 fg, bool clamp, const char* fmt,  va_list args) IM_FMTLIST(7) {
+        ImPlotAnnotation an;
+        an.Pos = pos; an.Offset = off;
+        an.ColorBg = bg; an.ColorFg = fg;
+        an.TextOffset = TextBuffer.size();
+        an.Clamp = clamp;
+        Annotations.push_back(an);
+        TextBuffer.appendfv(fmt, args);
+        const char nul[] = "";
+        TextBuffer.append(nul,nul+1);
+        Size++;
+    }
+
+    void Append(const ImVec2& pos, const ImVec2& off, ImU32 bg, ImU32 fg, bool clamp, const char* fmt,  ...) IM_FMTARGS(7) {
+        va_list args;
+        va_start(args, fmt);
+        AppendV(pos, off, bg, fg, clamp, fmt, args);
+        va_end(args);
+    }
+
+    const char* GetText(int idx) {
+        return TextBuffer.Buf.Data + Annotations[idx].TextOffset;
+    }
+
+    void Reset() {
+        Annotations.shrink(0);
+        TextBuffer.Buf.shrink(0);
+        Size = 0;
+    }
+};
+
+struct ImPlotTag {
+    ImAxis Axis;
+    double Value;
+    ImU32  ColorBg;
+    ImU32  ColorFg;
+    int    TextOffset;
+};
+
+struct ImPlotTagCollection {
+
+    ImVector<ImPlotTag> Tags;
+    ImGuiTextBuffer     TextBuffer;
+    int                 Size;
+
+    ImPlotTagCollection() { Reset(); }
+
+    void AppendV(ImAxis axis, double value, ImU32 bg, ImU32 fg, const char* fmt, va_list args) IM_FMTLIST(6) {
+        ImPlotTag tag;
+        tag.Axis = axis;
+        tag.Value = value;
+        tag.ColorBg = bg;
+        tag.ColorFg = fg;
+        tag.TextOffset = TextBuffer.size();
+        Tags.push_back(tag);
+        TextBuffer.appendfv(fmt, args);
+        const char nul[] = "";
+        TextBuffer.append(nul,nul+1);
+        Size++;
+    }
+
+    void Append(ImAxis axis, double value, ImU32 bg, ImU32 fg, const char* fmt, ...) IM_FMTARGS(6) {
+        va_list args;
+        va_start(args, fmt);
+        AppendV(axis, value, bg, fg, fmt, args);
+        va_end(args);
+    }
+
+    const char* GetText(int idx) {
+        return TextBuffer.Buf.Data + Tags[idx].TextOffset;
+    }
+
+    void Reset() {
+        Tags.shrink(0);
+        TextBuffer.Buf.shrink(0);
+        Size = 0;
+    }
+};
+
+// Tick mark info
+struct ImPlotTick
+{
+    double PlotPos;
+    float  PixelPos;
+    ImVec2 LabelSize;
+    int    TextOffset;
+    bool   Major;
+    bool   ShowLabel;
+    int    Level;
+    int    Idx;
+
+    ImPlotTick(double value, bool major, int level, bool show_label) {
+        PixelPos     = 0;
+        PlotPos      = value;
+        Major        = major;
+        ShowLabel    = show_label;
+        Level        = level;
+        TextOffset   = -1;
+    }
+};
+
+// Collection of ticks
+struct ImPlotTicker {
+    ImVector<ImPlotTick> Ticks;
+    ImGuiTextBuffer      TextBuffer;
+    ImVec2               MaxSize;
+    ImVec2               LateSize;
+    int                  Levels;
+
+    ImPlotTicker() {
+        Reset();
+    }
+
+    ImPlotTick& AddTick(double value, bool major, int level, bool show_label, const char* label) {
+        ImPlotTick tick(value, major, level, show_label);
+        if (show_label && label != NULL) {
+            tick.TextOffset = TextBuffer.size();
+            TextBuffer.append(label, label + strlen(label) + 1);
+            tick.LabelSize = ImGui::CalcTextSize(TextBuffer.Buf.Data + tick.TextOffset);
+        }
+        return AddTick(tick);
+    }
+
+    ImPlotTick& AddTick(double value, bool major, int level, bool show_label, ImPlotFormatter formatter, void* data) {
+        ImPlotTick tick(value, major, level, show_label);
+        if (show_label && formatter != NULL) {
+            char buff[IMPLOT_LABEL_MAX_SIZE];
+            tick.TextOffset = TextBuffer.size();
+            formatter(tick.PlotPos, buff, sizeof(buff), data);
+            TextBuffer.append(buff, buff + strlen(buff) + 1);
+            tick.LabelSize = ImGui::CalcTextSize(TextBuffer.Buf.Data + tick.TextOffset);
+        }
+        return AddTick(tick);
+    }
+
+    inline ImPlotTick& AddTick(ImPlotTick tick) {
+        if (tick.ShowLabel) {
+            MaxSize.x     =  tick.LabelSize.x > MaxSize.x ? tick.LabelSize.x : MaxSize.x;
+            MaxSize.y     =  tick.LabelSize.y > MaxSize.y ? tick.LabelSize.y : MaxSize.y;
+        }
+        tick.Idx = Ticks.size();
+        Ticks.push_back(tick);
+        return Ticks.back();
+    }
+
+    const char* GetText(int idx) const {
+        return TextBuffer.Buf.Data + Ticks[idx].TextOffset;
+    }
+
+    const char* GetText(const ImPlotTick& tick) {
+        return GetText(tick.Idx);
+    }
+
+    void OverrideSizeLate(const ImVec2& size) {
+        LateSize.x = size.x > LateSize.x ? size.x : LateSize.x;
+        LateSize.y = size.y > LateSize.y ? size.y : LateSize.y;
+    }
+
+    void Reset() {
+        Ticks.shrink(0);
+        TextBuffer.Buf.shrink(0);
+        MaxSize = LateSize;
+        LateSize = ImVec2(0,0);
+        Levels = 1;
+    }
+
+    int TickCount() const {
+        return Ticks.Size;
+    }
+};
+
+// Axis state information that must persist after EndPlot
+struct ImPlotAxis
+{
+    ImGuiID              ID;
+    ImPlotAxisFlags      Flags;
+    ImPlotAxisFlags      PreviousFlags;
+    ImPlotRange          Range;
+    ImPlotCond           RangeCond;
+    ImPlotScale          Scale;
+    ImPlotRange          FitExtents;
+    ImPlotAxis*          OrthoAxis;
+    ImPlotRange          ConstraintRange;
+    ImPlotRange          ConstraintZoom;
+
+    ImPlotTicker         Ticker;
+    ImPlotFormatter      Formatter;
+    void*                FormatterData;
+    char                 FormatSpec[16];
+    ImPlotLocator        Locator;
+
+    double*              LinkedMin;
+    double*              LinkedMax;
+
+    int                  PickerLevel;
+    ImPlotTime           PickerTimeMin, PickerTimeMax;
+
+    ImPlotTransform      TransformForward;
+    ImPlotTransform      TransformInverse;
+    void*                TransformData;
+    float                PixelMin, PixelMax;
+    double               ScaleMin, ScaleMax;
+    double               ScaleToPixel;
+    float                Datum1, Datum2;
+
+    ImRect               HoverRect;
+    int                  LabelOffset;
+    ImU32                ColorMaj, ColorMin, ColorTick, ColorTxt, ColorBg, ColorHov, ColorAct, ColorHiLi;
+
+    bool                 Enabled;
+    bool                 Vertical;
+    bool                 FitThisFrame;
+    bool                 HasRange;
+    bool                 HasFormatSpec;
+    bool                 ShowDefaultTicks;
+    bool                 Hovered;
+    bool                 Held;
+
+    ImPlotAxis() {
+        ID               = 0;
+        Flags            = PreviousFlags = ImPlotAxisFlags_None;
+        Range.Min        = 0;
+        Range.Max        = 1;
+        Scale            = ImPlotScale_Linear;
+        TransformForward = TransformInverse = NULL;
+        TransformData    = NULL;
+        FitExtents.Min   = HUGE_VAL;
+        FitExtents.Max   = -HUGE_VAL;
+        OrthoAxis        = NULL;
+        ConstraintRange  = ImPlotRange(-INFINITY,INFINITY);
+        ConstraintZoom   = ImPlotRange(DBL_MIN,INFINITY);
+        LinkedMin        = LinkedMax = NULL;
+        PickerLevel      = 0;
+        Datum1           = Datum2 = 0;
+        PixelMin         = PixelMax = 0;
+        LabelOffset      = -1;
+        ColorMaj         = ColorMin = ColorTick = ColorTxt = ColorBg = ColorHov = ColorAct = 0;
+        ColorHiLi        = IM_COL32_BLACK_TRANS;
+        Formatter        = NULL;
+        FormatterData    = NULL;
+        Locator          = NULL;
+        Enabled          = Hovered = Held = FitThisFrame = HasRange = HasFormatSpec = false;
+        ShowDefaultTicks = true;
+    }
+
+    inline void Reset() {
+        Enabled          = false;
+        Scale            = ImPlotScale_Linear;
+        TransformForward = TransformInverse = NULL;
+        TransformData    = NULL;
+        LabelOffset      = -1;
+        HasFormatSpec    = false;
+        Formatter        = NULL;
+        FormatterData    = NULL;
+        Locator          = NULL;
+        ShowDefaultTicks = true;
+        FitThisFrame     = false;
+        FitExtents.Min   = HUGE_VAL;
+        FitExtents.Max   = -HUGE_VAL;
+        OrthoAxis        = NULL;
+        ConstraintRange  = ImPlotRange(-INFINITY,INFINITY);
+        ConstraintZoom   = ImPlotRange(DBL_MIN,INFINITY);
+        Ticker.Reset();
+    }
+
+    inline bool SetMin(double _min, bool force=false) {
+        if (!force && IsLockedMin())
+            return false;
+        _min = ImConstrainNan(ImConstrainInf(_min));
+        if (_min < ConstraintRange.Min)
+            _min = ConstraintRange.Min;
+        double z = Range.Max - _min;
+        if (z < ConstraintZoom.Min)
+            _min = Range.Max - ConstraintZoom.Min;
+        if (z > ConstraintZoom.Max)
+            _min = Range.Max - ConstraintZoom.Max;
+        if (_min >= Range.Max)
+            return false;
+        Range.Min = _min;
+        PickerTimeMin = ImPlotTime::FromDouble(Range.Min);
+        UpdateTransformCache();
+        return true;
+    };
+
+    inline bool SetMax(double _max, bool force=false) {
+        if (!force && IsLockedMax())
+            return false;
+        _max = ImConstrainNan(ImConstrainInf(_max));
+        if (_max > ConstraintRange.Max)
+            _max = ConstraintRange.Max;
+        double z = _max - Range.Min;
+        if (z < ConstraintZoom.Min)
+            _max = Range.Min + ConstraintZoom.Min;
+        if (z > ConstraintZoom.Max)
+            _max = Range.Min + ConstraintZoom.Max;
+        if (_max <= Range.Min)
+            return false;
+        Range.Max = _max;
+        PickerTimeMax = ImPlotTime::FromDouble(Range.Max);
+        UpdateTransformCache();
+        return true;
+    };
+
+    inline void SetRange(double v1, double v2) {
+        Range.Min = ImMin(v1,v2);
+        Range.Max = ImMax(v1,v2);
+        Constrain();
+        PickerTimeMin = ImPlotTime::FromDouble(Range.Min);
+        PickerTimeMax = ImPlotTime::FromDouble(Range.Max);
+        UpdateTransformCache();
+    }
+
+    inline void SetRange(const ImPlotRange& range) {
+        SetRange(range.Min, range.Max);
+    }
+
+    inline void SetAspect(double unit_per_pix) {
+        double new_size = unit_per_pix * PixelSize();
+        double delta    = (new_size - Range.Size()) * 0.5;
+        if (IsLocked())
+            return;
+        else if (IsLockedMin() && !IsLockedMax())
+            SetRange(Range.Min, Range.Max  + 2*delta);
+        else if (!IsLockedMin() && IsLockedMax())
+            SetRange(Range.Min - 2*delta, Range.Max);
+        else
+            SetRange(Range.Min - delta, Range.Max + delta);
+    }
+
+    inline float PixelSize() const { return ImAbs(PixelMax - PixelMin); }
+
+    inline double GetAspect() const { return Range.Size() / PixelSize(); }
+
+    inline void Constrain() {
+        Range.Min = ImConstrainNan(ImConstrainInf(Range.Min));
+        Range.Max = ImConstrainNan(ImConstrainInf(Range.Max));
+        if (Range.Min < ConstraintRange.Min)
+            Range.Min = ConstraintRange.Min;
+        if (Range.Max > ConstraintRange.Max)
+            Range.Max = ConstraintRange.Max;
+        double z = Range.Size();
+        if (z < ConstraintZoom.Min) {
+            double delta = (ConstraintZoom.Min - z) * 0.5;
+            Range.Min -= delta;
+            Range.Max += delta;
+        }
+        if (z > ConstraintZoom.Max) {
+            double delta = (z - ConstraintZoom.Max) * 0.5;
+            Range.Min += delta;
+            Range.Max -= delta;
+        }
+        if (Range.Max <= Range.Min)
+            Range.Max = Range.Min + DBL_EPSILON;
+    }
+
+    inline void UpdateTransformCache() {
+        ScaleToPixel = (PixelMax - PixelMin) / Range.Size();
+        if (TransformForward != NULL) {
+            ScaleMin = TransformForward(Range.Min, TransformData);
+            ScaleMax = TransformForward(Range.Max, TransformData);
+        }
+        else {
+            ScaleMin = Range.Min;
+            ScaleMax = Range.Max;
+        }
+    }
+
+    inline float PlotToPixels(double plt) const {
+        if (TransformForward != NULL) {
+            double s = TransformForward(plt, TransformData);
+            double t = (s - ScaleMin) / (ScaleMax - ScaleMin);
+            plt      = Range.Min + Range.Size() * t;
+        }
+        return (float)(PixelMin + ScaleToPixel * (plt - Range.Min));
+    }
+
+
+    inline double PixelsToPlot(float pix) const {
+        double plt = (pix - PixelMin) / ScaleToPixel + Range.Min;
+        if (TransformInverse != NULL) {
+            double t = (plt - Range.Min) / Range.Size();
+            double s = t * (ScaleMax - ScaleMin) + ScaleMin;
+            plt = TransformInverse(s, TransformData);
+        }
+        return plt;
+    }
+
+    inline void ExtendFit(double v) {
+        if (!ImNanOrInf(v) && v >= ConstraintRange.Min && v <= ConstraintRange.Max) {
+            FitExtents.Min = v < FitExtents.Min ? v : FitExtents.Min;
+            FitExtents.Max = v > FitExtents.Max ? v : FitExtents.Max;
+        }
+    }
+
+    inline void ExtendFitWith(ImPlotAxis& alt, double v, double v_alt) {
+        if (ImHasFlag(Flags, ImPlotAxisFlags_RangeFit) && !alt.Range.Contains(v_alt))
+            return;
+        if (!ImNanOrInf(v) && v >= ConstraintRange.Min && v <= ConstraintRange.Max) {
+            FitExtents.Min = v < FitExtents.Min ? v : FitExtents.Min;
+            FitExtents.Max = v > FitExtents.Max ? v : FitExtents.Max;
+        }
+    }
+
+    inline void ApplyFit(float padding) {
+        const double ext_size = FitExtents.Size() * 0.5;
+        FitExtents.Min -= ext_size * padding;
+        FitExtents.Max += ext_size * padding;
+        if (!IsLockedMin() && !ImNanOrInf(FitExtents.Min))
+            Range.Min = FitExtents.Min;
+        if (!IsLockedMax() && !ImNanOrInf(FitExtents.Max))
+            Range.Max = FitExtents.Max;
+        if (ImAlmostEqual(Range.Min, Range.Max))  {
+            Range.Max += 0.5;
+            Range.Min -= 0.5;
+        }
+        Constrain();
+        UpdateTransformCache();
+    }
+
+    inline bool HasLabel()          const { return LabelOffset != -1 && !ImHasFlag(Flags, ImPlotAxisFlags_NoLabel);                          }
+    inline bool HasGridLines()      const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoGridLines);                                           }
+    inline bool HasTickLabels()     const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoTickLabels);                                          }
+    inline bool HasTickMarks()      const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoTickMarks);                                           }
+    inline bool WillRender()        const { return Enabled && (HasGridLines() || HasTickLabels() || HasTickMarks());                         }
+    inline bool IsOpposite()        const { return ImHasFlag(Flags, ImPlotAxisFlags_Opposite);                                               }
+    inline bool IsInverted()        const { return ImHasFlag(Flags, ImPlotAxisFlags_Invert);                                                 }
+    inline bool IsForeground()      const { return ImHasFlag(Flags, ImPlotAxisFlags_Foreground);                                             }
+    inline bool IsAutoFitting()     const { return ImHasFlag(Flags, ImPlotAxisFlags_AutoFit);                                                }
+    inline bool CanInitFit()        const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoInitialFit) && !HasRange && !LinkedMin && !LinkedMax; }
+    inline bool IsRangeLocked()     const { return HasRange && RangeCond == ImPlotCond_Always;                                               }
+    inline bool IsLockedMin()       const { return !Enabled || IsRangeLocked() || ImHasFlag(Flags, ImPlotAxisFlags_LockMin);                 }
+    inline bool IsLockedMax()       const { return !Enabled || IsRangeLocked() || ImHasFlag(Flags, ImPlotAxisFlags_LockMax);                 }
+    inline bool IsLocked()          const { return IsLockedMin() && IsLockedMax();                                                           }
+    inline bool IsInputLockedMin()  const { return IsLockedMin() || IsAutoFitting();                                                         }
+    inline bool IsInputLockedMax()  const { return IsLockedMax() || IsAutoFitting();                                                         }
+    inline bool IsInputLocked()     const { return IsLocked()    || IsAutoFitting();                                                         }
+    inline bool HasMenus()          const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoMenus);                                               }
+
+    inline bool IsPanLocked(bool increasing) {
+        if (ImHasFlag(Flags, ImPlotAxisFlags_PanStretch)) {
+            return IsInputLocked();
+        }
+        else {
+            if (IsLockedMin() || IsLockedMax() || IsAutoFitting())
+                return false;
+            if (increasing)
+                return Range.Max == ConstraintRange.Max;
+            else
+                return Range.Min == ConstraintRange.Min;
+        }
+    }
+
+    void PushLinks() {
+        if (LinkedMin) { *LinkedMin = Range.Min; }
+        if (LinkedMax) { *LinkedMax = Range.Max; }
+    }
+
+    void PullLinks() {
+        if (LinkedMin) { SetMin(*LinkedMin,true); }
+        if (LinkedMax) { SetMax(*LinkedMax,true); }
+    }
+};
+
+// Align plots group data
+struct ImPlotAlignmentData {
+    bool  Vertical;
+    float PadA;
+    float PadB;
+    float PadAMax;
+    float PadBMax;
+    ImPlotAlignmentData() {
+        Vertical    = true;
+        PadA = PadB = PadAMax = PadBMax = 0;
+    }
+    void Begin() { PadAMax = PadBMax = 0; }
+    void Update(float& pad_a, float& pad_b, float& delta_a, float& delta_b) {
+        float bak_a = pad_a; float bak_b = pad_b;
+        if (PadAMax < pad_a) { PadAMax = pad_a; }
+        if (PadBMax < pad_b) { PadBMax = pad_b; }
+        if (pad_a < PadA)    { pad_a = PadA; delta_a = pad_a - bak_a; } else { delta_a = 0; }
+        if (pad_b < PadB)    { pad_b = PadB; delta_b = pad_b - bak_b; } else { delta_b = 0; }
+    }
+    void End()   { PadA = PadAMax; PadB = PadBMax;      }
+    void Reset() { PadA = PadB = PadAMax = PadBMax = 0; }
+};
+
+// State information for Plot items
+struct ImPlotItem
+{
+    ImGuiID      ID;
+    ImU32        Color;
+    ImRect       LegendHoverRect;
+    int          NameOffset;
+    bool         Show;
+    bool         LegendHovered;
+    bool         SeenThisFrame;
+
+    ImPlotItem() {
+        ID            = 0;
+        Color         = IM_COL32_WHITE;
+        NameOffset    = -1;
+        Show          = true;
+        SeenThisFrame = false;
+        LegendHovered = false;
+    }
+
+    ~ImPlotItem() { ID = 0; }
+};
+
+// Holds Legend state
+struct ImPlotLegend
+{
+    ImPlotLegendFlags Flags;
+    ImPlotLegendFlags PreviousFlags;
+    ImPlotLocation    Location;
+    ImPlotLocation    PreviousLocation;
+    ImVector<int>     Indices;
+    ImGuiTextBuffer   Labels;
+    ImRect            Rect;
+    bool              Hovered;
+    bool              Held;
+    bool              CanGoInside;
+
+    ImPlotLegend() {
+        Flags        = PreviousFlags = ImPlotLegendFlags_None;
+        CanGoInside  = true;
+        Hovered      = Held = false;
+        Location     = PreviousLocation = ImPlotLocation_NorthWest;
+    }
+
+    void Reset() { Indices.shrink(0); Labels.Buf.shrink(0); }
+};
+
+// Holds Items and Legend data
+struct ImPlotItemGroup
+{
+    ImGuiID            ID;
+    ImPlotLegend       Legend;
+    ImPool<ImPlotItem> ItemPool;
+    int                ColormapIdx;
+
+    ImPlotItemGroup() { ID = 0; ColormapIdx = 0; }
+
+    int         GetItemCount() const             { return ItemPool.GetBufSize();                                 }
+    ImGuiID     GetItemID(const char*  label_id) { return ImGui::GetID(label_id); /* GetIDWithSeed */            }
+    ImPlotItem* GetItem(ImGuiID id)              { return ItemPool.GetByKey(id);                                 }
+    ImPlotItem* GetItem(const char* label_id)    { return GetItem(GetItemID(label_id));                          }
+    ImPlotItem* GetOrAddItem(ImGuiID id)         { return ItemPool.GetOrAddByKey(id);                            }
+    ImPlotItem* GetItemByIndex(int i)            { return ItemPool.GetByIndex(i);                                }
+    int         GetItemIndex(ImPlotItem* item)   { return ItemPool.GetIndex(item);                               }
+    int         GetLegendCount() const           { return Legend.Indices.size();                                 }
+    ImPlotItem* GetLegendItem(int i)             { return ItemPool.GetByIndex(Legend.Indices[i]);                }
+    const char* GetLegendLabel(int i)            { return Legend.Labels.Buf.Data + GetLegendItem(i)->NameOffset; }
+    void        Reset()                          { ItemPool.Clear(); Legend.Reset(); ColormapIdx = 0;            }
+};
+
+// Holds Plot state information that must persist after EndPlot
+struct ImPlotPlot
+{
+    ImGuiID              ID;
+    ImPlotFlags          Flags;
+    ImPlotFlags          PreviousFlags;
+    ImPlotLocation       MouseTextLocation;
+    ImPlotMouseTextFlags MouseTextFlags;
+    ImPlotAxis           Axes[ImAxis_COUNT];
+    ImGuiTextBuffer      TextBuffer;
+    ImPlotItemGroup      Items;
+    ImAxis               CurrentX;
+    ImAxis               CurrentY;
+    ImRect               FrameRect;
+    ImRect               CanvasRect;
+    ImRect               PlotRect;
+    ImRect               AxesRect;
+    ImRect               SelectRect;
+    ImVec2               SelectStart;
+    int                  TitleOffset;
+    bool                 JustCreated;
+    bool                 Initialized;
+    bool                 SetupLocked;
+    bool                 FitThisFrame;
+    bool                 Hovered;
+    bool                 Held;
+    bool                 Selecting;
+    bool                 Selected;
+    bool                 ContextLocked;
+
+    ImPlotPlot() {
+        Flags             = PreviousFlags = ImPlotFlags_None;
+        for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i)
+            XAxis(i).Vertical = false;
+        for (int i = 0; i < IMPLOT_NUM_Y_AXES; ++i)
+            YAxis(i).Vertical = true;
+        SelectStart       = ImVec2(0,0);
+        CurrentX          = ImAxis_X1;
+        CurrentY          = ImAxis_Y1;
+        MouseTextLocation  = ImPlotLocation_South | ImPlotLocation_East;
+        MouseTextFlags     = ImPlotMouseTextFlags_None;
+        TitleOffset       = -1;
+        JustCreated       = true;
+        Initialized = SetupLocked = FitThisFrame = false;
+        Hovered = Held = Selected = Selecting = ContextLocked = false;
+    }
+
+    inline bool IsInputLocked() const {
+        for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i) {
+            if (!XAxis(i).IsInputLocked())
+                return false;
+        }
+        for (int i = 0; i < IMPLOT_NUM_Y_AXES; ++i) {
+            if (!YAxis(i).IsInputLocked())
+                return false;
+        }
+        return true;
+    }
+
+    inline void ClearTextBuffer() { TextBuffer.Buf.shrink(0); }
+
+    inline void SetTitle(const char* title) {
+        if (title && ImGui::FindRenderedTextEnd(title, NULL) != title) {
+            TitleOffset = TextBuffer.size();
+            TextBuffer.append(title, title + strlen(title) + 1);
+        }
+        else {
+            TitleOffset = -1;
+        }
+    }
+    inline bool HasTitle() const { return TitleOffset != -1 && !ImHasFlag(Flags, ImPlotFlags_NoTitle); }
+    inline const char* GetTitle() const { return TextBuffer.Buf.Data + TitleOffset; }
+
+    inline       ImPlotAxis& XAxis(int i)       { return Axes[ImAxis_X1 + i]; }
+    inline const ImPlotAxis& XAxis(int i) const { return Axes[ImAxis_X1 + i]; }
+    inline       ImPlotAxis& YAxis(int i)       { return Axes[ImAxis_Y1 + i]; }
+    inline const ImPlotAxis& YAxis(int i) const { return Axes[ImAxis_Y1 + i]; }
+
+    inline int EnabledAxesX() {
+        int cnt = 0;
+        for (int i = 0; i < IMPLOT_NUM_X_AXES; ++i)
+            cnt += XAxis(i).Enabled;
+        return cnt;
+    }
+
+    inline int EnabledAxesY() {
+        int cnt = 0;
+        for (int i = 0; i < IMPLOT_NUM_Y_AXES; ++i)
+            cnt += YAxis(i).Enabled;
+        return cnt;
+    }
+
+    inline void SetAxisLabel(ImPlotAxis& axis, const char* label) {
+        if (label && ImGui::FindRenderedTextEnd(label, NULL) != label) {
+            axis.LabelOffset = TextBuffer.size();
+            TextBuffer.append(label, label + strlen(label) + 1);
+        }
+        else {
+            axis.LabelOffset = -1;
+        }
+    }
+
+    inline const char* GetAxisLabel(const ImPlotAxis& axis) const { return TextBuffer.Buf.Data + axis.LabelOffset; }
+};
+
+// Holds subplot data that must persist after EndSubplot
+struct ImPlotSubplot {
+    ImGuiID                       ID;
+    ImPlotSubplotFlags            Flags;
+    ImPlotSubplotFlags            PreviousFlags;
+    ImPlotItemGroup               Items;
+    int                           Rows;
+    int                           Cols;
+    int                           CurrentIdx;
+    ImRect                        FrameRect;
+    ImRect                        GridRect;
+    ImVec2                        CellSize;
+    ImVector<ImPlotAlignmentData> RowAlignmentData;
+    ImVector<ImPlotAlignmentData> ColAlignmentData;
+    ImVector<float>               RowRatios;
+    ImVector<float>               ColRatios;
+    ImVector<ImPlotRange>         RowLinkData;
+    ImVector<ImPlotRange>         ColLinkData;
+    float                         TempSizes[2];
+    bool                          FrameHovered;
+    bool                          HasTitle;
+
+    ImPlotSubplot() {
+        ID                          = 0;
+        Flags = PreviousFlags       = ImPlotSubplotFlags_None;
+        Rows = Cols = CurrentIdx    = 0;
+        FrameHovered                = false;
+        Items.Legend.Location       = ImPlotLocation_North;
+        Items.Legend.Flags          = ImPlotLegendFlags_Horizontal|ImPlotLegendFlags_Outside;
+        Items.Legend.CanGoInside    = false;
+        TempSizes[0] = TempSizes[1] = 0;
+        FrameHovered                = false;
+        HasTitle                    = false;
+    }
+};
+
+// Temporary data storage for upcoming plot
+struct ImPlotNextPlotData
+{
+    ImPlotCond  RangeCond[ImAxis_COUNT];
+    ImPlotRange Range[ImAxis_COUNT];
+    bool        HasRange[ImAxis_COUNT];
+    bool        Fit[ImAxis_COUNT];
+    double*     LinkedMin[ImAxis_COUNT];
+    double*     LinkedMax[ImAxis_COUNT];
+
+    ImPlotNextPlotData() { Reset(); }
+
+    void Reset() {
+        for (int i = 0; i < ImAxis_COUNT; ++i) {
+            HasRange[i]                 = false;
+            Fit[i]                      = false;
+            LinkedMin[i] = LinkedMax[i] = NULL;
+        }
+    }
+
+};
+
+// Temporary data storage for upcoming item
+struct ImPlotNextItemData {
+    ImVec4          Colors[5]; // ImPlotCol_Line, ImPlotCol_Fill, ImPlotCol_MarkerOutline, ImPlotCol_MarkerFill, ImPlotCol_ErrorBar
+    float           LineWeight;
+    ImPlotMarker    Marker;
+    float           MarkerSize;
+    float           MarkerWeight;
+    float           FillAlpha;
+    float           ErrorBarSize;
+    float           ErrorBarWeight;
+    float           DigitalBitHeight;
+    float           DigitalBitGap;
+    bool            RenderLine;
+    bool            RenderFill;
+    bool            RenderMarkerLine;
+    bool            RenderMarkerFill;
+    bool            HasHidden;
+    bool            Hidden;
+    ImPlotCond      HiddenCond;
+    ImPlotNextItemData() { Reset(); }
+    void Reset() {
+        for (int i = 0; i < 5; ++i)
+            Colors[i] = IMPLOT_AUTO_COL;
+        LineWeight    = MarkerSize = MarkerWeight = FillAlpha = ErrorBarSize = ErrorBarWeight = DigitalBitHeight = DigitalBitGap = IMPLOT_AUTO;
+        Marker        = IMPLOT_AUTO;
+        HasHidden     = Hidden = false;
+    }
+};
+
+// Holds state information that must persist between calls to BeginPlot()/EndPlot()
+struct ImPlotContext {
+    // Plot States
+    ImPool<ImPlotPlot>    Plots;
+    ImPool<ImPlotSubplot> Subplots;
+    ImPlotPlot*           CurrentPlot;
+    ImPlotSubplot*        CurrentSubplot;
+    ImPlotItemGroup*      CurrentItems;
+    ImPlotItem*           CurrentItem;
+    ImPlotItem*           PreviousItem;
+
+    // Tick Marks and Labels
+    ImPlotTicker CTicker;
+
+    // Annotation and Tabs
+    ImPlotAnnotationCollection Annotations;
+    ImPlotTagCollection        Tags;
+
+    // Flags
+    bool ChildWindowMade;
+
+    // Style and Colormaps
+    ImPlotStyle                 Style;
+    ImVector<ImGuiColorMod>     ColorModifiers;
+    ImVector<ImGuiStyleMod>     StyleModifiers;
+    ImPlotColormapData          ColormapData;
+    ImVector<ImPlotColormap>    ColormapModifiers;
+
+    // Time
+    tm Tm;
+
+    // Temp data for general use
+    ImVector<double>   TempDouble1, TempDouble2;
+    ImVector<int>      TempInt1;
+
+    // Misc
+    int                DigitalPlotItemCnt;
+    int                DigitalPlotOffset;
+    ImPlotNextPlotData NextPlotData;
+    ImPlotNextItemData NextItemData;
+    ImPlotInputMap     InputMap;
+    bool               OpenContextThisFrame;
+    ImGuiTextBuffer    MousePosStringBuilder;
+    ImPlotItemGroup*   SortItems;
+
+    // Align plots
+    ImPool<ImPlotAlignmentData> AlignmentData;
+    ImPlotAlignmentData*        CurrentAlignmentH;
+    ImPlotAlignmentData*        CurrentAlignmentV;
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Internal API
+// No guarantee of forward compatibility here!
+//-----------------------------------------------------------------------------
+
+namespace ImPlot {
+
+//-----------------------------------------------------------------------------
+// [SECTION] Context Utils
+//-----------------------------------------------------------------------------
+
+// Initializes an ImPlotContext
+IMPLOT_API void Initialize(ImPlotContext* ctx);
+// Resets an ImPlot context for the next call to BeginPlot
+IMPLOT_API void ResetCtxForNextPlot(ImPlotContext* ctx);
+// Resets an ImPlot context for the next call to BeginAlignedPlots
+IMPLOT_API void ResetCtxForNextAlignedPlots(ImPlotContext* ctx);
+// Resets an ImPlot context for the next call to BeginSubplot
+IMPLOT_API void ResetCtxForNextSubplot(ImPlotContext* ctx);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Plot Utils
+//-----------------------------------------------------------------------------
+
+// Gets a plot from the current ImPlotContext
+IMPLOT_API ImPlotPlot* GetPlot(const char* title);
+// Gets the current plot from the current ImPlotContext
+IMPLOT_API ImPlotPlot* GetCurrentPlot();
+// Busts the cache for every plot in the current context
+IMPLOT_API void BustPlotCache();
+
+// Shows a plot's context menu.
+IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Setup Utils
+//-----------------------------------------------------------------------------
+
+// Lock Setup and call SetupFinish if necessary.
+static inline void SetupLock() {
+    if (!GImPlot->CurrentPlot->SetupLocked)
+        SetupFinish();
+    GImPlot->CurrentPlot->SetupLocked = true;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Subplot Utils
+//-----------------------------------------------------------------------------
+
+// Advances to next subplot
+IMPLOT_API void SubplotNextCell();
+
+// Shows a subplot's context menu.
+IMPLOT_API void ShowSubplotsContextMenu(ImPlotSubplot& subplot);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Item Utils
+//-----------------------------------------------------------------------------
+
+// Begins a new item. Returns false if the item should not be plotted. Pushes PlotClipRect.
+IMPLOT_API bool BeginItem(const char* label_id, ImPlotItemFlags flags=0, ImPlotCol recolor_from=IMPLOT_AUTO);
+
+// Same as above but with fitting functionality.
+template <typename _Fitter>
+bool BeginItemEx(const char* label_id, const _Fitter& fitter, ImPlotItemFlags flags=0, ImPlotCol recolor_from=IMPLOT_AUTO) {
+    if (BeginItem(label_id, flags, recolor_from)) {
+        ImPlotPlot& plot = *GetCurrentPlot();
+        if (plot.FitThisFrame && !ImHasFlag(flags, ImPlotItemFlags_NoFit))
+            fitter.Fit(plot.Axes[plot.CurrentX], plot.Axes[plot.CurrentY]);
+        return true;
+    }
+    return false;
+}
+
+// Ends an item (call only if BeginItem returns true). Pops PlotClipRect.
+IMPLOT_API void EndItem();
+
+// Register or get an existing item from the current plot.
+IMPLOT_API ImPlotItem* RegisterOrGetItem(const char* label_id, ImPlotItemFlags flags, bool* just_created = NULL);
+// Get a plot item from the current plot.
+IMPLOT_API ImPlotItem* GetItem(const char* label_id);
+// Gets the current item.
+IMPLOT_API ImPlotItem* GetCurrentItem();
+// Busts the cache for every item for every plot in the current context.
+IMPLOT_API void BustItemCache();
+
+//-----------------------------------------------------------------------------
+// [SECTION] Axis Utils
+//-----------------------------------------------------------------------------
+
+// Returns true if any enabled axis is locked from user input.
+static inline bool AnyAxesInputLocked(ImPlotAxis* axes, int count) {
+    for (int i = 0; i < count; ++i) {
+        if (axes[i].Enabled && axes[i].IsInputLocked())
+            return true;
+    }
+    return false;
+}
+
+// Returns true if all enabled axes are locked from user input.
+static inline bool AllAxesInputLocked(ImPlotAxis* axes, int count) {
+    for (int i = 0; i < count; ++i) {
+        if (axes[i].Enabled && !axes[i].IsInputLocked())
+            return false;
+    }
+    return true;
+}
+
+static inline bool AnyAxesHeld(ImPlotAxis* axes, int count) {
+    for (int i = 0; i < count; ++i) {
+        if (axes[i].Enabled && axes[i].Held)
+            return true;
+    }
+    return false;
+}
+
+static inline bool AnyAxesHovered(ImPlotAxis* axes, int count) {
+    for (int i = 0; i < count; ++i) {
+        if (axes[i].Enabled && axes[i].Hovered)
+            return true;
+    }
+    return false;
+}
+
+// Returns true if the user has requested data to be fit.
+static inline bool FitThisFrame() {
+    return GImPlot->CurrentPlot->FitThisFrame;
+}
+
+// Extends the current plot's axes so that it encompasses a vertical line at x
+static inline void FitPointX(double x) {
+    ImPlotPlot& plot   = *GetCurrentPlot();
+    ImPlotAxis& x_axis = plot.Axes[plot.CurrentX];
+    x_axis.ExtendFit(x);
+}
+
+// Extends the current plot's axes so that it encompasses a horizontal line at y
+static inline void FitPointY(double y) {
+    ImPlotPlot& plot   = *GetCurrentPlot();
+    ImPlotAxis& y_axis = plot.Axes[plot.CurrentY];
+    y_axis.ExtendFit(y);
+}
+
+// Extends the current plot's axes so that it encompasses point p
+static inline void FitPoint(const ImPlotPoint& p) {
+    ImPlotPlot& plot   = *GetCurrentPlot();
+    ImPlotAxis& x_axis = plot.Axes[plot.CurrentX];
+    ImPlotAxis& y_axis = plot.Axes[plot.CurrentY];
+    x_axis.ExtendFitWith(y_axis, p.x, p.y);
+    y_axis.ExtendFitWith(x_axis, p.y, p.x);
+}
+
+// Returns true if two ranges overlap
+static inline bool RangesOverlap(const ImPlotRange& r1, const ImPlotRange& r2)
+{ return r1.Min <= r2.Max && r2.Min <= r1.Max; }
+
+// Shows an axis's context menu.
+IMPLOT_API void ShowAxisContextMenu(ImPlotAxis& axis, ImPlotAxis* equal_axis, bool time_allowed = false);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Legend Utils
+//-----------------------------------------------------------------------------
+
+// Gets the position of an inner rect that is located inside of an outer rect according to an ImPlotLocation and padding amount.
+IMPLOT_API ImVec2 GetLocationPos(const ImRect& outer_rect, const ImVec2& inner_size, ImPlotLocation location, const ImVec2& pad = ImVec2(0,0));
+// Calculates the bounding box size of a legend
+IMPLOT_API ImVec2 CalcLegendSize(ImPlotItemGroup& items, const ImVec2& pad, const ImVec2& spacing, bool vertical);
+// Renders legend entries into a bounding box
+IMPLOT_API bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool interactable, const ImVec2& pad, const ImVec2& spacing, bool vertical, ImDrawList& DrawList);
+// Shows an alternate legend for the plot identified by #title_id, outside of the plot frame (can be called before or after of Begin/EndPlot but must occur in the same ImGui window!).
+IMPLOT_API void ShowAltLegend(const char* title_id, bool vertical = true, const ImVec2 size = ImVec2(0,0), bool interactable = true);
+// Shows an legends's context menu.
+IMPLOT_API bool ShowLegendContextMenu(ImPlotLegend& legend, bool visible);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Label Utils
+//-----------------------------------------------------------------------------
+
+// Create a a string label for a an axis value
+IMPLOT_API void LabelAxisValue(const ImPlotAxis& axis, double value, char* buff, int size, bool round = false);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Styling Utils
+//-----------------------------------------------------------------------------
+
+// Get styling data for next item (call between Begin/EndItem)
+static inline const ImPlotNextItemData& GetItemData() { return GImPlot->NextItemData; }
+
+// Returns true if a color is set to be automatically determined
+static inline bool IsColorAuto(const ImVec4& col) { return col.w == -1; }
+// Returns true if a style color is set to be automaticaly determined
+static inline bool IsColorAuto(ImPlotCol idx) { return IsColorAuto(GImPlot->Style.Colors[idx]); }
+// Returns the automatically deduced style color
+IMPLOT_API ImVec4 GetAutoColor(ImPlotCol idx);
+
+// Returns the style color whether it is automatic or custom set
+static inline ImVec4 GetStyleColorVec4(ImPlotCol idx) { return IsColorAuto(idx) ? GetAutoColor(idx) : GImPlot->Style.Colors[idx]; }
+static inline ImU32  GetStyleColorU32(ImPlotCol idx)  { return ImGui::ColorConvertFloat4ToU32(GetStyleColorVec4(idx)); }
+
+// Draws vertical text. The position is the bottom left of the text rect.
+IMPLOT_API void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char* text_begin, const char* text_end = NULL);
+// Draws multiline horizontal text centered.
+IMPLOT_API void AddTextCentered(ImDrawList* DrawList, ImVec2 top_center, ImU32 col, const char* text_begin, const char* text_end = NULL);
+// Calculates the size of vertical text
+static inline ImVec2 CalcTextSizeVertical(const char *text) {
+    ImVec2 sz = ImGui::CalcTextSize(text);
+    return ImVec2(sz.y, sz.x);
+}
+// Returns white or black text given background color
+static inline ImU32 CalcTextColor(const ImVec4& bg) { return (bg.x * 0.299f + bg.y * 0.587f + bg.z * 0.114f) > 0.5f ? IM_COL32_BLACK : IM_COL32_WHITE; }
+static inline ImU32 CalcTextColor(ImU32 bg)         { return CalcTextColor(ImGui::ColorConvertU32ToFloat4(bg)); }
+// Lightens or darkens a color for hover
+static inline ImU32 CalcHoverColor(ImU32 col)       {  return ImMixU32(col, CalcTextColor(col), 32); }
+
+// Clamps a label position so that it fits a rect defined by Min/Max
+static inline ImVec2 ClampLabelPos(ImVec2 pos, const ImVec2& size, const ImVec2& Min, const ImVec2& Max) {
+    if (pos.x < Min.x)              pos.x = Min.x;
+    if (pos.y < Min.y)              pos.y = Min.y;
+    if ((pos.x + size.x) > Max.x)   pos.x = Max.x - size.x;
+    if ((pos.y + size.y) > Max.y)   pos.y = Max.y - size.y;
+    return pos;
+}
+
+// Returns a color from the Color map given an index >= 0 (modulo will be performed).
+IMPLOT_API ImU32  GetColormapColorU32(int idx, ImPlotColormap cmap);
+// Returns the next unused colormap color and advances the colormap. Can be used to skip colors if desired.
+IMPLOT_API ImU32  NextColormapColorU32();
+// Linearly interpolates a color from the current colormap given t between 0 and 1.
+IMPLOT_API ImU32  SampleColormapU32(float t, ImPlotColormap cmap);
+
+// Render a colormap bar
+IMPLOT_API void RenderColorBar(const ImU32* colors, int size, ImDrawList& DrawList, const ImRect& bounds, bool vert, bool reversed, bool continuous);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Math and Misc Utils
+//-----------------------------------------------------------------------------
+
+// Rounds x to powers of 2,5 and 10 for generating axis labels (from Graphics Gems 1 Chapter 11.2)
+IMPLOT_API double NiceNum(double x, bool round);
+// Computes order of magnitude of double.
+static inline int OrderOfMagnitude(double val) { return val == 0 ? 0 : (int)(floor(log10(fabs(val)))); }
+// Returns the precision required for a order of magnitude.
+static inline int OrderToPrecision(int order) { return order > 0 ? 0 : 1 - order; }
+// Returns a floating point precision to use given a value
+static inline int Precision(double val) { return OrderToPrecision(OrderOfMagnitude(val)); }
+// Round a value to a given precision
+static inline double RoundTo(double val, int prec) { double p = pow(10,(double)prec); return floor(val*p+0.5)/p; }
+
+// Returns the intersection point of two lines A and B (assumes they are not parallel!)
+static inline ImVec2 Intersection(const ImVec2& a1, const ImVec2& a2, const ImVec2& b1, const ImVec2& b2) {
+    float v1 = (a1.x * a2.y - a1.y * a2.x);  float v2 = (b1.x * b2.y - b1.y * b2.x);
+    float v3 = ((a1.x - a2.x) * (b1.y - b2.y) - (a1.y - a2.y) * (b1.x - b2.x));
+    return ImVec2((v1 * (b1.x - b2.x) - v2 * (a1.x - a2.x)) / v3, (v1 * (b1.y - b2.y) - v2 * (a1.y - a2.y)) / v3);
+}
+
+// Fills a buffer with n samples linear interpolated from vmin to vmax
+template <typename T>
+void FillRange(ImVector<T>& buffer, int n, T vmin, T vmax) {
+    buffer.resize(n);
+    T step = (vmax - vmin) / (n - 1);
+    for (int i = 0; i < n; ++i) {
+        buffer[i] = vmin + i * step;
+    }
+}
+
+// Calculate histogram bin counts and widths
+template <typename T>
+static inline void CalculateBins(const T* values, int count, ImPlotBin meth, const ImPlotRange& range, int& bins_out, double& width_out) {
+    switch (meth) {
+        case ImPlotBin_Sqrt:
+            bins_out  = (int)ceil(sqrt(count));
+            break;
+        case ImPlotBin_Sturges:
+            bins_out  = (int)ceil(1.0 + log2(count));
+            break;
+        case ImPlotBin_Rice:
+            bins_out  = (int)ceil(2 * cbrt(count));
+            break;
+        case ImPlotBin_Scott:
+            width_out = 3.49 * ImStdDev(values, count) / cbrt(count);
+            bins_out  = (int)round(range.Size() / width_out);
+            break;
+    }
+    width_out = range.Size() / bins_out;
+}
+
+//-----------------------------------------------------------------------------
+// Time Utils
+//-----------------------------------------------------------------------------
+
+// Returns true if year is leap year (366 days long)
+static inline bool IsLeapYear(int year) {
+    return  year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+// Returns the number of days in a month, accounting for Feb. leap years. #month is zero indexed.
+static inline int GetDaysInMonth(int year, int month) {
+    static const int days[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    return  days[month] + (int)(month == 1 && IsLeapYear(year));
+}
+
+// Make a UNIX timestamp from a tm struct expressed in UTC time (i.e. GMT timezone).
+IMPLOT_API ImPlotTime MkGmtTime(struct tm *ptm);
+// Make a tm struct expressed in UTC time (i.e. GMT timezone) from a UNIX timestamp.
+IMPLOT_API tm* GetGmtTime(const ImPlotTime& t, tm* ptm);
+
+// Make a UNIX timestamp from a tm struct expressed in local time.
+IMPLOT_API ImPlotTime MkLocTime(struct tm *ptm);
+// Make a tm struct expressed in local time from a UNIX timestamp.
+IMPLOT_API tm* GetLocTime(const ImPlotTime& t, tm* ptm);
+
+// NB: The following functions only work if there is a current ImPlotContext because the
+// internal tm struct is owned by the context! They are aware of ImPlotStyle.UseLocalTime.
+
+// Make a timestamp from time components.
+// year[1970-3000], month[0-11], day[1-31], hour[0-23], min[0-59], sec[0-59], us[0,999999]
+IMPLOT_API ImPlotTime MakeTime(int year, int month = 0, int day = 1, int hour = 0, int min = 0, int sec = 0, int us = 0);
+// Get year component from timestamp [1970-3000]
+IMPLOT_API int GetYear(const ImPlotTime& t);
+
+// Adds or subtracts time from a timestamp. #count > 0 to add, < 0 to subtract.
+IMPLOT_API ImPlotTime AddTime(const ImPlotTime& t, ImPlotTimeUnit unit, int count);
+// Rounds a timestamp down to nearest unit.
+IMPLOT_API ImPlotTime FloorTime(const ImPlotTime& t, ImPlotTimeUnit unit);
+// Rounds a timestamp up to the nearest unit.
+IMPLOT_API ImPlotTime CeilTime(const ImPlotTime& t, ImPlotTimeUnit unit);
+// Rounds a timestamp up or down to the nearest unit.
+IMPLOT_API ImPlotTime RoundTime(const ImPlotTime& t, ImPlotTimeUnit unit);
+// Combines the date of one timestamp with the time-of-day of another timestamp.
+IMPLOT_API ImPlotTime CombineDateTime(const ImPlotTime& date_part, const ImPlotTime& time_part);
+
+// Formats the time part of timestamp t into a buffer according to #fmt
+IMPLOT_API int FormatTime(const ImPlotTime& t, char* buffer, int size, ImPlotTimeFmt fmt, bool use_24_hr_clk);
+// Formats the date part of timestamp t into a buffer according to #fmt
+IMPLOT_API int FormatDate(const ImPlotTime& t, char* buffer, int size, ImPlotDateFmt fmt, bool use_iso_8601);
+// Formats the time and/or date parts of a timestamp t into a buffer according to #fmt
+IMPLOT_API int FormatDateTime(const ImPlotTime& t, char* buffer, int size, ImPlotDateTimeSpec fmt);
+
+// Shows a date picker widget block (year/month/day).
+// #level = 0 for day, 1 for month, 2 for year. Modified by user interaction.
+// #t will be set when a day is clicked and the function will return true.
+// #t1 and #t2 are optional dates to highlight.
+IMPLOT_API bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime* t1 = NULL, const ImPlotTime* t2 = NULL);
+// Shows a time picker widget block (hour/min/sec).
+// #t will be set when a new hour, minute, or sec is selected or am/pm is toggled, and the function will return true.
+IMPLOT_API bool ShowTimePicker(const char* id, ImPlotTime* t);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Transforms
+//-----------------------------------------------------------------------------
+
+static inline double TransformForward_Log10(double v, void*) {
+    v = v <= 0.0 ? DBL_MIN : v;
+    return ImLog10(v);
+}
+
+static inline double TransformInverse_Log10(double v, void*) {
+    return ImPow(10, v);
+}
+
+static inline double TransformForward_SymLog(double v, void*) {
+    return 2.0 * ImAsinh(v / 2.0);
+}
+
+static inline double TransformInverse_SymLog(double v, void*) {
+    return 2.0 * ImSinh(v / 2.0);
+}
+
+static inline double TransformForward_Logit(double v, void*) {
+    v = ImClamp(v, DBL_MIN, 1.0 - DBL_EPSILON);
+    return ImLog10(v / (1 - v));
+}
+
+static inline double TransformInverse_Logit(double v, void*) {
+    return 1.0 / (1.0 + ImPow(10,-v));
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Formatters
+//-----------------------------------------------------------------------------
+
+static inline int Formatter_Default(double value, char* buff, int size, void* data) {
+    char* fmt = (char*)data;
+    return ImFormatString(buff, size, fmt, value);
+}
+
+static inline int Formatter_Logit(double value, char* buff, int size, void*) {
+    if (value == 0.5)
+        return ImFormatString(buff,size,"1/2");
+    else if (value < 0.5)
+        return ImFormatString(buff,size,"%g", value);
+    else
+        return ImFormatString(buff,size,"1 - %g", 1 - value);
+}
+
+struct Formatter_Time_Data {
+    ImPlotTime Time;
+    ImPlotDateTimeSpec Spec;
+    ImPlotFormatter UserFormatter;
+    void* UserFormatterData;
+};
+
+static inline int Formatter_Time(double, char* buff, int size, void* data) {
+    Formatter_Time_Data* ftd = (Formatter_Time_Data*)data;
+    return FormatDateTime(ftd->Time, buff, size, ftd->Spec);
+}
+
+//------------------------------------------------------------------------------
+// [SECTION] Locator
+//------------------------------------------------------------------------------
+
+void Locator_Default(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+void Locator_Time(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+void Locator_Log10(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+void Locator_SymLog(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+
+} // namespace ImPlot

--- a/lib/implot/implot_internal.h
+++ b/lib/implot/implot_internal.h
@@ -1,6 +1,7 @@
 // MIT License
 
-// Copyright (c) 2022 Evan Pezent
+// Copyright (c) 2020-2024 Evan Pezent
+// Copyright (c) 2025-2026 Breno Cunha Queiroz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// ImPlot v0.14
+// ImPlot v1.1 WIP
 
 // You may use this file to debug, understand or extend ImPlot features but we
 // don't provide any guarantee of forward compatibility!
@@ -31,17 +32,13 @@
 
 #pragma once
 
-#ifndef IMGUI_DEFINE_MATH_OPERATORS
-#define IMGUI_DEFINE_MATH_OPERATORS
-#endif
-
-#include <time.h>
-#include "imgui_internal.h"
-
 #ifndef IMPLOT_VERSION
 #error Must include implot.h before implot_internal.h
 #endif
 
+#ifndef IMGUI_DISABLE
+#include <time.h>
+#include "imgui_internal.h"
 
 // Support for pre-1.84 versions. ImPool's GetSize() -> GetBufSize()
 #if (IMGUI_VERSION_NUM < 18303)
@@ -55,21 +52,24 @@
 // Constants can be changed unless stated otherwise. We may move some of these
 // to ImPlotStyleVar_ over time.
 
-// Mimimum allowable timestamp value 01/01/1970 @ 12:00am (UTC) (DO NOT DECREASE THIS)
-#define IMPLOT_MIN_TIME  0
+// Minimum allowable timestamp value 01/01/1970 @ 12:00am (UTC) (DO NOT DECREASE THIS)
+constexpr double IMPLOT_MIN_TIME = 0;
 // Maximum allowable timestamp value 01/01/3000 @ 12:00am (UTC) (DO NOT INCREASE THIS)
-#define IMPLOT_MAX_TIME  32503680000
+constexpr double IMPLOT_MAX_TIME = 32503680000;
+
 // Default label format for axis labels
-#define IMPLOT_LABEL_FORMAT "%g"
+constexpr const char* IMPLOT_LABEL_FORMAT = "%g";
 // Max character size for tick labels
-#define IMPLOT_LABEL_MAX_SIZE 32
+constexpr int IMPLOT_LABEL_MAX_SIZE = 32;
+
+// Number of X axes
+constexpr int IMPLOT_NUM_X_AXES = ImAxis_Y1;
+// Number of Y axes
+constexpr int IMPLOT_NUM_Y_AXES = ImAxis_COUNT - IMPLOT_NUM_X_AXES;
 
 //-----------------------------------------------------------------------------
 // [SECTION] Macros
 //-----------------------------------------------------------------------------
-
-#define IMPLOT_NUM_X_AXES ImAxis_Y1
-#define IMPLOT_NUM_Y_AXES (ImAxis_COUNT - IMPLOT_NUM_X_AXES)
 
 // Split ImU32 color into RGB components [0 255]
 #define IM_COL32_SPLIT_RGB(col,r,g,b) \
@@ -118,7 +118,7 @@ static inline void ImFlipFlag(TSet& set, TFlag flag) { ImHasFlag(set, flag) ? se
 // Linearly remaps x from [x0 x1] to [y0 y1].
 template <typename T>
 static inline T ImRemap(T x, T x0, T x1, T y0, T y1) { return y0 + (x - x0) * (y1 - y0) / (x1 - x0); }
-// Linear rempas x from [x0 x1] to [0 1]
+// Linearly remaps x from [x0 x1] to [0 1]
 template <typename T>
 static inline T ImRemap01(T x, T x0, T x1) { return (x - x0) / (x1 - x0); }
 // Returns always positive modulo (assumes r != 0)
@@ -137,6 +137,7 @@ static inline double ImConstrainLog(double val) { return val <= 0 ? 0.001f : val
 static inline double ImConstrainTime(double val) { return val < IMPLOT_MIN_TIME ? IMPLOT_MIN_TIME : (val > IMPLOT_MAX_TIME ? IMPLOT_MAX_TIME : val); }
 // True if two numbers are approximately equal using units in the last place.
 static inline bool ImAlmostEqual(double v1, double v2, int ulp = 2) { return ImAbs(v1-v2) < DBL_EPSILON * ImAbs(v1+v2) * ulp || ImAbs(v1-v2) < DBL_MIN; }
+
 // Finds min value in an unsorted array
 template <typename T>
 static inline T ImMinArray(const T* values, int count) { T m = values[0]; for (int i = 1; i < count; ++i) { if (values[i] < m) { m = values[i]; } } return m; }
@@ -180,6 +181,7 @@ static inline double ImStdDev(const T* values, int count) {
         x += ((double)values[i] - mu) * ((double)values[i] - mu) * den;
     return sqrt(x);
 }
+
 // Mix color a and b by factor s in [0 256]
 static inline ImU32 ImMixU32(ImU32 a, ImU32 b, ImU32 s) {
 #ifdef IMPLOT_MIX64
@@ -202,7 +204,7 @@ static inline ImU32 ImMixU32(ImU32 a, ImU32 b, ImU32 s) {
 #endif
 }
 
-// Lerp across an array of 32-bit collors given t in [0.0 1.0]
+// Lerp across an array of 32-bit colors given t in [0.0 1.0]
 static inline ImU32 ImLerpU32(const ImU32* colors, int size, float t) {
     int i1 = (int)((size - 1 ) * t);
     int i2 = i1 + 1;
@@ -230,9 +232,10 @@ static inline bool ImOverlaps(T min_a, T max_a, T min_b, T max_b) {
 // [SECTION] ImPlot Enums
 //-----------------------------------------------------------------------------
 
-typedef int ImPlotTimeUnit;    // -> enum ImPlotTimeUnit_
-typedef int ImPlotDateFmt;     // -> enum ImPlotDateFmt_
-typedef int ImPlotTimeFmt;     // -> enum ImPlotTimeFmt_
+typedef int ImPlotTimeUnit;       // -> enum ImPlotTimeUnit_
+typedef int ImPlotDateFmt;        // -> enum ImPlotDateFmt_
+typedef int ImPlotTimeFmt;        // -> enum ImPlotTimeFmt_
+typedef int ImPlotMarkerInternal; // -> enum ImPlotMarkerInternal_
 
 enum ImPlotTimeUnit_ {
     ImPlotTimeUnit_Us,  // microsecond
@@ -266,6 +269,10 @@ enum ImPlotTimeFmt_ {              // default        [ 24 Hour Clock ]
     ImPlotTimeFmt_HrMinS,          // 7:21:29pm      [ 19:21:29     ]
     ImPlotTimeFmt_HrMin,           // 7:21pm         [ 19:21        ]
     ImPlotTimeFmt_Hr               // 7pm            [ 19:00        ]
+};
+
+enum ImPlotMarkerInternal_ {
+    ImPlotMarker_Invalid = -3
 };
 
 //-----------------------------------------------------------------------------
@@ -400,18 +407,18 @@ struct ImPlotColormapData {
             _AppendTable(i);
     }
 
-    inline bool           IsQual(ImPlotColormap cmap) const                      { return Quals[cmap];                                             }
-    inline const char*    GetName(ImPlotColormap cmap) const                     { return cmap < Count ? Text.Buf.Data + TextOffsets[cmap] : NULL; }
-    inline ImPlotColormap GetIndex(const char* name) const                       { ImGuiID key = ImHashStr(name); return Map.GetInt(key,-1);       }
+    inline bool           IsQual(ImPlotColormap cmap) const                      { return Quals[cmap];                                                }
+    inline const char*    GetName(ImPlotColormap cmap) const                     { return cmap < Count ? Text.Buf.Data + TextOffsets[cmap] : nullptr; }
+    inline ImPlotColormap GetIndex(const char* name) const                       { ImGuiID key = ImHashStr(name); return Map.GetInt(key,-1);          }
 
-    inline const ImU32*   GetKeys(ImPlotColormap cmap) const                     { return &Keys[KeyOffsets[cmap]];                                 }
-    inline int            GetKeyCount(ImPlotColormap cmap) const                 { return KeyCounts[cmap];                                         }
-    inline ImU32          GetKeyColor(ImPlotColormap cmap, int idx) const        { return Keys[KeyOffsets[cmap]+idx];                              }
-    inline void           SetKeyColor(ImPlotColormap cmap, int idx, ImU32 value) { Keys[KeyOffsets[cmap]+idx] = value; RebuildTables();            }
+    inline const ImU32*   GetKeys(ImPlotColormap cmap) const                     { return &Keys[KeyOffsets[cmap]];                                    }
+    inline int            GetKeyCount(ImPlotColormap cmap) const                 { return KeyCounts[cmap];                                            }
+    inline ImU32          GetKeyColor(ImPlotColormap cmap, int idx) const        { return Keys[KeyOffsets[cmap]+idx];                                 }
+    inline void           SetKeyColor(ImPlotColormap cmap, int idx, ImU32 value) { Keys[KeyOffsets[cmap]+idx] = value; RebuildTables();               }
 
-    inline const ImU32*   GetTable(ImPlotColormap cmap) const                    { return &Tables[TableOffsets[cmap]];                             }
-    inline int            GetTableSize(ImPlotColormap cmap) const                { return TableSizes[cmap];                                        }
-    inline ImU32          GetTableColor(ImPlotColormap cmap, int idx) const      { return Tables[TableOffsets[cmap]+idx];                          }
+    inline const ImU32*   GetTable(ImPlotColormap cmap) const                    { return &Tables[TableOffsets[cmap]];                                }
+    inline int            GetTableSize(ImPlotColormap cmap) const                { return TableSizes[cmap];                                           }
+    inline ImU32          GetTableColor(ImPlotColormap cmap, int idx) const      { return Tables[TableOffsets[cmap]+idx];                             }
 
     inline ImU32 LerpTable(ImPlotColormap cmap, float t) const {
         int off = TableOffsets[cmap];
@@ -424,6 +431,7 @@ struct ImPlotColormapData {
 // ImPlotPoint with positive/negative error values
 struct ImPlotPointError {
     double X, Y, Neg, Pos;
+    ImPlotPointError() { X = 0; Y = 0; Neg = 0; Pos = 0; }
     ImPlotPointError(double x, double y, double neg, double pos) {
         X = x; Y = y; Neg = neg; Pos = pos;
     }
@@ -490,6 +498,14 @@ struct ImPlotTag {
     ImU32  ColorBg;
     ImU32  ColorFg;
     int    TextOffset;
+
+    ImPlotTag() {
+        Axis       = 0;
+        Value      = 0;
+        ColorBg    = 0;
+        ColorFg    = 0;
+        TextOffset = 0;
+    }
 };
 
 struct ImPlotTagCollection {
@@ -544,6 +560,17 @@ struct ImPlotTick
     int    Level;
     int    Idx;
 
+    ImPlotTick() {
+        PlotPos      = 0;
+        PixelPos     = 0;
+        LabelSize    = ImVec2(0,0);
+        TextOffset   = -1;
+        Major        = false;
+        ShowLabel    = false;
+        Level        = 0;
+        Idx          = -1;
+    }
+
     ImPlotTick(double value, bool major, int level, bool show_label) {
         PixelPos     = 0;
         PlotPos      = value;
@@ -568,7 +595,7 @@ struct ImPlotTicker {
 
     ImPlotTick& AddTick(double value, bool major, int level, bool show_label, const char* label) {
         ImPlotTick tick(value, major, level, show_label);
-        if (show_label && label != NULL) {
+        if (show_label && label != nullptr) {
             tick.TextOffset = TextBuffer.size();
             TextBuffer.append(label, label + strlen(label) + 1);
             tick.LabelSize = ImGui::CalcTextSize(TextBuffer.Buf.Data + tick.TextOffset);
@@ -578,7 +605,7 @@ struct ImPlotTicker {
 
     ImPlotTick& AddTick(double value, bool major, int level, bool show_label, ImPlotFormatter formatter, void* data) {
         ImPlotTick tick(value, major, level, show_label);
-        if (show_label && formatter != NULL) {
+        if (show_label && formatter != nullptr) {
             char buff[IMPLOT_LABEL_MAX_SIZE];
             tick.TextOffset = TextBuffer.size();
             formatter(tick.PlotPos, buff, sizeof(buff), data);
@@ -677,23 +704,23 @@ struct ImPlotAxis
         Range.Min        = 0;
         Range.Max        = 1;
         Scale            = ImPlotScale_Linear;
-        TransformForward = TransformInverse = NULL;
-        TransformData    = NULL;
+        TransformForward = TransformInverse = nullptr;
+        TransformData    = nullptr;
         FitExtents.Min   = HUGE_VAL;
         FitExtents.Max   = -HUGE_VAL;
-        OrthoAxis        = NULL;
+        OrthoAxis        = nullptr;
         ConstraintRange  = ImPlotRange(-INFINITY,INFINITY);
         ConstraintZoom   = ImPlotRange(DBL_MIN,INFINITY);
-        LinkedMin        = LinkedMax = NULL;
+        LinkedMin        = LinkedMax = nullptr;
         PickerLevel      = 0;
         Datum1           = Datum2 = 0;
         PixelMin         = PixelMax = 0;
         LabelOffset      = -1;
         ColorMaj         = ColorMin = ColorTick = ColorTxt = ColorBg = ColorHov = ColorAct = 0;
         ColorHiLi        = IM_COL32_BLACK_TRANS;
-        Formatter        = NULL;
-        FormatterData    = NULL;
-        Locator          = NULL;
+        Formatter        = nullptr;
+        FormatterData    = nullptr;
+        Locator          = nullptr;
         Enabled          = Hovered = Held = FitThisFrame = HasRange = HasFormatSpec = false;
         ShowDefaultTicks = true;
     }
@@ -701,18 +728,18 @@ struct ImPlotAxis
     inline void Reset() {
         Enabled          = false;
         Scale            = ImPlotScale_Linear;
-        TransformForward = TransformInverse = NULL;
-        TransformData    = NULL;
+        TransformForward = TransformInverse = nullptr;
+        TransformData    = nullptr;
         LabelOffset      = -1;
         HasFormatSpec    = false;
-        Formatter        = NULL;
-        FormatterData    = NULL;
-        Locator          = NULL;
+        Formatter        = nullptr;
+        FormatterData    = nullptr;
+        Locator          = nullptr;
         ShowDefaultTicks = true;
         FitThisFrame     = false;
         FitExtents.Min   = HUGE_VAL;
         FitExtents.Max   = -HUGE_VAL;
-        OrthoAxis        = NULL;
+        OrthoAxis        = nullptr;
         ConstraintRange  = ImPlotRange(-INFINITY,INFINITY);
         ConstraintZoom   = ImPlotRange(DBL_MIN,INFINITY);
         Ticker.Reset();
@@ -735,7 +762,7 @@ struct ImPlotAxis
         PickerTimeMin = ImPlotTime::FromDouble(Range.Min);
         UpdateTransformCache();
         return true;
-    };
+    }
 
     inline bool SetMax(double _max, bool force=false) {
         if (!force && IsLockedMax())
@@ -754,7 +781,7 @@ struct ImPlotAxis
         PickerTimeMax = ImPlotTime::FromDouble(Range.Max);
         UpdateTransformCache();
         return true;
-    };
+    }
 
     inline void SetRange(double v1, double v2) {
         Range.Min = ImMin(v1,v2);
@@ -810,7 +837,7 @@ struct ImPlotAxis
 
     inline void UpdateTransformCache() {
         ScaleToPixel = (PixelMax - PixelMin) / Range.Size();
-        if (TransformForward != NULL) {
+        if (TransformForward != nullptr) {
             ScaleMin = TransformForward(Range.Min, TransformData);
             ScaleMax = TransformForward(Range.Max, TransformData);
         }
@@ -821,7 +848,7 @@ struct ImPlotAxis
     }
 
     inline float PlotToPixels(double plt) const {
-        if (TransformForward != NULL) {
+        if (TransformForward != nullptr) {
             double s = TransformForward(plt, TransformData);
             double t = (s - ScaleMin) / (ScaleMax - ScaleMin);
             plt      = Range.Min + Range.Size() * t;
@@ -832,7 +859,7 @@ struct ImPlotAxis
 
     inline double PixelsToPlot(float pix) const {
         double plt = (pix - PixelMin) / ScaleToPixel + Range.Min;
-        if (TransformInverse != NULL) {
+        if (TransformInverse != nullptr) {
             double t = (plt - Range.Min) / Range.Size();
             double s = t * (ScaleMax - ScaleMin) + ScaleMin;
             plt = TransformInverse(s, TransformData);
@@ -911,8 +938,9 @@ struct ImPlotAxis
     }
 
     void PullLinks() {
-        if (LinkedMin) { SetMin(*LinkedMin,true); }
-        if (LinkedMax) { SetMax(*LinkedMax,true); }
+        if (LinkedMin && LinkedMax) { SetRange(*LinkedMin, *LinkedMax); }
+        else if (LinkedMin) { SetMin(*LinkedMin,true); }
+        else if (LinkedMax) { SetMax(*LinkedMax,true); }
     }
 };
 
@@ -944,6 +972,7 @@ struct ImPlotItem
 {
     ImGuiID      ID;
     ImU32        Color;
+    ImPlotMarker Marker;
     ImRect       LegendHoverRect;
     int          NameOffset;
     bool         Show;
@@ -953,6 +982,7 @@ struct ImPlotItem
     ImPlotItem() {
         ID            = 0;
         Color         = IM_COL32_WHITE;
+        Marker        = ImPlotMarker_None;
         NameOffset    = -1;
         Show          = true;
         SeenThisFrame = false;
@@ -969,9 +999,11 @@ struct ImPlotLegend
     ImPlotLegendFlags PreviousFlags;
     ImPlotLocation    Location;
     ImPlotLocation    PreviousLocation;
+    ImVec2            Scroll;
     ImVector<int>     Indices;
     ImGuiTextBuffer   Labels;
     ImRect            Rect;
+    ImRect            RectClamped;
     bool              Hovered;
     bool              Held;
     bool              CanGoInside;
@@ -981,6 +1013,7 @@ struct ImPlotLegend
         CanGoInside  = true;
         Hovered      = Held = false;
         Location     = PreviousLocation = ImPlotLocation_NorthWest;
+        Scroll       = ImVec2(0,0);
     }
 
     void Reset() { Indices.shrink(0); Labels.Buf.shrink(0); }
@@ -993,8 +1026,9 @@ struct ImPlotItemGroup
     ImPlotLegend       Legend;
     ImPool<ImPlotItem> ItemPool;
     int                ColormapIdx;
+    ImPlotMarker       MarkerIdx;
 
-    ImPlotItemGroup() { ID = 0; ColormapIdx = 0; }
+    ImPlotItemGroup() { ID = 0; ColormapIdx = 0; MarkerIdx = 0; }
 
     int         GetItemCount() const             { return ItemPool.GetBufSize();                                 }
     ImGuiID     GetItemID(const char*  label_id) { return ImGui::GetID(label_id); /* GetIDWithSeed */            }
@@ -1071,7 +1105,7 @@ struct ImPlotPlot
     inline void ClearTextBuffer() { TextBuffer.Buf.shrink(0); }
 
     inline void SetTitle(const char* title) {
-        if (title && ImGui::FindRenderedTextEnd(title, NULL) != title) {
+        if (title && ImGui::FindRenderedTextEnd(title, nullptr) != title) {
             TitleOffset = TextBuffer.size();
             TextBuffer.append(title, title + strlen(title) + 1);
         }
@@ -1102,7 +1136,7 @@ struct ImPlotPlot
     }
 
     inline void SetAxisLabel(ImPlotAxis& axis, const char* label) {
-        if (label && ImGui::FindRenderedTextEnd(label, NULL) != label) {
+        if (label && ImGui::FindRenderedTextEnd(label, nullptr) != label) {
             axis.LabelOffset = TextBuffer.size();
             TextBuffer.append(label, label + strlen(label) + 1);
         }
@@ -1140,7 +1174,6 @@ struct ImPlotSubplot {
         ID                          = 0;
         Flags = PreviousFlags       = ImPlotSubplotFlags_None;
         Rows = Cols = CurrentIdx    = 0;
-        FrameHovered                = false;
         Items.Legend.Location       = ImPlotLocation_North;
         Items.Legend.Flags          = ImPlotLegendFlags_Horizontal|ImPlotLegendFlags_Outside;
         Items.Legend.CanGoInside    = false;
@@ -1166,7 +1199,7 @@ struct ImPlotNextPlotData
         for (int i = 0; i < ImAxis_COUNT; ++i) {
             HasRange[i]                 = false;
             Fit[i]                      = false;
-            LinkedMin[i] = LinkedMax[i] = NULL;
+            LinkedMin[i] = LinkedMax[i] = nullptr;
         }
     }
 
@@ -1174,30 +1207,20 @@ struct ImPlotNextPlotData
 
 // Temporary data storage for upcoming item
 struct ImPlotNextItemData {
-    ImVec4          Colors[5]; // ImPlotCol_Line, ImPlotCol_Fill, ImPlotCol_MarkerOutline, ImPlotCol_MarkerFill, ImPlotCol_ErrorBar
-    float           LineWeight;
-    ImPlotMarker    Marker;
-    float           MarkerSize;
-    float           MarkerWeight;
-    float           FillAlpha;
-    float           ErrorBarSize;
-    float           ErrorBarWeight;
-    float           DigitalBitHeight;
-    float           DigitalBitGap;
+    ImPlotSpec      Spec;
     bool            RenderLine;
     bool            RenderFill;
     bool            RenderMarkerLine;
     bool            RenderMarkerFill;
+    bool            RenderMarkers;
     bool            HasHidden;
     bool            Hidden;
     ImPlotCond      HiddenCond;
     ImPlotNextItemData() { Reset(); }
     void Reset() {
-        for (int i = 0; i < 5; ++i)
-            Colors[i] = IMPLOT_AUTO_COL;
-        LineWeight    = MarkerSize = MarkerWeight = FillAlpha = ErrorBarSize = ErrorBarWeight = DigitalBitHeight = DigitalBitGap = IMPLOT_AUTO;
-        Marker        = IMPLOT_AUTO;
-        HasHidden     = Hidden = false;
+        Spec      = ImPlotSpec();
+        HasHidden = Hidden = false;
+        HiddenCond = ImPlotCond_None;
     }
 };
 
@@ -1218,9 +1241,6 @@ struct ImPlotContext {
     // Annotation and Tabs
     ImPlotAnnotationCollection Annotations;
     ImPlotTagCollection        Tags;
-
-    // Flags
-    bool ChildWindowMade;
 
     // Style and Colormaps
     ImPlotStyle                 Style;
@@ -1292,9 +1312,10 @@ IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot);
 
 // Lock Setup and call SetupFinish if necessary.
 static inline void SetupLock() {
-    if (!GImPlot->CurrentPlot->SetupLocked)
+    ImPlotContext& gp = *GImPlot;
+    if (!gp.CurrentPlot->SetupLocked)
         SetupFinish();
-    GImPlot->CurrentPlot->SetupLocked = true;
+    gp.CurrentPlot->SetupLocked = true;
 }
 
 //-----------------------------------------------------------------------------
@@ -1312,14 +1333,14 @@ IMPLOT_API void ShowSubplotsContextMenu(ImPlotSubplot& subplot);
 //-----------------------------------------------------------------------------
 
 // Begins a new item. Returns false if the item should not be plotted. Pushes PlotClipRect.
-IMPLOT_API bool BeginItem(const char* label_id, ImPlotItemFlags flags=0, ImPlotCol recolor_from=IMPLOT_AUTO);
+IMPLOT_API bool BeginItem(const char* label_id, const ImPlotSpec& spec = ImPlotSpec(), const ImVec4& item_col = IMPLOT_AUTO_COL, ImPlotMarker item_mkr = ImPlotMarker_Invalid);
 
 // Same as above but with fitting functionality.
 template <typename _Fitter>
-bool BeginItemEx(const char* label_id, const _Fitter& fitter, ImPlotItemFlags flags=0, ImPlotCol recolor_from=IMPLOT_AUTO) {
-    if (BeginItem(label_id, flags, recolor_from)) {
+bool BeginItemEx(const char* label_id, const _Fitter& fitter, const ImPlotSpec& spec, const ImVec4& item_col = IMPLOT_AUTO_COL, ImPlotMarker item_mkr = ImPlotMarker_Invalid) {
+    if (BeginItem(label_id, spec, item_col, item_mkr)) {
         ImPlotPlot& plot = *GetCurrentPlot();
-        if (plot.FitThisFrame && !ImHasFlag(flags, ImPlotItemFlags_NoFit))
+        if (plot.FitThisFrame && !ImHasFlag(spec.Flags, ImPlotItemFlags_NoFit))
             fitter.Fit(plot.Axes[plot.CurrentX], plot.Axes[plot.CurrentY]);
         return true;
     }
@@ -1330,7 +1351,7 @@ bool BeginItemEx(const char* label_id, const _Fitter& fitter, ImPlotItemFlags fl
 IMPLOT_API void EndItem();
 
 // Register or get an existing item from the current plot.
-IMPLOT_API ImPlotItem* RegisterOrGetItem(const char* label_id, ImPlotItemFlags flags, bool* just_created = NULL);
+IMPLOT_API ImPlotItem* RegisterOrGetItem(const char* label_id, ImPlotItemFlags flags, bool* just_created = nullptr);
 // Get a plot item from the current plot.
 IMPLOT_API ImPlotItem* GetItem(const char* label_id);
 // Gets the current item.
@@ -1417,13 +1438,15 @@ IMPLOT_API void ShowAxisContextMenu(ImPlotAxis& axis, ImPlotAxis* equal_axis, bo
 
 // Gets the position of an inner rect that is located inside of an outer rect according to an ImPlotLocation and padding amount.
 IMPLOT_API ImVec2 GetLocationPos(const ImRect& outer_rect, const ImVec2& inner_size, ImPlotLocation location, const ImVec2& pad = ImVec2(0,0));
-// Calculates the bounding box size of a legend
+// Calculates the bounding box size of a legend _before_ clipping.
 IMPLOT_API ImVec2 CalcLegendSize(ImPlotItemGroup& items, const ImVec2& pad, const ImVec2& spacing, bool vertical);
+// Clips calculated legend size
+IMPLOT_API bool ClampLegendRect(ImRect& legend_rect, const ImRect& outer_rect, const ImVec2& pad);
 // Renders legend entries into a bounding box
 IMPLOT_API bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool interactable, const ImVec2& pad, const ImVec2& spacing, bool vertical, ImDrawList& DrawList);
-// Shows an alternate legend for the plot identified by #title_id, outside of the plot frame (can be called before or after of Begin/EndPlot but must occur in the same ImGui window!).
+// Shows an alternate legend for the plot identified by #title_id, outside of the plot frame (can be called before or after of Begin/EndPlot but must occur in the same ImGui window! This is not thoroughly tested nor scrollable!).
 IMPLOT_API void ShowAltLegend(const char* title_id, bool vertical = true, const ImVec2 size = ImVec2(0,0), bool interactable = true);
-// Shows an legends's context menu.
+// Shows a legend's context menu.
 IMPLOT_API bool ShowLegendContextMenu(ImPlotLegend& legend, bool visible);
 
 //-----------------------------------------------------------------------------
@@ -1442,7 +1465,7 @@ static inline const ImPlotNextItemData& GetItemData() { return GImPlot->NextItem
 
 // Returns true if a color is set to be automatically determined
 static inline bool IsColorAuto(const ImVec4& col) { return col.w == -1; }
-// Returns true if a style color is set to be automaticaly determined
+// Returns true if a style color is set to be automatically determined
 static inline bool IsColorAuto(ImPlotCol idx) { return IsColorAuto(GImPlot->Style.Colors[idx]); }
 // Returns the automatically deduced style color
 IMPLOT_API ImVec4 GetAutoColor(ImPlotCol idx);
@@ -1452,9 +1475,9 @@ static inline ImVec4 GetStyleColorVec4(ImPlotCol idx) { return IsColorAuto(idx) 
 static inline ImU32  GetStyleColorU32(ImPlotCol idx)  { return ImGui::ColorConvertFloat4ToU32(GetStyleColorVec4(idx)); }
 
 // Draws vertical text. The position is the bottom left of the text rect.
-IMPLOT_API void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char* text_begin, const char* text_end = NULL);
+IMPLOT_API void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char* text_begin, const char* text_end = nullptr);
 // Draws multiline horizontal text centered.
-IMPLOT_API void AddTextCentered(ImDrawList* DrawList, ImVec2 top_center, ImU32 col, const char* text_begin, const char* text_end = NULL);
+IMPLOT_API void AddTextCentered(ImDrawList* DrawList, ImVec2 top_center, ImU32 col, const char* text_begin, const char* text_end = nullptr);
 // Calculates the size of vertical text
 static inline ImVec2 CalcTextSizeVertical(const char *text) {
     ImVec2 sz = ImGui::CalcTextSize(text);
@@ -1518,8 +1541,8 @@ void FillRange(ImVector<T>& buffer, int n, T vmin, T vmax) {
 }
 
 // Calculate histogram bin counts and widths
-template <typename T>
-static inline void CalculateBins(const T* values, int count, ImPlotBin meth, const ImPlotRange& range, int& bins_out, double& width_out) {
+template <typename TContainer>
+static inline void CalculateBins(const TContainer& values, int count, ImPlotBin meth, const ImPlotRange& range, int& bins_out, double& width_out) {
     switch (meth) {
         case ImPlotBin_Sqrt:
             bins_out  = (int)ceil(sqrt(count));
@@ -1548,7 +1571,7 @@ static inline bool IsLeapYear(int year) {
 }
 // Returns the number of days in a month, accounting for Feb. leap years. #month is zero indexed.
 static inline int GetDaysInMonth(int year, int month) {
-    static const int days[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    constexpr int days[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
     return  days[month] + (int)(month == 1 && IsLeapYear(year));
 }
 
@@ -1565,11 +1588,24 @@ IMPLOT_API tm* GetLocTime(const ImPlotTime& t, tm* ptm);
 // NB: The following functions only work if there is a current ImPlotContext because the
 // internal tm struct is owned by the context! They are aware of ImPlotStyle.UseLocalTime.
 
+// // Make a UNIX timestamp from a tm struct according to the current ImPlotStyle.UseLocalTime setting.
+static inline ImPlotTime MkTime(struct tm *ptm) {
+    if (GetStyle().UseLocalTime) return MkLocTime(ptm);
+    else                         return MkGmtTime(ptm);
+}
+// Get a tm struct from a UNIX timestamp according to the current ImPlotStyle.UseLocalTime setting.
+static inline tm* GetTime(const ImPlotTime& t, tm* ptm) {
+    if (GetStyle().UseLocalTime) return GetLocTime(t,ptm);
+    else                         return GetGmtTime(t,ptm);
+}
+
 // Make a timestamp from time components.
 // year[1970-3000], month[0-11], day[1-31], hour[0-23], min[0-59], sec[0-59], us[0,999999]
 IMPLOT_API ImPlotTime MakeTime(int year, int month = 0, int day = 1, int hour = 0, int min = 0, int sec = 0, int us = 0);
 // Get year component from timestamp [1970-3000]
 IMPLOT_API int GetYear(const ImPlotTime& t);
+// Get month component from timestamp [0-11]
+IMPLOT_API int GetMonth(const ImPlotTime& t);
 
 // Adds or subtracts time from a timestamp. #count > 0 to add, < 0 to subtract.
 IMPLOT_API ImPlotTime AddTime(const ImPlotTime& t, ImPlotTimeUnit unit, int count);
@@ -1582,6 +1618,11 @@ IMPLOT_API ImPlotTime RoundTime(const ImPlotTime& t, ImPlotTimeUnit unit);
 // Combines the date of one timestamp with the time-of-day of another timestamp.
 IMPLOT_API ImPlotTime CombineDateTime(const ImPlotTime& date_part, const ImPlotTime& time_part);
 
+// Get the current time as a timestamp.
+static inline ImPlotTime Now() { return ImPlotTime::FromDouble((double)time(nullptr)); }
+// Get the current date as a timestamp.
+static inline ImPlotTime Today() { return ImPlot::FloorTime(Now(), ImPlotTimeUnit_Day); }
+
 // Formats the time part of timestamp t into a buffer according to #fmt
 IMPLOT_API int FormatTime(const ImPlotTime& t, char* buffer, int size, ImPlotTimeFmt fmt, bool use_24_hr_clk);
 // Formats the date part of timestamp t into a buffer according to #fmt
@@ -1593,7 +1634,7 @@ IMPLOT_API int FormatDateTime(const ImPlotTime& t, char* buffer, int size, ImPlo
 // #level = 0 for day, 1 for month, 2 for year. Modified by user interaction.
 // #t will be set when a day is clicked and the function will return true.
 // #t1 and #t2 are optional dates to highlight.
-IMPLOT_API bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime* t1 = NULL, const ImPlotTime* t2 = NULL);
+IMPLOT_API bool ShowDatePicker(const char* id, int* level, ImPlotTime* t, const ImPlotTime* t1 = nullptr, const ImPlotTime* t2 = nullptr);
 // Shows a time picker widget block (hour/min/sec).
 // #t will be set when a new hour, minute, or sec is selected or am/pm is toggled, and the function will return true.
 IMPLOT_API bool ShowTimePicker(const char* id, ImPlotTime* t);
@@ -1662,9 +1703,11 @@ static inline int Formatter_Time(double, char* buff, int size, void* data) {
 // [SECTION] Locator
 //------------------------------------------------------------------------------
 
-void Locator_Default(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
-void Locator_Time(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
-void Locator_Log10(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
-void Locator_SymLog(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+IMPLOT_API void Locator_Default(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+IMPLOT_API void Locator_Time(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+IMPLOT_API void Locator_Log10(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
+IMPLOT_API void Locator_SymLog(ImPlotTicker& ticker, const ImPlotRange& range, float pixels, bool vertical, ImPlotFormatter formatter, void* formatter_data);
 
 } // namespace ImPlot
+
+#endif // #ifndef IMGUI_DISABLE

--- a/lib/implot/implot_items.cpp
+++ b/lib/implot/implot_items.cpp
@@ -1,0 +1,2686 @@
+// MIT License
+
+// Copyright (c) 2020 Evan Pezent
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ImPlot v0.14
+
+#include "implot.h"
+#include "implot_internal.h"
+
+//-----------------------------------------------------------------------------
+// [SECTION] Macros and Defines
+//-----------------------------------------------------------------------------
+
+#define SQRT_1_2 0.70710678118f
+#define SQRT_3_2 0.86602540378f
+
+#ifndef IMPLOT_NO_FORCE_INLINE
+    #ifdef _MSC_VER
+        #define IMPLOT_INLINE __forceinline
+    #elif defined(__GNUC__)
+        #define IMPLOT_INLINE inline __attribute__((__always_inline__))
+    #elif defined(__CLANG__)
+        #if __has_attribute(__always_inline__)
+            #define IMPLOT_INLINE inline __attribute__((__always_inline__))
+        #else
+            #define IMPLOT_INLINE inline
+        #endif
+    #else
+        #define IMPLOT_INLINE inline
+    #endif
+#else
+    #define IMPLOT_INLINE inline
+#endif
+
+#if defined __SSE__ || defined __x86_64__ || defined _M_X64
+#ifndef IMGUI_ENABLE_SSE
+#include <immintrin.h>
+#endif
+static IMPLOT_INLINE float  ImInvSqrt(float x) { return _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); }
+#else
+static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
+#endif
+
+#define IMPLOT_NORMALIZE2F_OVER_ZERO(VX,VY) do { float d2 = VX*VX + VY*VY; if (d2 > 0.0f) { float inv_len = ImInvSqrt(d2); VX *= inv_len; VY *= inv_len; } } while (0)
+
+// Support for pre-1.82 versions. Users on 1.82+ can use 0 (default) flags to mean "all corners" but in order to support older versions we are more explicit.
+#if (IMGUI_VERSION_NUM < 18102) && !defined(ImDrawFlags_RoundCornersAll)
+#define ImDrawFlags_RoundCornersAll ImDrawCornerFlags_All
+#endif
+
+//-----------------------------------------------------------------------------
+// [SECTION] Template instantiation utility
+//-----------------------------------------------------------------------------
+
+// By default, templates are instantiated for `float`, `double`, and for the following integer types, which are defined in imgui.h:
+//     signed char         ImS8;   // 8-bit signed integer
+//     unsigned char       ImU8;   // 8-bit unsigned integer
+//     signed short        ImS16;  // 16-bit signed integer
+//     unsigned short      ImU16;  // 16-bit unsigned integer
+//     signed int          ImS32;  // 32-bit signed integer == int
+//     unsigned int        ImU32;  // 32-bit unsigned integer
+//     signed   long long  ImS64;  // 64-bit signed integer
+//     unsigned long long  ImU64;  // 64-bit unsigned integer
+// (note: this list does *not* include `long`, `unsigned long` and `long double`)
+//
+// You can customize the supported types by defining IMPLOT_CUSTOM_NUMERIC_TYPES at compile time to define your own type list. 
+//    As an example, you could use the compile time define given by the line below in order to support only float and double.
+//        -DIMPLOT_CUSTOM_NUMERIC_TYPES="(float)(double)"
+//    In order to support all known C++ types, use:
+//        -DIMPLOT_CUSTOM_NUMERIC_TYPES="(signed char)(unsigned char)(signed short)(unsigned short)(signed int)(unsigned int)(signed long)(unsigned long)(signed long long)(unsigned long long)(float)(double)(long double)"
+
+#ifdef IMPLOT_CUSTOM_NUMERIC_TYPES
+    #define IMPLOT_NUMERIC_TYPES IMPLOT_CUSTOM_NUMERIC_TYPES
+#else
+    #define IMPLOT_NUMERIC_TYPES (ImS8)(ImU8)(ImS16)(ImU16)(ImS32)(ImU32)(ImS64)(ImU64)(float)(double)
+#endif
+
+// CALL_INSTANTIATE_FOR_NUMERIC_TYPES will duplicate the template instantion code `INSTANTIATE_MACRO(T)` on supported types.
+#define _CAT(x, y) _CAT_(x, y)
+#define _CAT_(x,y) x ## y
+#define _INSTANTIATE_FOR_NUMERIC_TYPES(chain) _CAT(_INSTANTIATE_FOR_NUMERIC_TYPES_1 chain, _END)
+#define _INSTANTIATE_FOR_NUMERIC_TYPES_1(T) INSTANTIATE_MACRO(T); _INSTANTIATE_FOR_NUMERIC_TYPES_2
+#define _INSTANTIATE_FOR_NUMERIC_TYPES_2(T) INSTANTIATE_MACRO(T); _INSTANTIATE_FOR_NUMERIC_TYPES_1
+#define _INSTANTIATE_FOR_NUMERIC_TYPES_1_END
+#define _INSTANTIATE_FOR_NUMERIC_TYPES_2_END
+#define CALL_INSTANTIATE_FOR_NUMERIC_TYPES() _INSTANTIATE_FOR_NUMERIC_TYPES(IMPLOT_NUMERIC_TYPES);
+
+namespace ImPlot {
+
+//-----------------------------------------------------------------------------
+// [SECTION] Utils
+//-----------------------------------------------------------------------------
+
+// Calc maximum index size of ImDrawIdx
+template <typename T>
+struct MaxIdx { static const unsigned int Value; };
+template <> const unsigned int MaxIdx<unsigned short>::Value = 65535;
+template <> const unsigned int MaxIdx<unsigned int>::Value   = 4294967295;
+
+IMPLOT_INLINE void GetLineRenderProps(const ImDrawList& draw_list, float& half_weight, ImVec2& tex_uv0, ImVec2& tex_uv1) {
+    const bool aa = ImHasFlag(draw_list.Flags, ImDrawListFlags_AntiAliasedLines) &&
+                    ImHasFlag(draw_list.Flags, ImDrawListFlags_AntiAliasedLinesUseTex);
+    if (aa) {
+        ImVec4 tex_uvs = draw_list._Data->TexUvLines[(int)(half_weight*2)];
+        tex_uv0 = ImVec2(tex_uvs.x, tex_uvs.y);
+        tex_uv1 = ImVec2(tex_uvs.z, tex_uvs.w);
+        half_weight += 1;
+    }
+    else {
+        tex_uv0 = tex_uv1 = draw_list._Data->TexUvWhitePixel;
+    }
+}
+
+IMPLOT_INLINE void PrimLine(ImDrawList& draw_list, const ImVec2& P1, const ImVec2& P2, float half_weight, ImU32 col, const ImVec2& tex_uv0, const ImVec2 tex_uv1) {
+    float dx = P2.x - P1.x;
+    float dy = P2.y - P1.y;
+    IMPLOT_NORMALIZE2F_OVER_ZERO(dx, dy);
+    dx *= half_weight;
+    dy *= half_weight;
+    draw_list._VtxWritePtr[0].pos.x = P1.x + dy;
+    draw_list._VtxWritePtr[0].pos.y = P1.y - dx;
+    draw_list._VtxWritePtr[0].uv    = tex_uv0;
+    draw_list._VtxWritePtr[0].col   = col;
+    draw_list._VtxWritePtr[1].pos.x = P2.x + dy;
+    draw_list._VtxWritePtr[1].pos.y = P2.y - dx;
+    draw_list._VtxWritePtr[1].uv    = tex_uv0;
+    draw_list._VtxWritePtr[1].col   = col;
+    draw_list._VtxWritePtr[2].pos.x = P2.x - dy;
+    draw_list._VtxWritePtr[2].pos.y = P2.y + dx;
+    draw_list._VtxWritePtr[2].uv    = tex_uv1;
+    draw_list._VtxWritePtr[2].col   = col;
+    draw_list._VtxWritePtr[3].pos.x = P1.x - dy;
+    draw_list._VtxWritePtr[3].pos.y = P1.y + dx;
+    draw_list._VtxWritePtr[3].uv    = tex_uv1;
+    draw_list._VtxWritePtr[3].col   = col;
+    draw_list._VtxWritePtr += 4;
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 2);
+    draw_list._IdxWritePtr[3] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+    draw_list._IdxWritePtr[4] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 2);
+    draw_list._IdxWritePtr[5] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 3);
+    draw_list._IdxWritePtr += 6;
+    draw_list._VtxCurrentIdx += 4;
+}
+
+IMPLOT_INLINE void PrimRectFill(ImDrawList& draw_list, const ImVec2& Pmin, const ImVec2& Pmax, ImU32 col, const ImVec2& uv) {
+    draw_list._VtxWritePtr[0].pos   = Pmin;
+    draw_list._VtxWritePtr[0].uv    = uv;
+    draw_list._VtxWritePtr[0].col   = col;
+    draw_list._VtxWritePtr[1].pos   = Pmax;
+    draw_list._VtxWritePtr[1].uv    = uv;
+    draw_list._VtxWritePtr[1].col   = col;
+    draw_list._VtxWritePtr[2].pos.x = Pmin.x;
+    draw_list._VtxWritePtr[2].pos.y = Pmax.y;
+    draw_list._VtxWritePtr[2].uv    = uv;
+    draw_list._VtxWritePtr[2].col   = col;
+    draw_list._VtxWritePtr[3].pos.x = Pmax.x;
+    draw_list._VtxWritePtr[3].pos.y = Pmin.y;
+    draw_list._VtxWritePtr[3].uv    = uv;
+    draw_list._VtxWritePtr[3].col   = col;
+    draw_list._VtxWritePtr += 4;
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 2);
+    draw_list._IdxWritePtr[3] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+    draw_list._IdxWritePtr[4] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1);
+    draw_list._IdxWritePtr[5] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 3);
+    draw_list._IdxWritePtr += 6;
+    draw_list._VtxCurrentIdx += 4;
+}
+
+IMPLOT_INLINE void PrimRectLine(ImDrawList& draw_list, const ImVec2& Pmin, const ImVec2& Pmax, float weight, ImU32 col, const ImVec2& uv) {
+
+    draw_list._VtxWritePtr[0].pos.x = Pmin.x;
+    draw_list._VtxWritePtr[0].pos.y = Pmin.y;
+    draw_list._VtxWritePtr[0].uv    = uv;
+    draw_list._VtxWritePtr[0].col   = col;
+
+    draw_list._VtxWritePtr[1].pos.x = Pmin.x;
+    draw_list._VtxWritePtr[1].pos.y = Pmax.y;
+    draw_list._VtxWritePtr[1].uv    = uv;
+    draw_list._VtxWritePtr[1].col   = col;
+
+    draw_list._VtxWritePtr[2].pos.x = Pmax.x;
+    draw_list._VtxWritePtr[2].pos.y = Pmax.y;
+    draw_list._VtxWritePtr[2].uv    = uv;
+    draw_list._VtxWritePtr[2].col   = col;
+
+    draw_list._VtxWritePtr[3].pos.x = Pmax.x;
+    draw_list._VtxWritePtr[3].pos.y = Pmin.y;
+    draw_list._VtxWritePtr[3].uv    = uv;
+    draw_list._VtxWritePtr[3].col   = col;
+
+    draw_list._VtxWritePtr[4].pos.x = Pmin.x + weight;
+    draw_list._VtxWritePtr[4].pos.y = Pmin.y + weight;
+    draw_list._VtxWritePtr[4].uv    = uv;
+    draw_list._VtxWritePtr[4].col   = col;
+
+    draw_list._VtxWritePtr[5].pos.x = Pmin.x + weight;
+    draw_list._VtxWritePtr[5].pos.y = Pmax.y - weight;
+    draw_list._VtxWritePtr[5].uv    = uv;
+    draw_list._VtxWritePtr[5].col   = col;
+
+    draw_list._VtxWritePtr[6].pos.x = Pmax.x - weight;
+    draw_list._VtxWritePtr[6].pos.y = Pmax.y - weight;
+    draw_list._VtxWritePtr[6].uv    = uv;
+    draw_list._VtxWritePtr[6].col   = col;
+
+    draw_list._VtxWritePtr[7].pos.x = Pmax.x - weight;
+    draw_list._VtxWritePtr[7].pos.y = Pmin.y + weight;
+    draw_list._VtxWritePtr[7].uv    = uv;
+    draw_list._VtxWritePtr[7].col   = col;
+
+    draw_list._VtxWritePtr += 8;
+
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 0);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 5);
+    draw_list._IdxWritePtr += 3;
+
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 0);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 5);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 4);
+    draw_list._IdxWritePtr += 3;
+
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 2);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 6);
+    draw_list._IdxWritePtr += 3;
+
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 6);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 5);
+    draw_list._IdxWritePtr += 3;
+
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 2);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 3);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 7);
+    draw_list._IdxWritePtr += 3;
+
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 2);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 7);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 6);
+    draw_list._IdxWritePtr += 3;
+
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 3);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 0);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 4);
+    draw_list._IdxWritePtr += 3;
+
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 3);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 4);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 7);
+    draw_list._IdxWritePtr += 3;
+
+    draw_list._VtxCurrentIdx += 8;
+}
+
+
+//-----------------------------------------------------------------------------
+// [SECTION] Item Utils
+//-----------------------------------------------------------------------------
+
+ImPlotItem* RegisterOrGetItem(const char* label_id, ImPlotItemFlags flags, bool* just_created) {
+    ImPlotContext& gp = *GImPlot;
+    ImPlotItemGroup& Items = *gp.CurrentItems;
+    ImGuiID id = Items.GetItemID(label_id);
+    if (just_created != NULL)
+        *just_created = Items.GetItem(id) == NULL;
+    ImPlotItem* item = Items.GetOrAddItem(id);
+    if (item->SeenThisFrame)
+        return item;
+    item->SeenThisFrame = true;
+    int idx = Items.GetItemIndex(item);
+    item->ID = id;
+    if (!ImHasFlag(flags, ImPlotItemFlags_NoLegend) && ImGui::FindRenderedTextEnd(label_id, NULL) != label_id) {
+        Items.Legend.Indices.push_back(idx);
+        item->NameOffset = Items.Legend.Labels.size();
+        Items.Legend.Labels.append(label_id, label_id + strlen(label_id) + 1);
+    }
+    else {
+        item->Show = true;
+    }
+    return item;
+}
+
+ImPlotItem* GetItem(const char* label_id) {
+    ImPlotContext& gp = *GImPlot;
+    return gp.CurrentItems->GetItem(label_id);
+}
+
+bool IsItemHidden(const char* label_id) {
+    ImPlotItem* item = GetItem(label_id);
+    return item != NULL && !item->Show;
+}
+
+ImPlotItem* GetCurrentItem() {
+    ImPlotContext& gp = *GImPlot;
+    return gp.CurrentItem;
+}
+
+void SetNextLineStyle(const ImVec4& col, float weight) {
+    ImPlotContext& gp = *GImPlot;
+    gp.NextItemData.Colors[ImPlotCol_Line] = col;
+    gp.NextItemData.LineWeight             = weight;
+}
+
+void SetNextFillStyle(const ImVec4& col, float alpha) {
+    ImPlotContext& gp = *GImPlot;
+    gp.NextItemData.Colors[ImPlotCol_Fill] = col;
+    gp.NextItemData.FillAlpha              = alpha;
+}
+
+void SetNextMarkerStyle(ImPlotMarker marker, float size, const ImVec4& fill, float weight, const ImVec4& outline) {
+    ImPlotContext& gp = *GImPlot;
+    gp.NextItemData.Marker                          = marker;
+    gp.NextItemData.Colors[ImPlotCol_MarkerFill]    = fill;
+    gp.NextItemData.MarkerSize                      = size;
+    gp.NextItemData.Colors[ImPlotCol_MarkerOutline] = outline;
+    gp.NextItemData.MarkerWeight                    = weight;
+}
+
+void SetNextErrorBarStyle(const ImVec4& col, float size, float weight) {
+    ImPlotContext& gp = *GImPlot;
+    gp.NextItemData.Colors[ImPlotCol_ErrorBar] = col;
+    gp.NextItemData.ErrorBarSize               = size;
+    gp.NextItemData.ErrorBarWeight             = weight;
+}
+
+ImVec4 GetLastItemColor() {
+    ImPlotContext& gp = *GImPlot;
+    if (gp.PreviousItem)
+        return ImGui::ColorConvertU32ToFloat4(gp.PreviousItem->Color);
+    return ImVec4();
+}
+
+void BustItemCache() {
+    ImPlotContext& gp = *GImPlot;
+    for (int p = 0; p < gp.Plots.GetBufSize(); ++p) {
+        ImPlotPlot& plot = *gp.Plots.GetByIndex(p);
+        plot.Items.Reset();
+    }
+    for (int p = 0; p < gp.Subplots.GetBufSize(); ++p) {
+        ImPlotSubplot& subplot = *gp.Subplots.GetByIndex(p);
+        subplot.Items.Reset();
+    }
+}
+
+void BustColorCache(const char* plot_title_id) {
+    ImPlotContext& gp = *GImPlot;
+    if (plot_title_id == NULL) {
+        BustItemCache();
+    }
+    else {
+        ImGuiID id = ImGui::GetCurrentWindow()->GetID(plot_title_id);
+        ImPlotPlot* plot = gp.Plots.GetByKey(id);
+        if (plot != NULL)
+            plot->Items.Reset();
+        else {
+            ImPlotSubplot* subplot = gp.Subplots.GetByKey(id);
+            if (subplot != NULL)
+                subplot->Items.Reset();
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] BeginItem / EndItem
+//-----------------------------------------------------------------------------
+
+static const float ITEM_HIGHLIGHT_LINE_SCALE = 2.0f;
+static const float ITEM_HIGHLIGHT_MARK_SCALE = 1.25f;
+
+// Begins a new item. Returns false if the item should not be plotted.
+bool BeginItem(const char* label_id, ImPlotItemFlags flags, ImPlotCol recolor_from) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "PlotX() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    bool just_created;
+    ImPlotItem* item = RegisterOrGetItem(label_id, flags, &just_created);
+    // set current item
+    gp.CurrentItem = item;
+    ImPlotNextItemData& s = gp.NextItemData;
+    // set/override item color
+    if (recolor_from != -1) {
+        if (!IsColorAuto(s.Colors[recolor_from]))
+            item->Color = ImGui::ColorConvertFloat4ToU32(s.Colors[recolor_from]);
+        else if (!IsColorAuto(gp.Style.Colors[recolor_from]))
+            item->Color = ImGui::ColorConvertFloat4ToU32(gp.Style.Colors[recolor_from]);
+        else if (just_created)
+            item->Color = NextColormapColorU32();
+    }
+    else if (just_created) {
+        item->Color = NextColormapColorU32();
+    }
+    // hide/show item
+    if (gp.NextItemData.HasHidden) {
+        if (just_created || gp.NextItemData.HiddenCond == ImGuiCond_Always)
+            item->Show = !gp.NextItemData.Hidden;
+    }
+    if (!item->Show) {
+        // reset next item data
+        gp.NextItemData.Reset();
+        gp.PreviousItem = item;
+        gp.CurrentItem  = NULL;
+        return false;
+    }
+    else {
+        ImVec4 item_color = ImGui::ColorConvertU32ToFloat4(item->Color);
+        // stage next item colors
+        s.Colors[ImPlotCol_Line]           = IsColorAuto(s.Colors[ImPlotCol_Line])          ? ( IsColorAuto(ImPlotCol_Line)           ? item_color                 : gp.Style.Colors[ImPlotCol_Line]          ) : s.Colors[ImPlotCol_Line];
+        s.Colors[ImPlotCol_Fill]           = IsColorAuto(s.Colors[ImPlotCol_Fill])          ? ( IsColorAuto(ImPlotCol_Fill)           ? item_color                 : gp.Style.Colors[ImPlotCol_Fill]          ) : s.Colors[ImPlotCol_Fill];
+        s.Colors[ImPlotCol_MarkerOutline]  = IsColorAuto(s.Colors[ImPlotCol_MarkerOutline]) ? ( IsColorAuto(ImPlotCol_MarkerOutline)  ? s.Colors[ImPlotCol_Line]   : gp.Style.Colors[ImPlotCol_MarkerOutline] ) : s.Colors[ImPlotCol_MarkerOutline];
+        s.Colors[ImPlotCol_MarkerFill]     = IsColorAuto(s.Colors[ImPlotCol_MarkerFill])    ? ( IsColorAuto(ImPlotCol_MarkerFill)     ? s.Colors[ImPlotCol_Line]   : gp.Style.Colors[ImPlotCol_MarkerFill]    ) : s.Colors[ImPlotCol_MarkerFill];
+        s.Colors[ImPlotCol_ErrorBar]       = IsColorAuto(s.Colors[ImPlotCol_ErrorBar])      ? ( GetStyleColorVec4(ImPlotCol_ErrorBar)                                                                         ) : s.Colors[ImPlotCol_ErrorBar];
+        // stage next item style vars
+        s.LineWeight         = s.LineWeight       < 0 ? gp.Style.LineWeight       : s.LineWeight;
+        s.Marker             = s.Marker           < 0 ? gp.Style.Marker           : s.Marker;
+        s.MarkerSize         = s.MarkerSize       < 0 ? gp.Style.MarkerSize       : s.MarkerSize;
+        s.MarkerWeight       = s.MarkerWeight     < 0 ? gp.Style.MarkerWeight     : s.MarkerWeight;
+        s.FillAlpha          = s.FillAlpha        < 0 ? gp.Style.FillAlpha        : s.FillAlpha;
+        s.ErrorBarSize       = s.ErrorBarSize     < 0 ? gp.Style.ErrorBarSize     : s.ErrorBarSize;
+        s.ErrorBarWeight     = s.ErrorBarWeight   < 0 ? gp.Style.ErrorBarWeight   : s.ErrorBarWeight;
+        s.DigitalBitHeight   = s.DigitalBitHeight < 0 ? gp.Style.DigitalBitHeight : s.DigitalBitHeight;
+        s.DigitalBitGap      = s.DigitalBitGap    < 0 ? gp.Style.DigitalBitGap    : s.DigitalBitGap;
+        // apply alpha modifier(s)
+        s.Colors[ImPlotCol_Fill].w       *= s.FillAlpha;
+        s.Colors[ImPlotCol_MarkerFill].w *= s.FillAlpha; // TODO: this should be separate, if it at all
+        // apply highlight mods
+        if (item->LegendHovered) {
+            if (!ImHasFlag(gp.CurrentItems->Legend.Flags, ImPlotLegendFlags_NoHighlightItem)) {
+                s.LineWeight   *= ITEM_HIGHLIGHT_LINE_SCALE;
+                s.MarkerSize   *= ITEM_HIGHLIGHT_MARK_SCALE;
+                s.MarkerWeight *= ITEM_HIGHLIGHT_LINE_SCALE;
+                // TODO: how to highlight fills?
+            }
+            if (!ImHasFlag(gp.CurrentItems->Legend.Flags, ImPlotLegendFlags_NoHighlightAxis)) {
+                if (gp.CurrentPlot->EnabledAxesX() > 1)
+                    gp.CurrentPlot->Axes[gp.CurrentPlot->CurrentX].ColorHiLi = item->Color;
+                if (gp.CurrentPlot->EnabledAxesY() > 1)
+                    gp.CurrentPlot->Axes[gp.CurrentPlot->CurrentY].ColorHiLi = item->Color;
+            }
+        }
+        // set render flags
+        s.RenderLine       = s.Colors[ImPlotCol_Line].w          > 0 && s.LineWeight > 0;
+        s.RenderFill       = s.Colors[ImPlotCol_Fill].w          > 0;
+        s.RenderMarkerFill = s.Colors[ImPlotCol_MarkerFill].w    > 0;
+        s.RenderMarkerLine = s.Colors[ImPlotCol_MarkerOutline].w > 0 && s.MarkerWeight > 0;
+        // push rendering clip rect
+        PushPlotClipRect();
+        return true;
+    }
+}
+
+// Ends an item (call only if BeginItem returns true)
+void EndItem() {
+    ImPlotContext& gp = *GImPlot;
+    // pop rendering clip rect
+    PopPlotClipRect();
+    // reset next item data
+    gp.NextItemData.Reset();
+    // set current item
+    gp.PreviousItem = gp.CurrentItem;
+    gp.CurrentItem  = NULL;
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Indexers
+//-----------------------------------------------------------------------------
+
+template <typename T>
+IMPLOT_INLINE T IndexData(const T* data, int idx, int count, int offset, int stride) {
+    const int s = ((offset == 0) << 0) | ((stride == sizeof(T)) << 1);
+    switch (s) {
+        case 3 : return data[idx];
+        case 2 : return data[(offset + idx) % count];
+        case 1 : return *(const T*)(const void*)((const unsigned char*)data + (size_t)((idx) ) * stride);
+        case 0 : return *(const T*)(const void*)((const unsigned char*)data + (size_t)((offset + idx) % count) * stride);
+        default: return T(0);
+    }
+}
+
+template <typename T>
+struct IndexerIdx {
+    IndexerIdx(const T* data, int count, int offset = 0, int stride = sizeof(T)) :
+        Data(data),
+        Count(count),
+        Offset(count ? ImPosMod(offset, count) : 0),
+        Stride(stride)
+    { }
+    template <typename I> IMPLOT_INLINE double operator()(I idx) const {
+        return (double)IndexData(Data, idx, Count, Offset, Stride);
+    }
+    const T* Data;
+    int Count;
+    int Offset;
+    int Stride;
+};
+
+template <typename _Indexer1, typename _Indexer2>
+struct IndexerAdd {
+    IndexerAdd(const _Indexer1& indexer1, const _Indexer2& indexer2, double scale1 = 1, double scale2 = 1)
+        : Indexer1(indexer1),
+          Indexer2(indexer2),
+          Scale1(scale1),
+          Scale2(scale2),
+          Count(ImMin(Indexer1.Count, Indexer2.Count))
+    { }
+    template <typename I> IMPLOT_INLINE double operator()(I idx) const {
+        return Scale1 * Indexer1(idx) + Scale2 * Indexer2(idx);
+    }
+    const _Indexer1& Indexer1;
+    const _Indexer2& Indexer2;
+    double Scale1;
+    double Scale2;
+    int Count;
+};
+
+struct IndexerLin {
+    IndexerLin(double m, double b) : M(m), B(b) { }
+    template <typename I> IMPLOT_INLINE double operator()(I idx) const {
+        return M * idx + B;
+    }
+    const double M;
+    const double B;
+};
+
+struct IndexerConst {
+    IndexerConst(double ref) : Ref(ref) { }
+    template <typename I> IMPLOT_INLINE double operator()(I) const { return Ref; }
+    const double Ref;
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Getters
+//-----------------------------------------------------------------------------
+
+template <typename _IndexerX, typename _IndexerY>
+struct GetterXY {
+    GetterXY(_IndexerX x, _IndexerY y, int count) : IndxerX(x), IndxerY(y), Count(count) { }
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
+        return ImPlotPoint(IndxerX(idx),IndxerY(idx));
+    }
+    const _IndexerX IndxerX;
+    const _IndexerY IndxerY;
+    const int Count;
+};
+
+/// Interprets a user's function pointer as ImPlotPoints
+struct GetterFuncPtr {
+    GetterFuncPtr(ImPlotGetter getter, void* data, int count) :
+        Getter(getter),
+        Data(data),
+        Count(count)
+    { }
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
+        return Getter(idx, Data);
+    }
+    ImPlotGetter Getter;
+    void* const Data;
+    const int Count;
+};
+
+template <typename _Getter>
+struct GetterOverrideX {
+    GetterOverrideX(_Getter getter, double x) : Getter(getter), X(x), Count(getter.Count) { }
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
+        ImPlotPoint p = Getter(idx);
+        p.x = X;
+        return p;
+    }
+    const _Getter Getter;
+    const double X;
+    const int Count;
+};
+
+template <typename _Getter>
+struct GetterOverrideY {
+    GetterOverrideY(_Getter getter, double y) : Getter(getter), Y(y), Count(getter.Count) { }
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
+        ImPlotPoint p = Getter(idx);
+        p.y = Y;
+        return p;
+    }
+    const _Getter Getter;
+    const double Y;
+    const int Count;
+};
+
+template <typename _Getter>
+struct GetterLoop {
+    GetterLoop(_Getter getter) : Getter(getter), Count(getter.Count + 1) { }
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
+        idx = idx % (Count - 1);
+        return Getter(idx);
+    }
+    const _Getter Getter;
+    const int Count;
+};
+
+template <typename T>
+struct GetterError {
+    GetterError(const T* xs, const T* ys, const T* neg, const T* pos, int count, int offset, int stride) :
+        Xs(xs),
+        Ys(ys),
+        Neg(neg),
+        Pos(pos),
+        Count(count),
+        Offset(count ? ImPosMod(offset, count) : 0),
+        Stride(stride)
+    { }
+    template <typename I> IMPLOT_INLINE ImPlotPointError operator()(I idx) const {
+        return ImPlotPointError((double)IndexData(Xs,  idx, Count, Offset, Stride),
+                                (double)IndexData(Ys,  idx, Count, Offset, Stride),
+                                (double)IndexData(Neg, idx, Count, Offset, Stride),
+                                (double)IndexData(Pos, idx, Count, Offset, Stride));
+    }
+    const T* const Xs;
+    const T* const Ys;
+    const T* const Neg;
+    const T* const Pos;
+    const int Count;
+    const int Offset;
+    const int Stride;
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Fitters
+//-----------------------------------------------------------------------------
+
+template <typename _Getter1>
+struct Fitter1 {
+    Fitter1(const _Getter1& getter) : Getter(getter) { }
+    void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
+        for (int i = 0; i < Getter.Count; ++i) {
+            ImPlotPoint p = Getter(i);
+            x_axis.ExtendFitWith(y_axis, p.x, p.y);
+            y_axis.ExtendFitWith(x_axis, p.y, p.x);
+        }
+    }
+    const _Getter1& Getter;
+};
+
+template <typename _Getter1>
+struct FitterX {
+    FitterX(const _Getter1& getter) : Getter(getter) { }
+    void Fit(ImPlotAxis& x_axis, ImPlotAxis&) const {
+        for (int i = 0; i < Getter.Count; ++i) {
+            ImPlotPoint p = Getter(i);
+            x_axis.ExtendFit(p.x);
+        }
+    }
+    const _Getter1& Getter;
+};
+
+template <typename _Getter1>
+struct FitterY {
+    FitterY(const _Getter1& getter) : Getter(getter) { }
+    void Fit(ImPlotAxis&, ImPlotAxis& y_axis) const {
+        for (int i = 0; i < Getter.Count; ++i) {
+            ImPlotPoint p = Getter(i);
+            y_axis.ExtendFit(p.y);
+        }
+    }
+    const _Getter1& Getter;
+};
+
+template <typename _Getter1, typename _Getter2>
+struct Fitter2 {
+    Fitter2(const _Getter1& getter1, const _Getter2& getter2) : Getter1(getter1), Getter2(getter2) { }
+    void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
+        for (int i = 0; i < Getter1.Count; ++i) {
+            ImPlotPoint p = Getter1(i);
+            x_axis.ExtendFitWith(y_axis, p.x, p.y);
+            y_axis.ExtendFitWith(x_axis, p.y, p.x);
+        }
+        for (int i = 0; i < Getter2.Count; ++i) {
+            ImPlotPoint p = Getter2(i);
+            x_axis.ExtendFitWith(y_axis, p.x, p.y);
+            y_axis.ExtendFitWith(x_axis, p.y, p.x);
+        }
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+};
+
+template <typename _Getter1, typename _Getter2>
+struct FitterBarV {
+    FitterBarV(const _Getter1& getter1, const _Getter2& getter2, double width) :
+        Getter1(getter1),
+        Getter2(getter2),
+        HalfWidth(width*0.5)
+    { }
+    void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
+        int count = ImMin(Getter1.Count, Getter2.Count);
+        for (int i = 0; i < count; ++i) {
+            ImPlotPoint p1 = Getter1(i); p1.x -= HalfWidth;
+            ImPlotPoint p2 = Getter2(i); p2.x += HalfWidth;
+            x_axis.ExtendFitWith(y_axis, p1.x, p1.y);
+            y_axis.ExtendFitWith(x_axis, p1.y, p1.x);
+            x_axis.ExtendFitWith(y_axis, p2.x, p2.y);
+            y_axis.ExtendFitWith(x_axis, p2.y, p2.x);
+        }
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+    const double    HalfWidth;
+};
+
+template <typename _Getter1, typename _Getter2>
+struct FitterBarH {
+    FitterBarH(const _Getter1& getter1, const _Getter2& getter2, double height) :
+        Getter1(getter1),
+        Getter2(getter2),
+        HalfHeight(height*0.5)
+    { }
+    void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
+        int count = ImMin(Getter1.Count, Getter2.Count);
+        for (int i = 0; i < count; ++i) {
+            ImPlotPoint p1 = Getter1(i); p1.y -= HalfHeight;
+            ImPlotPoint p2 = Getter2(i); p2.y += HalfHeight;
+            x_axis.ExtendFitWith(y_axis, p1.x, p1.y);
+            y_axis.ExtendFitWith(x_axis, p1.y, p1.x);
+            x_axis.ExtendFitWith(y_axis, p2.x, p2.y);
+            y_axis.ExtendFitWith(x_axis, p2.y, p2.x);
+        }
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+    const double    HalfHeight;
+};
+
+struct FitterRect {
+    FitterRect(const ImPlotPoint& pmin, const ImPlotPoint& pmax) :
+        Pmin(pmin),
+        Pmax(pmax)
+    { }
+    FitterRect(const ImPlotRect& rect) :
+        FitterRect(rect.Min(), rect.Max())
+    { }
+    void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
+        x_axis.ExtendFitWith(y_axis, Pmin.x, Pmin.y);
+        y_axis.ExtendFitWith(x_axis, Pmin.y, Pmin.x);
+        x_axis.ExtendFitWith(y_axis, Pmax.x, Pmax.y);
+        y_axis.ExtendFitWith(x_axis, Pmax.y, Pmax.x);
+    }
+    const ImPlotPoint Pmin;
+    const ImPlotPoint Pmax;
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Transformers
+//-----------------------------------------------------------------------------
+
+struct Transformer1 {
+    Transformer1(double pixMin, double pltMin, double pltMax, double m, double scaMin, double scaMax, ImPlotTransform fwd, void* data) :
+        ScaMin(scaMin),
+        ScaMax(scaMax),
+        PltMin(pltMin),
+        PltMax(pltMax),
+        PixMin(pixMin),
+        M(m),
+        TransformFwd(fwd),
+        TransformData(data)
+    { }
+
+    template <typename T> IMPLOT_INLINE float operator()(T p) const {
+        if (TransformFwd != NULL) {
+            double s = TransformFwd(p, TransformData);
+            double t = (s - ScaMin) / (ScaMax - ScaMin);
+            p = PltMin + (PltMax - PltMin) * t;
+        }
+        return (float)(PixMin + M * (p - PltMin));
+    }
+
+    double ScaMin, ScaMax, PltMin, PltMax, PixMin, M;
+    ImPlotTransform TransformFwd;
+    void*           TransformData;
+};
+
+struct Transformer2 {
+    Transformer2(const ImPlotAxis& x_axis, const ImPlotAxis& y_axis) :
+        Tx(x_axis.PixelMin,
+           x_axis.Range.Min,
+           x_axis.Range.Max,
+           x_axis.ScaleToPixel,
+           x_axis.ScaleMin,
+           x_axis.ScaleMax,
+           x_axis.TransformForward,
+           x_axis.TransformData),
+        Ty(y_axis.PixelMin,
+           y_axis.Range.Min,
+           y_axis.Range.Max,
+           y_axis.ScaleToPixel,
+           y_axis.ScaleMin,
+           y_axis.ScaleMax,
+           y_axis.TransformForward,
+           y_axis.TransformData)
+    { }
+
+    Transformer2(const ImPlotPlot& plot) :
+        Transformer2(plot.Axes[plot.CurrentX], plot.Axes[plot.CurrentY])
+    { }
+
+    Transformer2() :
+        Transformer2(*GImPlot->CurrentPlot)
+    { }
+
+    template <typename P> IMPLOT_INLINE ImVec2 operator()(const P& plt) const {
+        ImVec2 out;
+        out.x = Tx(plt.x);
+        out.y = Ty(plt.y);
+        return out;
+    }
+
+    template <typename T> IMPLOT_INLINE ImVec2 operator()(T x, T y) const {
+        ImVec2 out;
+        out.x = Tx(x);
+        out.y = Ty(y);
+        return out;
+    }
+
+    Transformer1 Tx;
+    Transformer1 Ty;
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Renderers
+//-----------------------------------------------------------------------------
+
+struct RendererBase {
+    RendererBase(int prims, int idx_consumed, int vtx_consumed) :
+        Prims(prims),
+        IdxConsumed(idx_consumed),
+        VtxConsumed(vtx_consumed)
+    { }
+    const int Prims;
+    Transformer2 Transformer;
+    const int IdxConsumed;
+    const int VtxConsumed;
+};
+
+template <class _Getter>
+struct RendererLineStrip : RendererBase {
+    RendererLineStrip(const _Getter& getter, ImU32 col, float weight) :
+        RendererBase(getter.Count - 1, 6, 4),
+        Getter(getter),
+        Col(col),
+        HalfWeight(ImMax(1.0f,weight)*0.5f)
+    {
+        P1 = this->Transformer(Getter(0));
+    }
+    void Init(ImDrawList& draw_list) const {
+        GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
+            P1 = P2;
+            return false;
+        }
+        PrimLine(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+        P1 = P2;
+        return true;
+    }
+    const _Getter& Getter;
+    const ImU32 Col;
+    mutable float HalfWeight;
+    mutable ImVec2 P1;
+    mutable ImVec2 UV0;
+    mutable ImVec2 UV1;
+};
+
+template <class _Getter>
+struct RendererLineStripSkip : RendererBase {
+    RendererLineStripSkip(const _Getter& getter, ImU32 col, float weight) :
+        RendererBase(getter.Count - 1, 6, 4),
+        Getter(getter),
+        Col(col),
+        HalfWeight(ImMax(1.0f,weight)*0.5f)
+    {
+        P1 = this->Transformer(Getter(0));
+    }
+    void Init(ImDrawList& draw_list) const {
+        GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
+            if (!ImNan(P2.x) && !ImNan(P2.y))
+                P1 = P2;
+            return false;
+        }
+        PrimLine(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+        if (!ImNan(P2.x) && !ImNan(P2.y))
+            P1 = P2;
+        return true;
+    }
+    const _Getter& Getter;
+    const ImU32 Col;
+    mutable float HalfWeight;
+    mutable ImVec2 P1;
+    mutable ImVec2 UV0;
+    mutable ImVec2 UV1;
+};
+
+template <class _Getter>
+struct RendererLineSegments1 : RendererBase {
+    RendererLineSegments1(const _Getter& getter, ImU32 col, float weight) :
+        RendererBase(getter.Count / 2, 6, 4),
+        Getter(getter),
+        Col(col),
+        HalfWeight(ImMax(1.0f,weight)*0.5f)
+    { }
+    void Init(ImDrawList& draw_list) const {
+        GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P1 = this->Transformer(Getter(prim*2+0));
+        ImVec2 P2 = this->Transformer(Getter(prim*2+1));
+        if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2))))
+            return false;
+        PrimLine(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+        return true;
+    }
+    const _Getter& Getter;
+    const ImU32 Col;
+    mutable float HalfWeight;
+    mutable ImVec2 UV0;
+    mutable ImVec2 UV1;
+};
+
+template <class _Getter1, class _Getter2>
+struct RendererLineSegments2 : RendererBase {
+    RendererLineSegments2(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, float weight) :
+        RendererBase(ImMin(getter1.Count, getter1.Count), 6, 4),
+        Getter1(getter1),
+        Getter2(getter2),
+        Col(col),
+        HalfWeight(ImMax(1.0f,weight)*0.5f)
+    {}
+    void Init(ImDrawList& draw_list) const {
+        GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P1 = this->Transformer(Getter1(prim));
+        ImVec2 P2 = this->Transformer(Getter2(prim));
+        if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2))))
+            return false;
+        PrimLine(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+        return true;
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+    const ImU32 Col;
+    mutable float HalfWeight;
+    mutable ImVec2 UV0;
+    mutable ImVec2 UV1;
+};
+
+template <class _Getter1, class _Getter2>
+struct RendererBarsFillV : RendererBase {
+    RendererBarsFillV(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, double width) :
+        RendererBase(ImMin(getter1.Count, getter1.Count), 6, 4),
+        Getter1(getter1),
+        Getter2(getter2),
+        Col(col),
+        HalfWidth(width/2)
+    {}
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImPlotPoint p1 = Getter1(prim);
+        ImPlotPoint p2 = Getter2(prim);
+        p1.x += HalfWidth;
+        p2.x -= HalfWidth;
+        ImVec2 P1 = this->Transformer(p1);
+        ImVec2 P2 = this->Transformer(p2);
+        float width_px = ImAbs(P1.x-P2.x);
+        if (width_px < 1.0f) {
+            P1.x += P1.x > P2.x ? (1-width_px) / 2 : (width_px-1) / 2;
+            P2.x += P2.x > P1.x ? (1-width_px) / 2 : (width_px-1) / 2;
+        }
+        ImVec2 PMin = ImMin(P1, P2);
+        ImVec2 PMax = ImMax(P1, P2);
+        if (!cull_rect.Overlaps(ImRect(PMin, PMax)))
+            return false;
+        PrimRectFill(draw_list,PMin,PMax,Col,UV);
+        return true;
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+    const ImU32 Col;
+    const double HalfWidth;
+    mutable ImVec2 UV;
+};
+
+template <class _Getter1, class _Getter2>
+struct RendererBarsFillH : RendererBase {
+    RendererBarsFillH(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, double height) :
+        RendererBase(ImMin(getter1.Count, getter1.Count), 6, 4),
+        Getter1(getter1),
+        Getter2(getter2),
+        Col(col),
+        HalfHeight(height/2)
+    {}
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImPlotPoint p1 = Getter1(prim);
+        ImPlotPoint p2 = Getter2(prim);
+        p1.y += HalfHeight;
+        p2.y -= HalfHeight;
+        ImVec2 P1 = this->Transformer(p1);
+        ImVec2 P2 = this->Transformer(p2);
+        float height_px = ImAbs(P1.y-P2.y);
+        if (height_px < 1.0f) {
+            P1.y += P1.y > P2.y ? (1-height_px) / 2 : (height_px-1) / 2;
+            P2.y += P2.y > P1.y ? (1-height_px) / 2 : (height_px-1) / 2;
+        }
+        ImVec2 PMin = ImMin(P1, P2);
+        ImVec2 PMax = ImMax(P1, P2);
+        if (!cull_rect.Overlaps(ImRect(PMin, PMax)))
+            return false;
+        PrimRectFill(draw_list,PMin,PMax,Col,UV);
+        return true;
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+    const ImU32 Col;
+    const double HalfHeight;
+    mutable ImVec2 UV;
+};
+
+template <class _Getter1, class _Getter2>
+struct RendererBarsLineV : RendererBase {
+    RendererBarsLineV(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, double width, float weight) :
+        RendererBase(ImMin(getter1.Count, getter1.Count), 24, 8),
+        Getter1(getter1),
+        Getter2(getter2),
+        Col(col),
+        HalfWidth(width/2),
+        Weight(weight)
+    {}
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImPlotPoint p1 = Getter1(prim);
+        ImPlotPoint p2 = Getter2(prim);
+        p1.x += HalfWidth;
+        p2.x -= HalfWidth;
+        ImVec2 P1 = this->Transformer(p1);
+        ImVec2 P2 = this->Transformer(p2);
+        float width_px = ImAbs(P1.x-P2.x);
+        if (width_px < 1.0f) {
+            P1.x += P1.x > P2.x ? (1-width_px) / 2 : (width_px-1) / 2;
+            P2.x += P2.x > P1.x ? (1-width_px) / 2 : (width_px-1) / 2;
+        }
+        ImVec2 PMin = ImMin(P1, P2);
+        ImVec2 PMax = ImMax(P1, P2);
+        if (!cull_rect.Overlaps(ImRect(PMin, PMax)))
+            return false;
+        PrimRectLine(draw_list,PMin,PMax,Weight,Col,UV);
+        return true;
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+    const ImU32 Col;
+    const double HalfWidth;
+    const float Weight;
+    mutable ImVec2 UV;
+};
+
+template <class _Getter1, class _Getter2>
+struct RendererBarsLineH : RendererBase {
+    RendererBarsLineH(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, double height, float weight) :
+        RendererBase(ImMin(getter1.Count, getter1.Count), 24, 8),
+        Getter1(getter1),
+        Getter2(getter2),
+        Col(col),
+        HalfHeight(height/2),
+        Weight(weight)
+    {}
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImPlotPoint p1 = Getter1(prim);
+        ImPlotPoint p2 = Getter2(prim);
+        p1.y += HalfHeight;
+        p2.y -= HalfHeight;
+        ImVec2 P1 = this->Transformer(p1);
+        ImVec2 P2 = this->Transformer(p2);
+        float height_px = ImAbs(P1.y-P2.y);
+        if (height_px < 1.0f) {
+            P1.y += P1.y > P2.y ? (1-height_px) / 2 : (height_px-1) / 2;
+            P2.y += P2.y > P1.y ? (1-height_px) / 2 : (height_px-1) / 2;
+        }
+        ImVec2 PMin = ImMin(P1, P2);
+        ImVec2 PMax = ImMax(P1, P2);
+        if (!cull_rect.Overlaps(ImRect(PMin, PMax)))
+            return false;
+        PrimRectLine(draw_list,PMin,PMax,Weight,Col,UV);
+        return true;
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+    const ImU32 Col;
+    const double HalfHeight;
+    const float Weight;
+    mutable ImVec2 UV;
+};
+
+
+template <class _Getter>
+struct RendererStairsPre : RendererBase {
+    RendererStairsPre(const _Getter& getter, ImU32 col, float weight) :
+        RendererBase(getter.Count - 1, 12, 8),
+        Getter(getter),
+        Col(col),
+        HalfWeight(ImMax(1.0f,weight)*0.5f)
+    {
+        P1 = this->Transformer(Getter(0));
+    }
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
+            P1 = P2;
+            return false;
+        }
+        PrimRectFill(draw_list, ImVec2(P1.x - HalfWeight, P1.y), ImVec2(P1.x + HalfWeight, P2.y), Col, UV);
+        PrimRectFill(draw_list, ImVec2(P1.x, P2.y + HalfWeight), ImVec2(P2.x, P2.y - HalfWeight), Col, UV);
+        P1 = P2;
+        return true;
+    }
+    const _Getter& Getter;
+    const ImU32 Col;
+    mutable float HalfWeight;
+    mutable ImVec2 P1;
+    mutable ImVec2 UV;
+};
+
+template <class _Getter>
+struct RendererStairsPost : RendererBase {
+    RendererStairsPost(const _Getter& getter, ImU32 col, float weight) :
+        RendererBase(getter.Count - 1, 12, 8),
+        Getter(getter),
+        Col(col),
+        HalfWeight(ImMax(1.0f,weight) * 0.5f)
+    {
+        P1 = this->Transformer(Getter(0));
+    }
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
+            P1 = P2;
+            return false;
+        }
+        PrimRectFill(draw_list, ImVec2(P1.x, P1.y + HalfWeight), ImVec2(P2.x, P1.y - HalfWeight), Col, UV);
+        PrimRectFill(draw_list, ImVec2(P2.x - HalfWeight, P2.y), ImVec2(P2.x + HalfWeight, P1.y), Col, UV);
+        P1 = P2;
+        return true;
+    }
+    const _Getter& Getter;
+    const ImU32 Col;
+    mutable float HalfWeight;
+    mutable ImVec2 P1;
+    mutable ImVec2 UV;
+};
+
+template <class _Getter>
+struct RendererStairsPreShaded : RendererBase {
+    RendererStairsPreShaded(const _Getter& getter, ImU32 col) :
+        RendererBase(getter.Count - 1, 6, 4),
+        Getter(getter),
+        Col(col)
+    {
+        P1 = this->Transformer(Getter(0));
+        Y0 = this->Transformer(ImPlotPoint(0,0)).y;
+    }
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        ImVec2 PMin(ImMin(P1.x, P2.x), ImMin(Y0, P2.y));
+        ImVec2 PMax(ImMax(P1.x, P2.x), ImMax(Y0, P2.y));
+        if (!cull_rect.Overlaps(ImRect(PMin, PMax))) {
+            P1 = P2;
+            return false;
+        }
+        PrimRectFill(draw_list, PMin, PMax, Col, UV);
+        P1 = P2;
+        return true;
+    }
+    const _Getter& Getter;
+    const ImU32 Col;
+    float Y0;
+    mutable ImVec2 P1;
+    mutable ImVec2 UV;
+};
+
+template <class _Getter>
+struct RendererStairsPostShaded : RendererBase {
+    RendererStairsPostShaded(const _Getter& getter, ImU32 col) :
+        RendererBase(getter.Count - 1, 6, 4),
+        Getter(getter),
+        Col(col)
+    {
+        P1 = this->Transformer(Getter(0));
+        Y0 = this->Transformer(ImPlotPoint(0,0)).y;
+    }
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        ImVec2 PMin(ImMin(P1.x, P2.x), ImMin(P1.y, Y0));
+        ImVec2 PMax(ImMax(P1.x, P2.x), ImMax(P1.y, Y0));
+        if (!cull_rect.Overlaps(ImRect(PMin, PMax))) {
+            P1 = P2;
+            return false;
+        }
+        PrimRectFill(draw_list, PMin, PMax, Col, UV);
+        P1 = P2;
+        return true;
+    }
+    const _Getter& Getter;
+    const ImU32 Col;
+    float Y0;
+    mutable ImVec2 P1;
+    mutable ImVec2 UV;
+};
+
+
+
+template <class _Getter1, class _Getter2>
+struct RendererShaded : RendererBase {
+    RendererShaded(const _Getter1& getter1, const _Getter2& getter2, ImU32 col) :
+        RendererBase(ImMin(getter1.Count, getter2.Count) - 1, 6, 5),
+        Getter1(getter1),
+        Getter2(getter2),
+        Col(col)
+    {
+        P11 = this->Transformer(Getter1(0));
+        P12 = this->Transformer(Getter2(0));
+    }
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P21 = this->Transformer(Getter1(prim+1));
+        ImVec2 P22 = this->Transformer(Getter2(prim+1));
+        ImRect rect(ImMin(ImMin(ImMin(P11,P12),P21),P22), ImMax(ImMax(ImMax(P11,P12),P21),P22));
+        if (!cull_rect.Overlaps(rect)) {
+            P11 = P21;
+            P12 = P22;
+            return false;
+        }
+        const int intersect = (P11.y > P12.y && P22.y > P21.y) || (P12.y > P11.y && P21.y > P22.y);
+        ImVec2 intersection = Intersection(P11,P21,P12,P22);
+        draw_list._VtxWritePtr[0].pos = P11;
+        draw_list._VtxWritePtr[0].uv  = UV;
+        draw_list._VtxWritePtr[0].col = Col;
+        draw_list._VtxWritePtr[1].pos = P21;
+        draw_list._VtxWritePtr[1].uv  = UV;
+        draw_list._VtxWritePtr[1].col = Col;
+        draw_list._VtxWritePtr[2].pos = intersection;
+        draw_list._VtxWritePtr[2].uv  = UV;
+        draw_list._VtxWritePtr[2].col = Col;
+        draw_list._VtxWritePtr[3].pos = P12;
+        draw_list._VtxWritePtr[3].uv  = UV;
+        draw_list._VtxWritePtr[3].col = Col;
+        draw_list._VtxWritePtr[4].pos = P22;
+        draw_list._VtxWritePtr[4].uv  = UV;
+        draw_list._VtxWritePtr[4].col = Col;
+        draw_list._VtxWritePtr += 5;
+        draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+        draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1 + intersect);
+        draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 3);
+        draw_list._IdxWritePtr[3] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1);
+        draw_list._IdxWritePtr[4] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 4);
+        draw_list._IdxWritePtr[5] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 3 - intersect);
+        draw_list._IdxWritePtr += 6;
+        draw_list._VtxCurrentIdx += 5;
+        P11 = P21;
+        P12 = P22;
+        return true;
+    }
+    const _Getter1& Getter1;
+    const _Getter2& Getter2;
+    const ImU32 Col;
+    mutable ImVec2 P11;
+    mutable ImVec2 P12;
+    mutable ImVec2 UV;
+};
+
+struct RectC {
+    ImPlotPoint Pos;
+    ImPlotPoint HalfSize;
+    ImU32 Color;
+};
+
+template <typename _Getter>
+struct RendererRectC : RendererBase {
+    RendererRectC(const _Getter& getter) :
+        RendererBase(getter.Count, 6, 4),
+        Getter(getter)
+    {}
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        RectC rect = Getter(prim);
+        ImVec2 P1 = this->Transformer(rect.Pos.x - rect.HalfSize.x , rect.Pos.y - rect.HalfSize.y);
+        ImVec2 P2 = this->Transformer(rect.Pos.x + rect.HalfSize.x , rect.Pos.y + rect.HalfSize.y);
+        if ((rect.Color & IM_COL32_A_MASK) == 0 || !cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2))))
+            return false;
+        PrimRectFill(draw_list,P1,P2,rect.Color,UV);
+        return true;
+    }
+    const _Getter& Getter;
+    mutable ImVec2 UV;
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] RenderPrimitives
+//-----------------------------------------------------------------------------
+
+/// Renders primitive shapes in bulk as efficiently as possible.
+template <class _Renderer>
+void RenderPrimitivesEx(const _Renderer& renderer, ImDrawList& draw_list, const ImRect& cull_rect) {
+    unsigned int prims        = renderer.Prims;
+    unsigned int prims_culled = 0;
+    unsigned int idx          = 0;
+    renderer.Init(draw_list);
+    while (prims) {
+        // find how many can be reserved up to end of current draw command's limit
+        unsigned int cnt = ImMin(prims, (MaxIdx<ImDrawIdx>::Value - draw_list._VtxCurrentIdx) / renderer.VtxConsumed);
+        // make sure at least this many elements can be rendered to avoid situations where at the end of buffer this slow path is not taken all the time
+        if (cnt >= ImMin(64u, prims)) {
+            if (prims_culled >= cnt)
+                prims_culled -= cnt; // reuse previous reservation
+            else {
+                // add more elements to previous reservation
+                draw_list.PrimReserve((cnt - prims_culled) * renderer.IdxConsumed, (cnt - prims_culled) * renderer.VtxConsumed);
+                prims_culled = 0;
+            }
+        }
+        else
+        {
+            if (prims_culled > 0) {
+                draw_list.PrimUnreserve(prims_culled * renderer.IdxConsumed, prims_culled * renderer.VtxConsumed);
+                prims_culled = 0;
+            }
+            cnt = ImMin(prims, (MaxIdx<ImDrawIdx>::Value - 0/*draw_list._VtxCurrentIdx*/) / renderer.VtxConsumed);
+            // reserve new draw command
+            draw_list.PrimReserve(cnt * renderer.IdxConsumed, cnt * renderer.VtxConsumed);
+        }
+        prims -= cnt;
+        for (unsigned int ie = idx + cnt; idx != ie; ++idx) {
+            if (!renderer.Render(draw_list, cull_rect, idx))
+                prims_culled++;
+        }
+    }
+    if (prims_culled > 0)
+        draw_list.PrimUnreserve(prims_culled * renderer.IdxConsumed, prims_culled * renderer.VtxConsumed);
+}
+
+template <template <class> class _Renderer, class _Getter, typename ...Args>
+void RenderPrimitives1(const _Getter& getter, Args... args) {
+    ImDrawList& draw_list = *GetPlotDrawList();
+    const ImRect& cull_rect = GetCurrentPlot()->PlotRect;
+    RenderPrimitivesEx(_Renderer<_Getter>(getter,args...), draw_list, cull_rect);
+}
+
+template <template <class,class> class _Renderer, class _Getter1, class _Getter2, typename ...Args>
+void RenderPrimitives2(const _Getter1& getter1, const _Getter2& getter2, Args... args) {
+    ImDrawList& draw_list = *GetPlotDrawList();
+    const ImRect& cull_rect = GetCurrentPlot()->PlotRect;
+    RenderPrimitivesEx(_Renderer<_Getter1,_Getter2>(getter1,getter2,args...), draw_list, cull_rect);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] Markers
+//-----------------------------------------------------------------------------
+
+template <class _Getter>
+struct RendererMarkersFill : RendererBase {
+    RendererMarkersFill(const _Getter& getter, const ImVec2* marker, int count, float size, ImU32 col) :
+        RendererBase(getter.Count, (count-2)*3, count),
+        Getter(getter),
+        Marker(marker),
+        Count(count),
+        Size(size),
+        Col(col)
+    { }
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 p = this->Transformer(Getter(prim));
+        if (p.x >= cull_rect.Min.x && p.y >= cull_rect.Min.y && p.x <= cull_rect.Max.x && p.y <= cull_rect.Max.y) {
+            for (int i = 0; i < Count; i++) {
+                draw_list._VtxWritePtr[0].pos.x = p.x + Marker[i].x * Size;
+                draw_list._VtxWritePtr[0].pos.y = p.y + Marker[i].y * Size;
+                draw_list._VtxWritePtr[0].uv = UV;
+                draw_list._VtxWritePtr[0].col = Col;
+                draw_list._VtxWritePtr++;
+            }
+            for (int i = 2; i < Count; i++) {
+                draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+                draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + i - 1);
+                draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + i);
+                draw_list._IdxWritePtr += 3;
+            }
+            draw_list._VtxCurrentIdx += (ImDrawIdx)Count;
+            return true;
+        }
+        return false;
+    }
+    const _Getter& Getter;
+    const ImVec2* Marker;
+    const int Count;
+    const float Size;
+    const ImU32 Col;
+    mutable ImVec2 UV;
+};
+
+
+template <class _Getter>
+struct RendererMarkersLine : RendererBase {
+    RendererMarkersLine(const _Getter& getter, const ImVec2* marker, int count, float size, float weight, ImU32 col) :
+        RendererBase(getter.Count, count/2*6, count/2*4),
+        Getter(getter),
+        Marker(marker),
+        Count(count),
+        HalfWeight(ImMax(1.0f,weight)*0.5f),
+        Size(size),
+        Col(col)
+    { }
+    void Init(ImDrawList& draw_list) const {
+        GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 p = this->Transformer(Getter(prim));
+        if (p.x >= cull_rect.Min.x && p.y >= cull_rect.Min.y && p.x <= cull_rect.Max.x && p.y <= cull_rect.Max.y) {
+            for (int i = 0; i < Count; i = i + 2) {
+                ImVec2 p1(p.x + Marker[i].x * Size, p.y + Marker[i].y * Size);
+                ImVec2 p2(p.x + Marker[i+1].x * Size, p.y + Marker[i+1].y * Size);
+                PrimLine(draw_list, p1, p2, HalfWeight, Col, UV0, UV1);
+            }
+            return true;
+        }
+        return false;
+    }
+    const _Getter& Getter;
+    const ImVec2* Marker;
+    const int Count;
+    mutable float HalfWeight;
+    const float Size;
+    const ImU32 Col;
+    mutable ImVec2 UV0;
+    mutable ImVec2 UV1;
+};
+
+static const ImVec2 MARKER_FILL_CIRCLE[10]  = {ImVec2(1.0f, 0.0f), ImVec2(0.809017f, 0.58778524f),ImVec2(0.30901697f, 0.95105654f),ImVec2(-0.30901703f, 0.9510565f),ImVec2(-0.80901706f, 0.5877852f),ImVec2(-1.0f, 0.0f),ImVec2(-0.80901694f, -0.58778536f),ImVec2(-0.3090171f, -0.9510565f),ImVec2(0.30901712f, -0.9510565f),ImVec2(0.80901694f, -0.5877853f)};
+static const ImVec2 MARKER_FILL_SQUARE[4]   = {ImVec2(SQRT_1_2,SQRT_1_2), ImVec2(SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,SQRT_1_2)};
+static const ImVec2 MARKER_FILL_DIAMOND[4]  = {ImVec2(1, 0), ImVec2(0, -1), ImVec2(-1, 0), ImVec2(0, 1)};
+static const ImVec2 MARKER_FILL_UP[3]       = {ImVec2(SQRT_3_2,0.5f),ImVec2(0,-1),ImVec2(-SQRT_3_2,0.5f)};
+static const ImVec2 MARKER_FILL_DOWN[3]     = {ImVec2(SQRT_3_2,-0.5f),ImVec2(0,1),ImVec2(-SQRT_3_2,-0.5f)};
+static const ImVec2 MARKER_FILL_LEFT[3]     = {ImVec2(-1,0), ImVec2(0.5, SQRT_3_2), ImVec2(0.5, -SQRT_3_2)};
+static const ImVec2 MARKER_FILL_RIGHT[3]    = {ImVec2(1,0), ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, -SQRT_3_2)};
+
+static const ImVec2 MARKER_LINE_CIRCLE[20]  = {
+    ImVec2(1.0f, 0.0f),
+    ImVec2(0.809017f, 0.58778524f),
+    ImVec2(0.809017f, 0.58778524f),
+    ImVec2(0.30901697f, 0.95105654f),
+    ImVec2(0.30901697f, 0.95105654f),
+    ImVec2(-0.30901703f, 0.9510565f),
+    ImVec2(-0.30901703f, 0.9510565f),
+    ImVec2(-0.80901706f, 0.5877852f),
+    ImVec2(-0.80901706f, 0.5877852f),
+    ImVec2(-1.0f, 0.0f),
+    ImVec2(-1.0f, 0.0f),
+    ImVec2(-0.80901694f, -0.58778536f),
+    ImVec2(-0.80901694f, -0.58778536f),
+    ImVec2(-0.3090171f, -0.9510565f),
+    ImVec2(-0.3090171f, -0.9510565f),
+    ImVec2(0.30901712f, -0.9510565f),
+    ImVec2(0.30901712f, -0.9510565f),
+    ImVec2(0.80901694f, -0.5877853f),
+    ImVec2(0.80901694f, -0.5877853f),
+    ImVec2(1.0f, 0.0f)
+};
+static const ImVec2 MARKER_LINE_SQUARE[8]   = {ImVec2(SQRT_1_2,SQRT_1_2), ImVec2(SQRT_1_2,-SQRT_1_2), ImVec2(SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,SQRT_1_2), ImVec2(-SQRT_1_2,SQRT_1_2), ImVec2(SQRT_1_2,SQRT_1_2)};
+static const ImVec2 MARKER_LINE_DIAMOND[8]  = {ImVec2(1, 0), ImVec2(0, -1), ImVec2(0, -1), ImVec2(-1, 0), ImVec2(-1, 0), ImVec2(0, 1), ImVec2(0, 1), ImVec2(1, 0)};
+static const ImVec2 MARKER_LINE_UP[6]       = {ImVec2(SQRT_3_2,0.5f), ImVec2(0,-1),ImVec2(0,-1),ImVec2(-SQRT_3_2,0.5f),ImVec2(-SQRT_3_2,0.5f),ImVec2(SQRT_3_2,0.5f)};
+static const ImVec2 MARKER_LINE_DOWN[6]     = {ImVec2(SQRT_3_2,-0.5f),ImVec2(0,1),ImVec2(0,1),ImVec2(-SQRT_3_2,-0.5f), ImVec2(-SQRT_3_2,-0.5f), ImVec2(SQRT_3_2,-0.5f)};
+static const ImVec2 MARKER_LINE_LEFT[6]     = {ImVec2(-1,0), ImVec2(0.5, SQRT_3_2),  ImVec2(0.5, SQRT_3_2),  ImVec2(0.5, -SQRT_3_2) , ImVec2(0.5, -SQRT_3_2) , ImVec2(-1,0) };
+static const ImVec2 MARKER_LINE_RIGHT[6]    = {ImVec2(1,0),  ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, -SQRT_3_2), ImVec2(-0.5, -SQRT_3_2), ImVec2(1,0) };
+static const ImVec2 MARKER_LINE_ASTERISK[6] = {ImVec2(-SQRT_3_2, -0.5f), ImVec2(SQRT_3_2, 0.5f),  ImVec2(-SQRT_3_2, 0.5f), ImVec2(SQRT_3_2, -0.5f), ImVec2(0, -1), ImVec2(0, 1)};
+static const ImVec2 MARKER_LINE_PLUS[4]     = {ImVec2(-1, 0), ImVec2(1, 0), ImVec2(0, -1), ImVec2(0, 1)};
+static const ImVec2 MARKER_LINE_CROSS[4]    = {ImVec2(-SQRT_1_2,-SQRT_1_2),ImVec2(SQRT_1_2,SQRT_1_2),ImVec2(SQRT_1_2,-SQRT_1_2),ImVec2(-SQRT_1_2,SQRT_1_2)};
+
+template <typename _Getter>
+void RenderMarkers(const _Getter& getter, ImPlotMarker marker, float size, bool rend_fill, ImU32 col_fill, bool rend_line, ImU32 col_line, float weight) {
+    if (rend_fill) {
+        switch (marker) {
+            case ImPlotMarker_Circle  : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_CIRCLE,10,size,col_fill); break;
+            case ImPlotMarker_Square  : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_SQUARE, 4,size,col_fill); break;
+            case ImPlotMarker_Diamond : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_DIAMOND,4,size,col_fill); break;
+            case ImPlotMarker_Up      : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_UP,     3,size,col_fill); break;
+            case ImPlotMarker_Down    : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_DOWN,   3,size,col_fill); break;
+            case ImPlotMarker_Left    : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_LEFT,   3,size,col_fill); break;
+            case ImPlotMarker_Right   : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_RIGHT,  3,size,col_fill); break;
+        }
+    }
+    if (rend_line) {
+        switch (marker) {
+            case ImPlotMarker_Circle    : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_CIRCLE, 20,size,weight,col_line); break;
+            case ImPlotMarker_Square    : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_SQUARE,  8,size,weight,col_line); break;
+            case ImPlotMarker_Diamond   : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_DIAMOND, 8,size,weight,col_line); break;
+            case ImPlotMarker_Up        : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_UP,      6,size,weight,col_line); break;
+            case ImPlotMarker_Down      : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_DOWN,    6,size,weight,col_line); break;
+            case ImPlotMarker_Left      : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_LEFT,    6,size,weight,col_line); break;
+            case ImPlotMarker_Right     : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_RIGHT,   6,size,weight,col_line); break;
+            case ImPlotMarker_Asterisk  : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_ASTERISK,6,size,weight,col_line); break;
+            case ImPlotMarker_Plus      : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_PLUS,    4,size,weight,col_line); break;
+            case ImPlotMarker_Cross     : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_CROSS,   4,size,weight,col_line); break;
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotLine
+//-----------------------------------------------------------------------------
+
+template <typename _Getter>
+void PlotLineEx(const char* label_id, const _Getter& getter, ImPlotLineFlags flags) {
+    if (BeginItemEx(label_id, Fitter1<_Getter>(getter), flags, ImPlotCol_Line)) {
+        const ImPlotNextItemData& s = GetItemData();
+        if (getter.Count > 1) {
+            if (ImHasFlag(flags, ImPlotLineFlags_Shaded) && s.RenderFill) {
+                const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
+                GetterOverrideY<_Getter> getter2(getter, 0);
+                RenderPrimitives2<RendererShaded>(getter,getter2,col_fill);
+            }
+            if (s.RenderLine) {
+                const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+                if (ImHasFlag(flags,ImPlotLineFlags_Segments)) {
+                    RenderPrimitives1<RendererLineSegments1>(getter,col_line,s.LineWeight);
+                }
+                else if (ImHasFlag(flags, ImPlotLineFlags_Loop)) {
+                    if (ImHasFlag(flags, ImPlotLineFlags_SkipNaN))
+                        RenderPrimitives1<RendererLineStripSkip>(GetterLoop<_Getter>(getter),col_line,s.LineWeight);
+                    else
+                        RenderPrimitives1<RendererLineStrip>(GetterLoop<_Getter>(getter),col_line,s.LineWeight);
+                }
+                else {
+                    if (ImHasFlag(flags, ImPlotLineFlags_SkipNaN))
+                        RenderPrimitives1<RendererLineStripSkip>(getter,col_line,s.LineWeight);
+                    else
+                        RenderPrimitives1<RendererLineStrip>(getter,col_line,s.LineWeight);
+                }
+            }
+        }
+        // render markers
+        if (s.Marker != ImPlotMarker_None) {
+            if (ImHasFlag(flags, ImPlotLineFlags_NoClip)) {
+                PopPlotClipRect();
+                PushPlotClipRect(s.MarkerSize);
+            }
+            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
+            const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
+            RenderMarkers<_Getter>(getter, s.Marker, s.MarkerSize, s.RenderMarkerFill, col_fill, s.RenderMarkerLine, col_line, s.MarkerWeight);
+        }
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotLine(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride) {
+    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
+    PlotLineEx(label_id, getter, flags);
+}
+
+template <typename T>
+void PlotLine(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+    PlotLineEx(label_id, getter, flags);
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotLine<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotLine<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+// custom
+void PlotLineG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotLineFlags flags) {
+    GetterFuncPtr getter(getter_func,data, count);
+    PlotLineEx(label_id, getter, flags);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotScatter
+//-----------------------------------------------------------------------------
+
+template <typename Getter>
+void PlotScatterEx(const char* label_id, const Getter& getter, ImPlotScatterFlags flags) {
+    if (BeginItemEx(label_id, Fitter1<Getter>(getter), flags, ImPlotCol_MarkerOutline)) {
+        const ImPlotNextItemData& s = GetItemData();
+        ImPlotMarker marker = s.Marker == ImPlotMarker_None ? ImPlotMarker_Circle: s.Marker;
+        if (marker != ImPlotMarker_None) {
+            if (ImHasFlag(flags,ImPlotScatterFlags_NoClip)) {
+                PopPlotClipRect();
+                PushPlotClipRect(s.MarkerSize);
+            }
+            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
+            const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
+            RenderMarkers<Getter>(getter, marker, s.MarkerSize, s.RenderMarkerFill, col_fill, s.RenderMarkerLine, col_line, s.MarkerWeight);
+        }
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotScatter(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride) {
+    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
+    PlotScatterEx(label_id, getter, flags);
+}
+
+template <typename T>
+void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+    return PlotScatterEx(label_id, getter, flags);
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+// custom
+void PlotScatterG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotScatterFlags flags) {
+    GetterFuncPtr getter(getter_func,data, count);
+    return PlotScatterEx(label_id, getter, flags);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotStairs
+//-----------------------------------------------------------------------------
+
+template <typename Getter>
+void PlotStairsEx(const char* label_id, const Getter& getter, ImPlotStairsFlags flags) {
+    if (BeginItemEx(label_id, Fitter1<Getter>(getter), flags, ImPlotCol_Line)) {
+        const ImPlotNextItemData& s = GetItemData();
+        if (getter.Count > 1 ) {
+            if (s.RenderFill && ImHasFlag(flags,ImPlotStairsFlags_Shaded)) {
+                const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
+                if (ImHasFlag(flags, ImPlotStairsFlags_PreStep))
+                    RenderPrimitives1<RendererStairsPreShaded>(getter,col_fill);
+                else
+                    RenderPrimitives1<RendererStairsPostShaded>(getter,col_fill);
+            }
+            if (s.RenderLine) {
+                const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+                if (ImHasFlag(flags, ImPlotStairsFlags_PreStep))
+                    RenderPrimitives1<RendererStairsPre>(getter,col_line,s.LineWeight);
+                else
+                    RenderPrimitives1<RendererStairsPost>(getter,col_line,s.LineWeight);
+            }
+        }
+        // render markers
+        if (s.Marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
+            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
+            const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
+            RenderMarkers<Getter>(getter, s.Marker, s.MarkerSize, s.RenderMarkerFill, col_fill, s.RenderMarkerLine, col_line, s.MarkerWeight);
+        }
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotStairs(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride) {
+    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
+    PlotStairsEx(label_id, getter, flags);
+}
+
+template <typename T>
+void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+    return PlotStairsEx(label_id, getter, flags);
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotStairs<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotStairs<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+// custom
+void PlotStairsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotStairsFlags flags) {
+    GetterFuncPtr getter(getter_func,data, count);
+    return PlotStairsEx(label_id, getter, flags);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotShaded
+//-----------------------------------------------------------------------------
+
+template <typename Getter1, typename Getter2>
+void PlotShadedEx(const char* label_id, const Getter1& getter1, const Getter2& getter2, ImPlotShadedFlags flags) {
+    if (BeginItemEx(label_id, Fitter2<Getter1,Getter2>(getter1,getter2), flags, ImPlotCol_Fill)) {
+        const ImPlotNextItemData& s = GetItemData();
+        if (s.RenderFill) {
+            const ImU32 col = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
+            RenderPrimitives2<RendererShaded>(getter1,getter2,col);
+        }
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotShaded(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride) {
+    if (!(y_ref > -DBL_MAX))
+        y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Min;
+    if (!(y_ref < DBL_MAX))
+        y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Max;
+    GetterXY<IndexerLin,IndexerIdx<T>> getter1(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
+    GetterXY<IndexerLin,IndexerConst>  getter2(IndexerLin(xscale,x0),IndexerConst(y_ref),count);
+    PlotShadedEx(label_id, getter1, getter2, flags);
+}
+
+template <typename T>
+void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride) {
+    if (y_ref == -HUGE_VAL)
+        y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Min;
+    if (y_ref == HUGE_VAL)
+        y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Max;
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+    GetterXY<IndexerIdx<T>,IndexerConst>  getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerConst(y_ref),count);
+    PlotShadedEx(label_id, getter1, getter2, flags);
+}
+
+
+template <typename T>
+void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys1,count,offset,stride),count);
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys2,count,offset,stride),count);
+    PlotShadedEx(label_id, getter1, getter2, flags);
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+// custom
+void PlotShadedG(const char* label_id, ImPlotGetter getter_func1, void* data1, ImPlotGetter getter_func2, void* data2, int count, ImPlotShadedFlags flags) {
+    GetterFuncPtr getter1(getter_func1, data1, count);
+    GetterFuncPtr getter2(getter_func2, data2, count);
+    PlotShadedEx(label_id, getter1, getter2, flags);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotBars
+//-----------------------------------------------------------------------------
+
+template <typename Getter1, typename Getter2>
+void PlotBarsVEx(const char* label_id, const Getter1& getter1, const Getter2 getter2, double width, ImPlotBarsFlags flags) {
+    if (BeginItemEx(label_id, FitterBarV<Getter1,Getter2>(getter1,getter2,width), flags, ImPlotCol_Fill)) {
+        const ImPlotNextItemData& s = GetItemData();
+        const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
+        const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+        bool rend_fill = s.RenderFill;
+        bool rend_line = s.RenderLine;
+        if (rend_fill) {
+            RenderPrimitives2<RendererBarsFillV>(getter1,getter2,col_fill,width);
+            if (rend_line && col_fill == col_line)
+                rend_line = false;
+        }
+        if (rend_line) {
+            RenderPrimitives2<RendererBarsLineV>(getter1,getter2,col_line,width,s.LineWeight);
+        }
+        EndItem();
+    }
+}
+
+template <typename Getter1, typename Getter2>
+void PlotBarsHEx(const char* label_id, const Getter1& getter1, const Getter2& getter2, double height, ImPlotBarsFlags flags) {
+    if (BeginItemEx(label_id, FitterBarH<Getter1,Getter2>(getter1,getter2,height), flags, ImPlotCol_Fill)) {
+        const ImPlotNextItemData& s = GetItemData();
+        const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
+        const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+        bool rend_fill = s.RenderFill;
+        bool rend_line = s.RenderLine;
+        if (rend_fill) {
+            RenderPrimitives2<RendererBarsFillH>(getter1,getter2,col_fill,height);
+            if (rend_line && col_fill == col_line)
+                rend_line = false;
+        }
+        if (rend_line) {
+            RenderPrimitives2<RendererBarsLineH>(getter1,getter2,col_line,height,s.LineWeight);
+        }
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotBars(const char* label_id, const T* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride) {
+    if (ImHasFlag(flags, ImPlotBarsFlags_Horizontal)) {
+        GetterXY<IndexerIdx<T>,IndexerLin> getter1(IndexerIdx<T>(values,count,offset,stride),IndexerLin(1.0,shift),count);
+        GetterXY<IndexerConst,IndexerLin>  getter2(IndexerConst(0),IndexerLin(1.0,shift),count);
+        PlotBarsHEx(label_id, getter1, getter2, bar_size, flags);
+    }
+    else {
+        GetterXY<IndexerLin,IndexerIdx<T>> getter1(IndexerLin(1.0,shift),IndexerIdx<T>(values,count,offset,stride),count);
+        GetterXY<IndexerLin,IndexerConst>  getter2(IndexerLin(1.0,shift),IndexerConst(0),count);
+        PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
+    }
+}
+
+template <typename T>
+void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride) {
+    if (ImHasFlag(flags, ImPlotBarsFlags_Horizontal)) {
+        GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+        GetterXY<IndexerConst, IndexerIdx<T>> getter2(IndexerConst(0),IndexerIdx<T>(ys,count,offset,stride),count);
+        PlotBarsHEx(label_id, getter1, getter2, bar_size, flags);
+    }
+    else {
+        GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+        GetterXY<IndexerIdx<T>,IndexerConst>  getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerConst(0),count);
+        PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
+    }
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotBars<T>(const char* label_id, const T* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotBars<T>(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+void PlotBarsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, double bar_size, ImPlotBarsFlags flags) {
+    if (ImHasFlag(flags, ImPlotBarsFlags_Horizontal)) {
+        GetterFuncPtr getter1(getter_func, data, count);
+        GetterOverrideX<GetterFuncPtr> getter2(getter1,0);
+        PlotBarsHEx(label_id, getter1, getter2, bar_size, flags);
+    }
+    else {
+        GetterFuncPtr getter1(getter_func, data, count);
+        GetterOverrideY<GetterFuncPtr> getter2(getter1,0);
+        PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotBarGroups
+//-----------------------------------------------------------------------------
+
+template <typename T>
+void PlotBarGroups(const char* const label_ids[], const T* values, int item_count, int group_count, double group_size, double shift, ImPlotBarGroupsFlags flags) {
+    const bool horz = ImHasFlag(flags, ImPlotBarGroupsFlags_Horizontal);
+    const bool stack = ImHasFlag(flags, ImPlotBarGroupsFlags_Stacked);
+    if (stack) {
+        SetupLock();
+        GImPlot->TempDouble1.resize(4*group_count);
+        double* temp = GImPlot->TempDouble1.Data;
+        double* neg =      &temp[0];
+        double* pos =      &temp[group_count];
+        double* curr_min = &temp[group_count*2];
+        double* curr_max = &temp[group_count*3];
+        for (int g = 0; g < group_count*2; ++g)
+            temp[g] = 0;
+        if (horz) {
+            for (int i = 0; i < item_count; ++i) {
+                if (!IsItemHidden(label_ids[i])) {
+                    for (int g = 0; g < group_count; ++g) {
+                        double v = (double)values[i*group_count+g];
+                        if (v > 0) {
+                            curr_min[g] = pos[g];
+                            curr_max[g] = curr_min[g] + v;
+                            pos[g]      += v;
+                        }
+                        else {
+                            curr_max[g] = neg[g];
+                            curr_min[g] = curr_max[g] + v;
+                            neg[g]      += v;
+                        }
+                    }
+                }
+                GetterXY<IndexerIdx<double>,IndexerLin> getter1(IndexerIdx<double>(curr_min,group_count),IndexerLin(1.0,shift),group_count);
+                GetterXY<IndexerIdx<double>,IndexerLin> getter2(IndexerIdx<double>(curr_max,group_count),IndexerLin(1.0,shift),group_count);
+                PlotBarsHEx(label_ids[i],getter1,getter2,group_size,0);
+            }
+        }
+        else {
+            for (int i = 0; i < item_count; ++i) {
+                if (!IsItemHidden(label_ids[i])) {
+                    for (int g = 0; g < group_count; ++g) {
+                        double v = (double)values[i*group_count+g];
+                        if (v > 0) {
+                            curr_min[g] = pos[g];
+                            curr_max[g] = curr_min[g] + v;
+                            pos[g]      += v;
+                        }
+                        else {
+                            curr_max[g] = neg[g];
+                            curr_min[g] = curr_max[g] + v;
+                            neg[g]      += v;
+                        }
+                    }
+                }
+                GetterXY<IndexerLin,IndexerIdx<double>> getter1(IndexerLin(1.0,shift),IndexerIdx<double>(curr_min,group_count),group_count);
+                GetterXY<IndexerLin,IndexerIdx<double>> getter2(IndexerLin(1.0,shift),IndexerIdx<double>(curr_max,group_count),group_count);
+                PlotBarsVEx(label_ids[i],getter1,getter2,group_size,0);
+            }
+        }
+    }
+    else {
+        const double subsize = group_size / item_count;
+        if (horz) {
+            for (int i = 0; i < item_count; ++i) {
+                const double subshift = (i+0.5)*subsize - group_size/2;
+                PlotBars(label_ids[i],&values[i*group_count],group_count,subsize,subshift+shift,ImPlotBarsFlags_Horizontal);
+            }
+        }
+        else {
+            for (int i = 0; i < item_count; ++i) {
+                const double subshift = (i+0.5)*subsize - group_size/2;
+                PlotBars(label_ids[i],&values[i*group_count],group_count,subsize,subshift+shift);
+            }
+        }
+    }
+}
+
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotBarGroups<T>(const char* const label_ids[], const T* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotErrorBars
+//-----------------------------------------------------------------------------
+
+template <typename _GetterPos, typename _GetterNeg>
+void PlotErrorBarsVEx(const char* label_id, const _GetterPos& getter_pos, const _GetterNeg& getter_neg, ImPlotErrorBarsFlags flags) {
+    if (BeginItemEx(label_id, Fitter2<_GetterPos,_GetterNeg>(getter_pos, getter_neg), flags, IMPLOT_AUTO)) {
+        const ImPlotNextItemData& s = GetItemData();
+        ImDrawList& draw_list = *GetPlotDrawList();
+        const ImU32 col = ImGui::GetColorU32(s.Colors[ImPlotCol_ErrorBar]);
+        const bool rend_whisker  = s.ErrorBarSize > 0;
+        const float half_whisker = s.ErrorBarSize * 0.5f;
+        for (int i = 0; i < getter_pos.Count; ++i) {
+            ImVec2 p1 = PlotToPixels(getter_neg(i),IMPLOT_AUTO,IMPLOT_AUTO);
+            ImVec2 p2 = PlotToPixels(getter_pos(i),IMPLOT_AUTO,IMPLOT_AUTO);
+            draw_list.AddLine(p1,p2,col, s.ErrorBarWeight);
+            if (rend_whisker) {
+                draw_list.AddLine(p1 - ImVec2(half_whisker, 0), p1 + ImVec2(half_whisker, 0), col, s.ErrorBarWeight);
+                draw_list.AddLine(p2 - ImVec2(half_whisker, 0), p2 + ImVec2(half_whisker, 0), col, s.ErrorBarWeight);
+            }
+        }
+        EndItem();
+    }
+}
+
+template <typename _GetterPos, typename _GetterNeg>
+void PlotErrorBarsHEx(const char* label_id, const _GetterPos& getter_pos, const _GetterNeg& getter_neg, ImPlotErrorBarsFlags flags) {
+    if (BeginItemEx(label_id, Fitter2<_GetterPos,_GetterNeg>(getter_pos, getter_neg), flags, IMPLOT_AUTO)) {
+        const ImPlotNextItemData& s = GetItemData();
+        ImDrawList& draw_list = *GetPlotDrawList();
+        const ImU32 col = ImGui::GetColorU32(s.Colors[ImPlotCol_ErrorBar]);
+        const bool rend_whisker  = s.ErrorBarSize > 0;
+        const float half_whisker = s.ErrorBarSize * 0.5f;
+        for (int i = 0; i < getter_pos.Count; ++i) {
+            ImVec2 p1 = PlotToPixels(getter_neg(i),IMPLOT_AUTO,IMPLOT_AUTO);
+            ImVec2 p2 = PlotToPixels(getter_pos(i),IMPLOT_AUTO,IMPLOT_AUTO);
+            draw_list.AddLine(p1, p2, col, s.ErrorBarWeight);
+            if (rend_whisker) {
+                draw_list.AddLine(p1 - ImVec2(0, half_whisker), p1 + ImVec2(0, half_whisker), col, s.ErrorBarWeight);
+                draw_list.AddLine(p2 - ImVec2(0, half_whisker), p2 + ImVec2(0, half_whisker), col, s.ErrorBarWeight);
+            }
+        }
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride) {
+    PlotErrorBars(label_id, xs, ys, err, err, count, flags, offset, stride);
+}
+
+template <typename T>
+void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride) {
+    IndexerIdx<T> indexer_x(xs, count,offset,stride);
+    IndexerIdx<T> indexer_y(ys, count,offset,stride);
+    IndexerIdx<T> indexer_n(neg,count,offset,stride);
+    IndexerIdx<T> indexer_p(pos,count,offset,stride);
+    GetterError<T> getter(xs, ys, neg, pos, count, offset, stride);
+    if (ImHasFlag(flags, ImPlotErrorBarsFlags_Horizontal)) {
+        IndexerAdd<IndexerIdx<T>,IndexerIdx<T>> indexer_xp(indexer_x, indexer_p, 1,  1);
+        IndexerAdd<IndexerIdx<T>,IndexerIdx<T>> indexer_xn(indexer_x, indexer_n, 1, -1);
+        GetterXY<IndexerAdd<IndexerIdx<T>,IndexerIdx<T>>,IndexerIdx<T>> getter_p(indexer_xp, indexer_y, count);
+        GetterXY<IndexerAdd<IndexerIdx<T>,IndexerIdx<T>>,IndexerIdx<T>> getter_n(indexer_xn, indexer_y, count);
+        PlotErrorBarsHEx(label_id, getter_p, getter_n, flags);
+    }
+    else {
+        IndexerAdd<IndexerIdx<T>,IndexerIdx<T>> indexer_yp(indexer_y, indexer_p, 1,  1);
+        IndexerAdd<IndexerIdx<T>,IndexerIdx<T>> indexer_yn(indexer_y, indexer_n, 1, -1);
+        GetterXY<IndexerIdx<T>,IndexerAdd<IndexerIdx<T>,IndexerIdx<T>>> getter_p(indexer_x, indexer_yp, count);
+        GetterXY<IndexerIdx<T>,IndexerAdd<IndexerIdx<T>,IndexerIdx<T>>> getter_n(indexer_x, indexer_yn, count);
+        PlotErrorBarsVEx(label_id, getter_p, getter_n, flags);
+    }
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotStems
+//-----------------------------------------------------------------------------
+
+template <typename _GetterM, typename _GetterB>
+void PlotStemsEx(const char* label_id, const _GetterM& get_mark, const _GetterB& get_base, ImPlotStemsFlags flags) {
+    if (BeginItemEx(label_id, Fitter2<_GetterM,_GetterB>(get_mark,get_base), flags, ImPlotCol_Line)) {
+        const ImPlotNextItemData& s = GetItemData();
+        // render stems
+        if (s.RenderLine) {
+            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+            RenderPrimitives2<RendererLineSegments2>(get_mark, get_base, col_line, s.LineWeight);
+        }
+        // render markers
+        if (s.Marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
+            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
+            const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
+            RenderMarkers<_GetterM>(get_mark, s.Marker, s.MarkerSize, s.RenderMarkerFill, col_fill, s.RenderMarkerLine, col_line, s.MarkerWeight);
+        }
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotStems(const char* label_id, const T* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride) {
+    if (ImHasFlag(flags, ImPlotStemsFlags_Horizontal)) {
+        GetterXY<IndexerIdx<T>,IndexerLin> get_mark(IndexerIdx<T>(values,count,offset,stride),IndexerLin(scale,start),count);
+        GetterXY<IndexerConst,IndexerLin>  get_base(IndexerConst(ref),IndexerLin(scale,start),count);
+        PlotStemsEx(label_id, get_mark, get_base, flags);
+    }
+    else {
+        GetterXY<IndexerLin,IndexerIdx<T>> get_mark(IndexerLin(scale,start),IndexerIdx<T>(values,count,offset,stride),count);
+        GetterXY<IndexerLin,IndexerConst>  get_base(IndexerLin(scale,start),IndexerConst(ref),count);
+        PlotStemsEx(label_id, get_mark, get_base, flags);
+    }
+}
+
+template <typename T>
+void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride) {
+    if (ImHasFlag(flags, ImPlotStemsFlags_Horizontal)) {
+        GetterXY<IndexerIdx<T>,IndexerIdx<T>> get_mark(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+        GetterXY<IndexerConst,IndexerIdx<T>>  get_base(IndexerConst(ref),IndexerIdx<T>(ys,count,offset,stride),count);
+        PlotStemsEx(label_id, get_mark, get_base, flags);
+    }
+    else {
+        GetterXY<IndexerIdx<T>,IndexerIdx<T>> get_mark(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+        GetterXY<IndexerIdx<T>,IndexerConst>  get_base(IndexerIdx<T>(xs,count,offset,stride),IndexerConst(ref),count);
+        PlotStemsEx(label_id, get_mark, get_base, flags);
+    }
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotStems<T>(const char* label_id, const T* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotStems<T>(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotInfLines
+//-----------------------------------------------------------------------------
+
+template <typename T>
+void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLinesFlags flags, int offset, int stride) {
+    const ImPlotRect lims = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO);
+    if (ImHasFlag(flags, ImPlotInfLinesFlags_Horizontal)) {
+        GetterXY<IndexerConst,IndexerIdx<T>> get_min(IndexerConst(lims.X.Min),IndexerIdx<T>(values,count,offset,stride),count);
+        GetterXY<IndexerConst,IndexerIdx<T>> get_max(IndexerConst(lims.X.Max),IndexerIdx<T>(values,count,offset,stride),count);
+        if (BeginItemEx(label_id, FitterY<GetterXY<IndexerConst,IndexerIdx<T>>>(get_min), flags, ImPlotCol_Line)) {
+            const ImPlotNextItemData& s = GetItemData();
+            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+            if (s.RenderLine)
+                RenderPrimitives2<RendererLineSegments2>(get_min, get_max, col_line, s.LineWeight);
+            EndItem();
+        }
+    }
+    else {
+        GetterXY<IndexerIdx<T>,IndexerConst> get_min(IndexerIdx<T>(values,count,offset,stride),IndexerConst(lims.Y.Min),count);
+        GetterXY<IndexerIdx<T>,IndexerConst> get_max(IndexerIdx<T>(values,count,offset,stride),IndexerConst(lims.Y.Max),count);
+        if (BeginItemEx(label_id, FitterX<GetterXY<IndexerIdx<T>,IndexerConst>>(get_min), flags, ImPlotCol_Line)) {
+            const ImPlotNextItemData& s = GetItemData();
+            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+            if (s.RenderLine)
+                RenderPrimitives2<RendererLineSegments2>(get_min, get_max, col_line, s.LineWeight);
+            EndItem();
+        }
+    }
+}
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotInfLines<T>(const char* label_id, const T* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotPieChart
+//-----------------------------------------------------------------------------
+
+IMPLOT_INLINE void RenderPieSlice(ImDrawList& draw_list, const ImPlotPoint& center, double radius, double a0, double a1, ImU32 col) {
+    const float resolution = 50 / (2 * IM_PI);
+    ImVec2 buffer[52];
+    buffer[0] = PlotToPixels(center,IMPLOT_AUTO,IMPLOT_AUTO);
+    int n = ImMax(3, (int)((a1 - a0) * resolution));
+    double da = (a1 - a0) / (n - 1);
+    int i = 0;
+    for (; i < n; ++i) {
+        double a = a0 + i * da;
+        buffer[i + 1] = PlotToPixels(center.x + radius * cos(a), center.y + radius * sin(a),IMPLOT_AUTO,IMPLOT_AUTO);
+    }
+    buffer[i+1] = buffer[0];
+    // fill
+    draw_list.AddConvexPolyFilled(buffer, n + 1, col);
+    // border (for AA)
+    draw_list.AddPolyline(buffer, n + 2, col, 0, 2.0f);
+}
+
+template <typename T>
+void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "PlotPieChart() needs to be called between BeginPlot() and EndPlot()!");
+    ImDrawList & draw_list = *GetPlotDrawList();
+    double sum = 0;
+    for (int i = 0; i < count; ++i)
+        sum += (double)values[i];
+    const bool normalize = ImHasFlag(flags,ImPlotPieChartFlags_Normalize) || sum > 1.0;
+    ImPlotPoint center(x,y);
+    PushPlotClipRect();
+    double a0 = angle0 * 2 * IM_PI / 360.0;
+    double a1 = angle0 * 2 * IM_PI / 360.0;
+    ImPlotPoint Pmin = ImPlotPoint(x-radius,y-radius);
+    ImPlotPoint Pmax = ImPlotPoint(x+radius,y+radius);
+    for (int i = 0; i < count; ++i) {
+        double percent = normalize ? (double)values[i] / sum : (double)values[i];
+        a1 = a0 + 2 * IM_PI * percent;
+        if (BeginItemEx(label_ids[i], FitterRect(Pmin,Pmax))) {
+            ImU32 col = GetCurrentItem()->Color;
+            if (percent < 0.5) {
+                RenderPieSlice(draw_list, center, radius, a0, a1, col);
+            }
+            else  {
+                RenderPieSlice(draw_list, center, radius, a0, a0 + (a1 - a0) * 0.5, col);
+                RenderPieSlice(draw_list, center, radius, a0 + (a1 - a0) * 0.5, a1, col);
+            }
+            EndItem();
+        }
+        a0 = a1;
+    }
+    if (fmt != NULL) {
+        a0 = angle0 * 2 * IM_PI / 360.0;
+        a1 = angle0 * 2 * IM_PI / 360.0;
+        char buffer[32];
+        for (int i = 0; i < count; ++i) {
+            ImPlotItem* item = GetItem(label_ids[i]);
+            double percent = normalize ? (double)values[i] / sum : (double)values[i];
+            a1 = a0 + 2 * IM_PI * percent;
+            if (item->Show) {
+                ImFormatString(buffer, 32, fmt, (double)values[i]);
+                ImVec2 size = ImGui::CalcTextSize(buffer);
+                double angle = a0 + (a1 - a0) * 0.5;
+                ImVec2 pos = PlotToPixels(center.x + 0.5 * radius * cos(angle), center.y + 0.5 * radius * sin(angle),IMPLOT_AUTO,IMPLOT_AUTO);
+                ImU32 col  = CalcTextColor(ImGui::ColorConvertU32ToFloat4(item->Color));
+                draw_list.AddText(pos - size * 0.5f, col, buffer);
+            }
+            a0 = a1;
+        }
+    }
+    PopPlotClipRect();
+}
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotPieChart<T>(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotHeatmap
+//-----------------------------------------------------------------------------
+
+template <typename T>
+struct GetterHeatmapRowMaj {
+    GetterHeatmapRowMaj(const T* values, int rows, int cols, double scale_min, double scale_max, double width, double height, double xref, double yref, double ydir) :
+        Values(values),
+        Count(rows*cols),
+        Rows(rows),
+        Cols(cols),
+        ScaleMin(scale_min),
+        ScaleMax(scale_max),
+        Width(width),
+        Height(height),
+        XRef(xref),
+        YRef(yref),
+        YDir(ydir),
+        HalfSize(Width*0.5, Height*0.5)
+    { }
+    template <typename I> IMPLOT_INLINE RectC operator()(I idx) const {
+        double val = (double)Values[idx];
+        const int r = idx / Cols;
+        const int c = idx % Cols;
+        const ImPlotPoint p(XRef + HalfSize.x + c*Width, YRef + YDir * (HalfSize.y + r*Height));
+        RectC rect;
+        rect.Pos = p;
+        rect.HalfSize = HalfSize;
+        const float t = ImClamp((float)ImRemap01(val, ScaleMin, ScaleMax),0.0f,1.0f);
+        rect.Color = GImPlot->ColormapData.LerpTable(GImPlot->Style.Colormap, t);
+        return rect;
+    }
+    const T* const Values;
+    const int Count, Rows, Cols;
+    const double ScaleMin, ScaleMax, Width, Height, XRef, YRef, YDir;
+    const ImPlotPoint HalfSize;
+};
+
+template <typename T>
+struct GetterHeatmapColMaj {
+    GetterHeatmapColMaj(const T* values, int rows, int cols, double scale_min, double scale_max, double width, double height, double xref, double yref, double ydir) :
+        Values(values),
+        Count(rows*cols),
+        Rows(rows),
+        Cols(cols),
+        ScaleMin(scale_min),
+        ScaleMax(scale_max),
+        Width(width),
+        Height(height),
+        XRef(xref),
+        YRef(yref),
+        YDir(ydir),
+        HalfSize(Width*0.5, Height*0.5)
+    { }
+    template <typename I> IMPLOT_INLINE RectC operator()(I idx) const {
+        double val = (double)Values[idx];
+        const int r = idx % Cols;
+        const int c = idx / Cols;
+        const ImPlotPoint p(XRef + HalfSize.x + c*Width, YRef + YDir * (HalfSize.y + r*Height));
+        RectC rect;
+        rect.Pos = p;
+        rect.HalfSize = HalfSize;
+        const float t = ImClamp((float)ImRemap01(val, ScaleMin, ScaleMax),0.0f,1.0f);
+        rect.Color = GImPlot->ColormapData.LerpTable(GImPlot->Style.Colormap, t);
+        return rect;
+    }
+    const T* const Values;
+    const int Count, Rows, Cols;
+    const double ScaleMin, ScaleMax, Width, Height, XRef, YRef, YDir;
+    const ImPlotPoint HalfSize;
+};
+
+template <typename T>
+void RenderHeatmap(ImDrawList& draw_list, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, bool reverse_y, bool col_maj) {
+    ImPlotContext& gp = *GImPlot;
+    Transformer2 transformer;
+    if (scale_min == 0 && scale_max == 0) {
+        T temp_min, temp_max;
+        ImMinMaxArray(values,rows*cols,&temp_min,&temp_max);
+        scale_min = (double)temp_min;
+        scale_max = (double)temp_max;
+    }
+    if (scale_min == scale_max) {
+        ImVec2 a = transformer(bounds_min);
+        ImVec2 b = transformer(bounds_max);
+        ImU32  col = GetColormapColorU32(0,gp.Style.Colormap);
+        draw_list.AddRectFilled(a, b, col);
+        return;
+    }
+    const double yref = reverse_y ? bounds_max.y : bounds_min.y;
+    const double ydir = reverse_y ? -1 : 1;
+    if (col_maj) {
+        GetterHeatmapColMaj<T> getter(values, rows, cols, scale_min, scale_max, (bounds_max.x - bounds_min.x) / cols, (bounds_max.y - bounds_min.y) / rows, bounds_min.x, yref, ydir);
+        RenderPrimitives1<RendererRectC>(getter);
+    }
+    else {
+        GetterHeatmapRowMaj<T> getter(values, rows, cols, scale_min, scale_max, (bounds_max.x - bounds_min.x) / cols, (bounds_max.y - bounds_min.y) / rows, bounds_min.x, yref, ydir);
+        RenderPrimitives1<RendererRectC>(getter);
+    }
+    // labels
+    if (fmt != NULL) {
+        const double w = (bounds_max.x - bounds_min.x) / cols;
+        const double h = (bounds_max.y - bounds_min.y) / rows;
+        const ImPlotPoint half_size(w*0.5,h*0.5);
+        int i = 0;
+        if (col_maj) {
+            for (int c = 0; c < cols; ++c) {
+                for (int r = 0; r < rows; ++r) {
+                    ImPlotPoint p;
+                    p.x = bounds_min.x + 0.5*w + c*w;
+                    p.y = yref + ydir * (0.5*h + r*h);
+                    ImVec2 px = transformer(p);
+                    char buff[32];
+                    ImFormatString(buff, 32, fmt, values[i]);
+                    ImVec2 size = ImGui::CalcTextSize(buff);
+                    double t = ImClamp(ImRemap01((double)values[i], scale_min, scale_max),0.0,1.0);
+                    ImVec4 color = SampleColormap((float)t);
+                    ImU32 col = CalcTextColor(color);
+                    draw_list.AddText(px - size * 0.5f, col, buff);
+                    i++;
+                }
+            }
+        }
+        else {
+            for (int r = 0; r < rows; ++r) {
+                for (int c = 0; c < cols; ++c) {
+                    ImPlotPoint p;
+                    p.x = bounds_min.x + 0.5*w + c*w;
+                    p.y = yref + ydir * (0.5*h + r*h);
+                    ImVec2 px = transformer(p);
+                    char buff[32];
+                    ImFormatString(buff, 32, fmt, values[i]);
+                    ImVec2 size = ImGui::CalcTextSize(buff);
+                    double t = ImClamp(ImRemap01((double)values[i], scale_min, scale_max),0.0,1.0);
+                    ImVec4 color = SampleColormap((float)t);
+                    ImU32 col = CalcTextColor(color);
+                    draw_list.AddText(px - size * 0.5f, col, buff);
+                    i++;
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+void PlotHeatmap(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags) {
+    if (BeginItemEx(label_id, FitterRect(bounds_min, bounds_max))) {
+        ImDrawList& draw_list = *GetPlotDrawList();
+        const bool col_maj = ImHasFlag(flags, ImPlotHeatmapFlags_ColMajor);
+        RenderHeatmap(draw_list, values, rows, cols, scale_min, scale_max, fmt, bounds_min, bounds_max, true, col_maj);
+        EndItem();
+    }
+}
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotHeatmap<T>(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotHistogram
+//-----------------------------------------------------------------------------
+
+template <typename T>
+double PlotHistogram(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags) {
+
+    const bool cumulative = ImHasFlag(flags, ImPlotHistogramFlags_Cumulative);
+    const bool density    = ImHasFlag(flags, ImPlotHistogramFlags_Density);
+    const bool outliers   = !ImHasFlag(flags, ImPlotHistogramFlags_NoOutliers);
+
+    if (count <= 0 || bins == 0)
+        return 0;
+
+    if (range.Min == 0 && range.Max == 0) {
+        T Min, Max;
+        ImMinMaxArray(values, count, &Min, &Max);
+        range.Min = (double)Min;
+        range.Max = (double)Max;
+    }
+
+    double width;
+    if (bins < 0)
+        CalculateBins(values, count, bins, range, bins, width);
+    else
+        width = range.Size() / bins;
+
+    ImVector<double>& bin_centers = GImPlot->TempDouble1;
+    ImVector<double>& bin_counts  = GImPlot->TempDouble2;
+    bin_centers.resize(bins);
+    bin_counts.resize(bins);
+    int below = 0;
+
+    for (int b = 0; b < bins; ++b) {
+        bin_centers[b] = range.Min + b * width + width * 0.5;
+        bin_counts[b] = 0;
+    }
+    int counted = 0;
+    double max_count = 0;
+    for (int i = 0; i < count; ++i) {
+        double val = (double)values[i];
+        if (range.Contains(val)) {
+            const int b = ImClamp((int)((val - range.Min) / width), 0, bins - 1);
+            bin_counts[b] += 1.0;
+            if (bin_counts[b] > max_count)
+                max_count = bin_counts[b];
+            counted++;
+        }
+        else if (val < range.Min) {
+            below++;
+        }
+    }
+    if (cumulative && density) {
+        if (outliers)
+            bin_counts[0] += below;
+        for (int b = 1; b < bins; ++b)
+            bin_counts[b] += bin_counts[b-1];
+        double scale = 1.0 / (outliers ? count : counted);
+        for (int b = 0; b < bins; ++b)
+            bin_counts[b] *= scale;
+        max_count = bin_counts[bins-1];
+    }
+    else if (cumulative) {
+        if (outliers)
+            bin_counts[0] += below;
+        for (int b = 1; b < bins; ++b)
+            bin_counts[b] += bin_counts[b-1];
+        max_count = bin_counts[bins-1];
+    }
+    else if (density) {
+        double scale = 1.0 / ((outliers ? count : counted) * width);
+        for (int b = 0; b < bins; ++b)
+            bin_counts[b] *= scale;
+        max_count *= scale;
+    }
+    if (ImHasFlag(flags, ImPlotHistogramFlags_Horizontal))
+        PlotBars(label_id, &bin_counts.Data[0], &bin_centers.Data[0], bins, bar_scale*width, ImPlotBarsFlags_Horizontal);
+    else
+        PlotBars(label_id, &bin_centers.Data[0], &bin_counts.Data[0], bins, bar_scale*width);
+    return max_count;
+}
+#define INSTANTIATE_MACRO(T) template IMPLOT_API double PlotHistogram<T>(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotHistogram2D
+//-----------------------------------------------------------------------------
+
+template <typename T>
+double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags) {
+
+    // const bool cumulative = ImHasFlag(flags, ImPlotHistogramFlags_Cumulative); NOT SUPPORTED
+    const bool density  = ImHasFlag(flags, ImPlotHistogramFlags_Density);
+    const bool outliers = !ImHasFlag(flags, ImPlotHistogramFlags_NoOutliers);
+    const bool col_maj  = ImHasFlag(flags, ImPlotHistogramFlags_ColMajor);
+
+    if (count <= 0 || x_bins == 0 || y_bins == 0)
+        return 0;
+
+    if (range.X.Min == 0 && range.X.Max == 0) {
+        T Min, Max;
+        ImMinMaxArray(xs, count, &Min, &Max);
+        range.X.Min = (double)Min;
+        range.X.Max = (double)Max;
+    }
+    if (range.Y.Min == 0 && range.Y.Max == 0) {
+        T Min, Max;
+        ImMinMaxArray(ys, count, &Min, &Max);
+        range.Y.Min = (double)Min;
+        range.Y.Max = (double)Max;
+    }
+
+    double width, height;
+    if (x_bins < 0)
+        CalculateBins(xs, count, x_bins, range.X, x_bins, width);
+    else
+        width = range.X.Size() / x_bins;
+    if (y_bins < 0)
+        CalculateBins(ys, count, y_bins, range.Y, y_bins, height);
+    else
+        height = range.Y.Size() / y_bins;
+
+    const int bins = x_bins * y_bins;
+
+    ImVector<double>& bin_counts = GImPlot->TempDouble1;
+    bin_counts.resize(bins);
+
+    for (int b = 0; b < bins; ++b)
+        bin_counts[b] = 0;
+
+    int counted = 0;
+    double max_count = 0;
+    for (int i = 0; i < count; ++i) {
+        if (range.Contains((double)xs[i], (double)ys[i])) {
+            const int xb = ImClamp( (int)((double)(xs[i] - range.X.Min) / width)  , 0, x_bins - 1);
+            const int yb = ImClamp( (int)((double)(ys[i] - range.Y.Min) / height) , 0, y_bins - 1);
+            const int b  = yb * x_bins + xb;
+            bin_counts[b] += 1.0;
+            if (bin_counts[b] > max_count)
+                max_count = bin_counts[b];
+            counted++;
+        }
+    }
+    if (density) {
+        double scale = 1.0 / ((outliers ? count : counted) * width * height);
+        for (int b = 0; b < bins; ++b)
+            bin_counts[b] *= scale;
+        max_count *= scale;
+    }
+
+    if (BeginItemEx(label_id, FitterRect(range))) {
+        ImDrawList& draw_list = *GetPlotDrawList();
+        RenderHeatmap(draw_list, &bin_counts.Data[0], y_bins, x_bins, 0, max_count, NULL, range.Min(), range.Max(), false, col_maj);
+        EndItem();
+    }
+    return max_count;
+}
+#define INSTANTIATE_MACRO(T) template IMPLOT_API double PlotHistogram2D<T>(const char* label_id,   const T*   xs, const T*   ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotDigital
+//-----------------------------------------------------------------------------
+
+// TODO: Make this behave like all the other plot types (.e. not fixed in y axis)
+
+template <typename Getter>
+void PlotDigitalEx(const char* label_id, Getter getter, ImPlotDigitalFlags flags) {
+    if (BeginItem(label_id, flags, ImPlotCol_Fill)) {
+        ImPlotContext& gp = *GImPlot;
+        ImDrawList& draw_list = *GetPlotDrawList();
+        const ImPlotNextItemData& s = GetItemData();
+        if (getter.Count > 1 && s.RenderFill) {
+            ImPlotPlot& plot   = *gp.CurrentPlot;
+            ImPlotAxis& x_axis = plot.Axes[plot.CurrentX];
+            ImPlotAxis& y_axis = plot.Axes[plot.CurrentY];
+
+            int pixYMax = 0;
+            ImPlotPoint itemData1 = getter(0);
+            for (int i = 0; i < getter.Count; ++i) {
+                ImPlotPoint itemData2 = getter(i);
+                if (ImNanOrInf(itemData1.y)) {
+                    itemData1 = itemData2;
+                    continue;
+                }
+                if (ImNanOrInf(itemData2.y)) itemData2.y = ImConstrainNan(ImConstrainInf(itemData2.y));
+                int pixY_0 = (int)(s.LineWeight);
+                itemData1.y = ImMax(0.0, itemData1.y);
+                float pixY_1_float = s.DigitalBitHeight * (float)itemData1.y;
+                int pixY_1 = (int)(pixY_1_float); //allow only positive values
+                int pixY_chPosOffset = (int)(ImMax(s.DigitalBitHeight, pixY_1_float) + s.DigitalBitGap);
+                pixYMax = ImMax(pixYMax, pixY_chPosOffset);
+                ImVec2 pMin = PlotToPixels(itemData1,IMPLOT_AUTO,IMPLOT_AUTO);
+                ImVec2 pMax = PlotToPixels(itemData2,IMPLOT_AUTO,IMPLOT_AUTO);
+                int pixY_Offset = 0; //20 pixel from bottom due to mouse cursor label
+                pMin.y = (y_axis.PixelMin) + ((-gp.DigitalPlotOffset)                   - pixY_Offset);
+                pMax.y = (y_axis.PixelMin) + ((-gp.DigitalPlotOffset) - pixY_0 - pixY_1 - pixY_Offset);
+                //plot only one rectangle for same digital state
+                while (((i+2) < getter.Count) && (itemData1.y == itemData2.y)) {
+                    const int in = (i + 1);
+                    itemData2 = getter(in);
+                    if (ImNanOrInf(itemData2.y)) break;
+                    pMax.x = PlotToPixels(itemData2,IMPLOT_AUTO,IMPLOT_AUTO).x;
+                    i++;
+                }
+                //do not extend plot outside plot range
+                if (pMin.x < x_axis.PixelMin) pMin.x = x_axis.PixelMin;
+                if (pMax.x < x_axis.PixelMin) pMax.x = x_axis.PixelMin;
+                if (pMin.x > x_axis.PixelMax) pMin.x = x_axis.PixelMax;
+                if (pMax.x > x_axis.PixelMax) pMax.x = x_axis.PixelMax;
+                //plot a rectangle that extends up to x2 with y1 height
+                if ((pMax.x > pMin.x) && (gp.CurrentPlot->PlotRect.Contains(pMin) || gp.CurrentPlot->PlotRect.Contains(pMax))) {
+                    // ImVec4 colAlpha = item->Color;
+                    // colAlpha.w = item->Highlight ? 1.0f : 0.9f;
+                    draw_list.AddRectFilled(pMin, pMax, ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]));
+                }
+                itemData1 = itemData2;
+            }
+            gp.DigitalPlotItemCnt++;
+            gp.DigitalPlotOffset += pixYMax;
+        }
+        EndItem();
+    }
+}
+
+
+template <typename T>
+void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags, int offset, int stride) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
+    return PlotDigitalEx(label_id, getter, flags);
+}
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotDigital<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+// custom
+void PlotDigitalG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotDigitalFlags flags) {
+    GetterFuncPtr getter(getter_func,data,count);
+    return PlotDigitalEx(label_id, getter, flags);
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotImage
+//-----------------------------------------------------------------------------
+
+void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bmin, const ImPlotPoint& bmax, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, ImPlotImageFlags) {
+    if (BeginItemEx(label_id, FitterRect(bmin,bmax))) {
+        ImU32 tint_col32 = ImGui::ColorConvertFloat4ToU32(tint_col);
+        GetCurrentItem()->Color = tint_col32;
+        ImDrawList& draw_list = *GetPlotDrawList();
+        ImVec2 p1 = PlotToPixels(bmin.x, bmax.y,IMPLOT_AUTO,IMPLOT_AUTO);
+        ImVec2 p2 = PlotToPixels(bmax.x, bmin.y,IMPLOT_AUTO,IMPLOT_AUTO);
+        PushPlotClipRect();
+        draw_list.AddImage(user_texture_id, p1, p2, uv0, uv1, tint_col32);
+        PopPlotClipRect();
+        EndItem();
+    }
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotText
+//-----------------------------------------------------------------------------
+
+void PlotText(const char* text, double x, double y, const ImVec2& pixel_offset, ImPlotTextFlags flags) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "PlotText() needs to be called between BeginPlot() and EndPlot()!");
+    SetupLock();
+    ImDrawList & draw_list = *GetPlotDrawList();
+    PushPlotClipRect();
+    ImU32 colTxt = GetStyleColorU32(ImPlotCol_InlayText);
+    if (ImHasFlag(flags,ImPlotTextFlags_Vertical)) {
+        ImVec2 siz = CalcTextSizeVertical(text) * 0.5f;
+        ImVec2 ctr = siz * 0.5f;
+        ImVec2 pos = PlotToPixels(ImPlotPoint(x,y),IMPLOT_AUTO,IMPLOT_AUTO) + ImVec2(-ctr.x, ctr.y) + pixel_offset;
+        if (FitThisFrame()) {
+            FitPoint(PixelsToPlot(pos));
+            FitPoint(PixelsToPlot(pos.x + siz.x, pos.y - siz.y));
+        }
+        AddTextVertical(&draw_list, pos, colTxt, text);
+    }
+    else {
+        ImVec2 siz = ImGui::CalcTextSize(text);
+        ImVec2 pos = PlotToPixels(ImPlotPoint(x,y),IMPLOT_AUTO,IMPLOT_AUTO) - siz * 0.5f + pixel_offset;
+        if (FitThisFrame()) {
+            FitPoint(PixelsToPlot(pos));
+            FitPoint(PixelsToPlot(pos+siz));
+        }
+        draw_list.AddText(pos, colTxt, text);
+    }
+    PopPlotClipRect();
+}
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotDummy
+//-----------------------------------------------------------------------------
+
+void PlotDummy(const char* label_id, ImPlotDummyFlags flags) {
+    if (BeginItem(label_id, flags, ImPlotCol_Line))
+        EndItem();
+}
+
+} // namespace ImPlot

--- a/lib/implot/implot_items.cpp
+++ b/lib/implot/implot_items.cpp
@@ -1,6 +1,7 @@
 // MIT License
 
-// Copyright (c) 2020 Evan Pezent
+// Copyright (c) 2020-2024 Evan Pezent
+// Copyright (c) 2025-2026 Breno Cunha Queiroz
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,9 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// ImPlot v0.14
+// ImPlot v1.1 WIP
 
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "implot.h"
+#ifndef IMGUI_DISABLE
 #include "implot_internal.h"
 
 //-----------------------------------------------------------------------------
@@ -81,7 +86,7 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
 //     unsigned long long  ImU64;  // 64-bit unsigned integer
 // (note: this list does *not* include `long`, `unsigned long` and `long double`)
 //
-// You can customize the supported types by defining IMPLOT_CUSTOM_NUMERIC_TYPES at compile time to define your own type list. 
+// You can customize the supported types by defining IMPLOT_CUSTOM_NUMERIC_TYPES at compile time to define your own type list.
 //    As an example, you could use the compile time define given by the line below in order to support only float and double.
 //        -DIMPLOT_CUSTOM_NUMERIC_TYPES="(float)(double)"
 //    In order to support all known C++ types, use:
@@ -93,15 +98,15 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
     #define IMPLOT_NUMERIC_TYPES (ImS8)(ImU8)(ImS16)(ImU16)(ImS32)(ImU32)(ImS64)(ImU64)(float)(double)
 #endif
 
-// CALL_INSTANTIATE_FOR_NUMERIC_TYPES will duplicate the template instantion code `INSTANTIATE_MACRO(T)` on supported types.
+// CALL_INSTANTIATE_FOR_NUMERIC_TYPES will duplicate the template instantiation code `INSTANTIATE_MACRO(T)` on supported types.
 #define _CAT(x, y) _CAT_(x, y)
 #define _CAT_(x,y) x ## y
 #define _INSTANTIATE_FOR_NUMERIC_TYPES(chain) _CAT(_INSTANTIATE_FOR_NUMERIC_TYPES_1 chain, _END)
-#define _INSTANTIATE_FOR_NUMERIC_TYPES_1(T) INSTANTIATE_MACRO(T); _INSTANTIATE_FOR_NUMERIC_TYPES_2
-#define _INSTANTIATE_FOR_NUMERIC_TYPES_2(T) INSTANTIATE_MACRO(T); _INSTANTIATE_FOR_NUMERIC_TYPES_1
+#define _INSTANTIATE_FOR_NUMERIC_TYPES_1(T) INSTANTIATE_MACRO(T) _INSTANTIATE_FOR_NUMERIC_TYPES_2
+#define _INSTANTIATE_FOR_NUMERIC_TYPES_2(T) INSTANTIATE_MACRO(T) _INSTANTIATE_FOR_NUMERIC_TYPES_1
 #define _INSTANTIATE_FOR_NUMERIC_TYPES_1_END
 #define _INSTANTIATE_FOR_NUMERIC_TYPES_2_END
-#define CALL_INSTANTIATE_FOR_NUMERIC_TYPES() _INSTANTIATE_FOR_NUMERIC_TYPES(IMPLOT_NUMERIC_TYPES);
+#define CALL_INSTANTIATE_FOR_NUMERIC_TYPES() _INSTANTIATE_FOR_NUMERIC_TYPES(IMPLOT_NUMERIC_TYPES)
 
 namespace ImPlot {
 
@@ -114,6 +119,43 @@ template <typename T>
 struct MaxIdx { static const unsigned int Value; };
 template <> const unsigned int MaxIdx<unsigned short>::Value = 65535;
 template <> const unsigned int MaxIdx<unsigned int>::Value   = 4294967295;
+
+template <typename T>
+int Stride(const ImPlotSpec& spec) {
+    return spec.Stride == IMPLOT_AUTO ? sizeof(T) : spec.Stride;
+}
+
+// Finds the min and max value in an unsorted array
+template <typename Indexer, typename T>
+static inline void ImMinMaxIndexer(const Indexer& values, int count, T* min_out, T* max_out) {
+    T Min = values[0]; T Max = values[0];
+    for (int i = 1; i < count; ++i) {
+        if (values[i] < Min) { Min = values[i]; }
+        if (values[i] > Max) { Max = values[i]; }
+    }
+    *min_out = Min; *max_out = Max;
+}
+
+// Finds the mean of a container
+template <typename TContainer>
+static inline double ImMean(const TContainer& values, int count) {
+    double den = 1.0 / count;
+    double mu  = 0;
+    for (int i = 0; i < count; ++i)
+        mu += (double)values[i] * den;
+    return mu;
+}
+
+// Finds the sample standard deviation of a container
+template <typename TContainer>
+static inline double ImStdDev(const TContainer& values, int count) {
+    double den = 1.0 / (count - 1.0);
+    double mu  = ImMean(values, count);
+    double x   = 0;
+    for (int i = 0; i < count; ++i)
+        x += ((double)values[i] - mu) * ((double)values[i] - mu) * den;
+    return sqrt(x);
+}
 
 IMPLOT_INLINE void GetLineRenderProps(const ImDrawList& draw_list, float& half_weight, ImVec2& tex_uv0, ImVec2& tex_uv1) {
     const bool aa = ImHasFlag(draw_list.Flags, ImDrawListFlags_AntiAliasedLines) &&
@@ -284,15 +326,15 @@ ImPlotItem* RegisterOrGetItem(const char* label_id, ImPlotItemFlags flags, bool*
     ImPlotContext& gp = *GImPlot;
     ImPlotItemGroup& Items = *gp.CurrentItems;
     ImGuiID id = Items.GetItemID(label_id);
-    if (just_created != NULL)
-        *just_created = Items.GetItem(id) == NULL;
+    if (just_created != nullptr)
+        *just_created = Items.GetItem(id) == nullptr;
     ImPlotItem* item = Items.GetOrAddItem(id);
     if (item->SeenThisFrame)
         return item;
     item->SeenThisFrame = true;
     int idx = Items.GetItemIndex(item);
     item->ID = id;
-    if (!ImHasFlag(flags, ImPlotItemFlags_NoLegend) && ImGui::FindRenderedTextEnd(label_id, NULL) != label_id) {
+    if (!ImHasFlag(flags, ImPlotItemFlags_NoLegend) && ImGui::FindRenderedTextEnd(label_id, nullptr) != label_id) {
         Items.Legend.Indices.push_back(idx);
         item->NameOffset = Items.Legend.Labels.size();
         Items.Legend.Labels.append(label_id, label_id + strlen(label_id) + 1);
@@ -310,40 +352,12 @@ ImPlotItem* GetItem(const char* label_id) {
 
 bool IsItemHidden(const char* label_id) {
     ImPlotItem* item = GetItem(label_id);
-    return item != NULL && !item->Show;
+    return item != nullptr && !item->Show;
 }
 
 ImPlotItem* GetCurrentItem() {
     ImPlotContext& gp = *GImPlot;
     return gp.CurrentItem;
-}
-
-void SetNextLineStyle(const ImVec4& col, float weight) {
-    ImPlotContext& gp = *GImPlot;
-    gp.NextItemData.Colors[ImPlotCol_Line] = col;
-    gp.NextItemData.LineWeight             = weight;
-}
-
-void SetNextFillStyle(const ImVec4& col, float alpha) {
-    ImPlotContext& gp = *GImPlot;
-    gp.NextItemData.Colors[ImPlotCol_Fill] = col;
-    gp.NextItemData.FillAlpha              = alpha;
-}
-
-void SetNextMarkerStyle(ImPlotMarker marker, float size, const ImVec4& fill, float weight, const ImVec4& outline) {
-    ImPlotContext& gp = *GImPlot;
-    gp.NextItemData.Marker                          = marker;
-    gp.NextItemData.Colors[ImPlotCol_MarkerFill]    = fill;
-    gp.NextItemData.MarkerSize                      = size;
-    gp.NextItemData.Colors[ImPlotCol_MarkerOutline] = outline;
-    gp.NextItemData.MarkerWeight                    = weight;
-}
-
-void SetNextErrorBarStyle(const ImVec4& col, float size, float weight) {
-    ImPlotContext& gp = *GImPlot;
-    gp.NextItemData.Colors[ImPlotCol_ErrorBar] = col;
-    gp.NextItemData.ErrorBarSize               = size;
-    gp.NextItemData.ErrorBarWeight             = weight;
 }
 
 ImVec4 GetLastItemColor() {
@@ -367,17 +381,17 @@ void BustItemCache() {
 
 void BustColorCache(const char* plot_title_id) {
     ImPlotContext& gp = *GImPlot;
-    if (plot_title_id == NULL) {
+    if (plot_title_id == nullptr) {
         BustItemCache();
     }
     else {
         ImGuiID id = ImGui::GetCurrentWindow()->GetID(plot_title_id);
         ImPlotPlot* plot = gp.Plots.GetByKey(id);
-        if (plot != NULL)
+        if (plot != nullptr)
             plot->Items.Reset();
         else {
             ImPlotSubplot* subplot = gp.Subplots.GetByKey(id);
-            if (subplot != NULL)
+            if (subplot != nullptr)
                 subplot->Items.Reset();
         }
     }
@@ -387,70 +401,65 @@ void BustColorCache(const char* plot_title_id) {
 // [SECTION] BeginItem / EndItem
 //-----------------------------------------------------------------------------
 
-static const float ITEM_HIGHLIGHT_LINE_SCALE = 2.0f;
-static const float ITEM_HIGHLIGHT_MARK_SCALE = 1.25f;
+constexpr float ITEM_HIGHLIGHT_LINE_SCALE = 2.0f;
+constexpr float ITEM_HIGHLIGHT_MARK_SCALE = 1.25f;
 
 // Begins a new item. Returns false if the item should not be plotted.
-bool BeginItem(const char* label_id, ImPlotItemFlags flags, ImPlotCol recolor_from) {
+bool BeginItem(const char* label_id, const ImPlotSpec& spec, const ImVec4& item_col, ImPlotMarker item_mkr) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "PlotX() needs to be called between BeginPlot() and EndPlot()!");
+    IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "PlotX() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     bool just_created;
-    ImPlotItem* item = RegisterOrGetItem(label_id, flags, &just_created);
+    ImPlotItem* item = RegisterOrGetItem(label_id, spec.Flags, &just_created);
     // set current item
     gp.CurrentItem = item;
     ImPlotNextItemData& s = gp.NextItemData;
     // set/override item color
-    if (recolor_from != -1) {
-        if (!IsColorAuto(s.Colors[recolor_from]))
-            item->Color = ImGui::ColorConvertFloat4ToU32(s.Colors[recolor_from]);
-        else if (!IsColorAuto(gp.Style.Colors[recolor_from]))
-            item->Color = ImGui::ColorConvertFloat4ToU32(gp.Style.Colors[recolor_from]);
-        else if (just_created)
-            item->Color = NextColormapColorU32();
-    }
-    else if (just_created) {
+    if (!IsColorAuto(item_col))
+        item->Color = ImGui::ColorConvertFloat4ToU32(item_col);
+    else if (just_created)
         item->Color = NextColormapColorU32();
-    }
-    // hide/show item
     if (gp.NextItemData.HasHidden) {
         if (just_created || gp.NextItemData.HiddenCond == ImGuiCond_Always)
             item->Show = !gp.NextItemData.Hidden;
     }
+    // set/override item marker
+    if (item_mkr != ImPlotMarker_Invalid) {
+        if (item_mkr != ImPlotMarker_Auto) {
+            item->Marker = item_mkr;
+        }
+        else if (just_created && item_mkr == ImPlotMarker_Auto) {
+            item->Marker = NextMarker();
+        }
+        else if (item_mkr == ImPlotMarker_Auto && item->Marker == ImPlotMarker_None) {
+            item->Marker = NextMarker();
+        }
+    }
+    // return false if not shown
     if (!item->Show) {
         // reset next item data
         gp.NextItemData.Reset();
         gp.PreviousItem = item;
-        gp.CurrentItem  = NULL;
+        gp.CurrentItem  = nullptr;
         return false;
     }
     else {
         ImVec4 item_color = ImGui::ColorConvertU32ToFloat4(item->Color);
-        // stage next item colors
-        s.Colors[ImPlotCol_Line]           = IsColorAuto(s.Colors[ImPlotCol_Line])          ? ( IsColorAuto(ImPlotCol_Line)           ? item_color                 : gp.Style.Colors[ImPlotCol_Line]          ) : s.Colors[ImPlotCol_Line];
-        s.Colors[ImPlotCol_Fill]           = IsColorAuto(s.Colors[ImPlotCol_Fill])          ? ( IsColorAuto(ImPlotCol_Fill)           ? item_color                 : gp.Style.Colors[ImPlotCol_Fill]          ) : s.Colors[ImPlotCol_Fill];
-        s.Colors[ImPlotCol_MarkerOutline]  = IsColorAuto(s.Colors[ImPlotCol_MarkerOutline]) ? ( IsColorAuto(ImPlotCol_MarkerOutline)  ? s.Colors[ImPlotCol_Line]   : gp.Style.Colors[ImPlotCol_MarkerOutline] ) : s.Colors[ImPlotCol_MarkerOutline];
-        s.Colors[ImPlotCol_MarkerFill]     = IsColorAuto(s.Colors[ImPlotCol_MarkerFill])    ? ( IsColorAuto(ImPlotCol_MarkerFill)     ? s.Colors[ImPlotCol_Line]   : gp.Style.Colors[ImPlotCol_MarkerFill]    ) : s.Colors[ImPlotCol_MarkerFill];
-        s.Colors[ImPlotCol_ErrorBar]       = IsColorAuto(s.Colors[ImPlotCol_ErrorBar])      ? ( GetStyleColorVec4(ImPlotCol_ErrorBar)                                                                         ) : s.Colors[ImPlotCol_ErrorBar];
-        // stage next item style vars
-        s.LineWeight         = s.LineWeight       < 0 ? gp.Style.LineWeight       : s.LineWeight;
-        s.Marker             = s.Marker           < 0 ? gp.Style.Marker           : s.Marker;
-        s.MarkerSize         = s.MarkerSize       < 0 ? gp.Style.MarkerSize       : s.MarkerSize;
-        s.MarkerWeight       = s.MarkerWeight     < 0 ? gp.Style.MarkerWeight     : s.MarkerWeight;
-        s.FillAlpha          = s.FillAlpha        < 0 ? gp.Style.FillAlpha        : s.FillAlpha;
-        s.ErrorBarSize       = s.ErrorBarSize     < 0 ? gp.Style.ErrorBarSize     : s.ErrorBarSize;
-        s.ErrorBarWeight     = s.ErrorBarWeight   < 0 ? gp.Style.ErrorBarWeight   : s.ErrorBarWeight;
-        s.DigitalBitHeight   = s.DigitalBitHeight < 0 ? gp.Style.DigitalBitHeight : s.DigitalBitHeight;
-        s.DigitalBitGap      = s.DigitalBitGap    < 0 ? gp.Style.DigitalBitGap    : s.DigitalBitGap;
-        // apply alpha modifier(s)
-        s.Colors[ImPlotCol_Fill].w       *= s.FillAlpha;
-        s.Colors[ImPlotCol_MarkerFill].w *= s.FillAlpha; // TODO: this should be separate, if it at all
+        // stage next item spec
+        s.Spec = spec;
+        s.Spec.LineColor = IsColorAuto(s.Spec.LineColor) ? item_color : s.Spec.LineColor;
+        s.Spec.FillColor = IsColorAuto(s.Spec.FillColor) ? item_color : s.Spec.FillColor;
+        s.Spec.FillColor.w *= s.Spec.FillAlpha;
+        s.Spec.Marker = item->Marker;
+        s.Spec.MarkerLineColor = IsColorAuto(s.Spec.MarkerLineColor) ? s.Spec.LineColor : s.Spec.MarkerLineColor;
+        s.Spec.MarkerFillColor = IsColorAuto(s.Spec.MarkerFillColor) ? s.Spec.LineColor : s.Spec.MarkerFillColor;
+        s.Spec.MarkerFillColor.w *= s.Spec.FillAlpha;
         // apply highlight mods
         if (item->LegendHovered) {
             if (!ImHasFlag(gp.CurrentItems->Legend.Flags, ImPlotLegendFlags_NoHighlightItem)) {
-                s.LineWeight   *= ITEM_HIGHLIGHT_LINE_SCALE;
-                s.MarkerSize   *= ITEM_HIGHLIGHT_MARK_SCALE;
-                s.MarkerWeight *= ITEM_HIGHLIGHT_LINE_SCALE;
+                s.Spec.LineWeight *= ITEM_HIGHLIGHT_LINE_SCALE;
+                s.Spec.MarkerSize *= ITEM_HIGHLIGHT_MARK_SCALE;
+                s.Spec.Size *= ITEM_HIGHLIGHT_MARK_SCALE;
                 // TODO: how to highlight fills?
             }
             if (!ImHasFlag(gp.CurrentItems->Legend.Flags, ImPlotLegendFlags_NoHighlightAxis)) {
@@ -461,10 +470,11 @@ bool BeginItem(const char* label_id, ImPlotItemFlags flags, ImPlotCol recolor_fr
             }
         }
         // set render flags
-        s.RenderLine       = s.Colors[ImPlotCol_Line].w          > 0 && s.LineWeight > 0;
-        s.RenderFill       = s.Colors[ImPlotCol_Fill].w          > 0;
-        s.RenderMarkerFill = s.Colors[ImPlotCol_MarkerFill].w    > 0;
-        s.RenderMarkerLine = s.Colors[ImPlotCol_MarkerOutline].w > 0 && s.MarkerWeight > 0;
+        s.RenderLine = s.Spec.LineColor.w > 0 && s.Spec.LineWeight > 0;
+        s.RenderFill = s.Spec.FillColor.w > 0;
+        s.RenderMarkerLine = s.Spec.MarkerLineColor.w > 0 && s.Spec.LineWeight > 0;
+        s.RenderMarkerFill = s.Spec.MarkerFillColor.w > 0;
+        s.RenderMarkers = s.Spec.Marker >= 0 && (s.RenderMarkerFill || s.RenderMarkerLine);
         // push rendering clip rect
         PushPlotClipRect();
         return true;
@@ -480,7 +490,7 @@ void EndItem() {
     gp.NextItemData.Reset();
     // set current item
     gp.PreviousItem = gp.CurrentItem;
-    gp.CurrentItem  = NULL;
+    gp.CurrentItem  = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -507,13 +517,14 @@ struct IndexerIdx {
         Offset(count ? ImPosMod(offset, count) : 0),
         Stride(stride)
     { }
-    template <typename I> IMPLOT_INLINE double operator()(I idx) const {
+    template <typename I> IMPLOT_INLINE double operator[](I idx) const {
         return (double)IndexData(Data, idx, Count, Offset, Stride);
     }
     const T* Data;
     int Count;
     int Offset;
     int Stride;
+    typedef double value_type;
 };
 
 template <typename _Indexer1, typename _Indexer2>
@@ -525,29 +536,32 @@ struct IndexerAdd {
           Scale2(scale2),
           Count(ImMin(Indexer1.Count, Indexer2.Count))
     { }
-    template <typename I> IMPLOT_INLINE double operator()(I idx) const {
-        return Scale1 * Indexer1(idx) + Scale2 * Indexer2(idx);
+    template <typename I> IMPLOT_INLINE double operator[](I idx) const {
+        return Scale1 * Indexer1[idx] + Scale2 * Indexer2[idx];
     }
     const _Indexer1& Indexer1;
     const _Indexer2& Indexer2;
     double Scale1;
     double Scale2;
     int Count;
+    typedef double value_type;
 };
 
 struct IndexerLin {
     IndexerLin(double m, double b) : M(m), B(b) { }
-    template <typename I> IMPLOT_INLINE double operator()(I idx) const {
+    template <typename I> IMPLOT_INLINE double operator[](I idx) const {
         return M * idx + B;
     }
     const double M;
     const double B;
+    typedef double value_type;
 };
 
 struct IndexerConst {
     IndexerConst(double ref) : Ref(ref) { }
-    template <typename I> IMPLOT_INLINE double operator()(I) const { return Ref; }
+    template <typename I> IMPLOT_INLINE double operator[](I) const { return Ref; }
     const double Ref;
+    typedef double value_type;
 };
 
 //-----------------------------------------------------------------------------
@@ -556,13 +570,35 @@ struct IndexerConst {
 
 template <typename _IndexerX, typename _IndexerY>
 struct GetterXY {
-    GetterXY(_IndexerX x, _IndexerY y, int count) : IndxerX(x), IndxerY(y), Count(count) { }
-    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
-        return ImPlotPoint(IndxerX(idx),IndxerY(idx));
+    GetterXY(_IndexerX x, _IndexerY y, int count) : IndexerX(x), IndexerY(y), Count(count) { }
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator[](I idx) const {
+        return ImPlotPoint(IndexerX[idx],IndexerY[idx]);
     }
-    const _IndexerX IndxerX;
-    const _IndexerY IndxerY;
+    const _IndexerX IndexerX;
+    const _IndexerY IndexerY;
     const int Count;
+    typedef ImPlotPoint value_type;
+};
+
+// Double precision point with three coordinates used by ImPlot.
+struct ImPlotPoint3D {
+  double x, y, z;
+  constexpr ImPlotPoint3D()                     : x(0.0), y(0.0), z(0.0) { }
+  constexpr ImPlotPoint3D(double _x, double _y, double _z) : x(_x), y(_y), z(_z) { }
+  double& operator[] (size_t idx)             { IM_ASSERT(idx == 0 || idx == 1 || idx == 2); return ((double*)(void*)(char*)this)[idx]; }
+  double  operator[] (size_t idx) const       { IM_ASSERT(idx == 0 || idx == 1 || idx == 2); return ((const double*)(const void*)(const char*)this)[idx]; }
+};
+
+template <typename _IndexerX, typename _IndexerY, typename _IndexerZ>
+struct GetterXYZ {
+  GetterXYZ(_IndexerX x, _IndexerY y, _IndexerZ z, int count) : IndxerX(x), IndxerY(y), IndxerZ(z), Count(count) { }
+  template <typename I> IMPLOT_INLINE ImPlotPoint3D operator()(I idx) const {
+    return ImPlotPoint3D(IndxerX[idx],IndxerY[idx],IndxerZ[idx]);
+  }
+  const _IndexerX IndxerX;
+  const _IndexerY IndxerY;
+  const _IndexerZ IndxerZ;
+  const int Count;
 };
 
 /// Interprets a user's function pointer as ImPlotPoints
@@ -572,49 +608,53 @@ struct GetterFuncPtr {
         Data(data),
         Count(count)
     { }
-    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator[](I idx) const {
         return Getter(idx, Data);
     }
     ImPlotGetter Getter;
     void* const Data;
     const int Count;
+    typedef ImPlotPoint value_type;
 };
 
 template <typename _Getter>
 struct GetterOverrideX {
     GetterOverrideX(_Getter getter, double x) : Getter(getter), X(x), Count(getter.Count) { }
-    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
-        ImPlotPoint p = Getter(idx);
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator[](I idx) const {
+        ImPlotPoint p = Getter[idx];
         p.x = X;
         return p;
     }
     const _Getter Getter;
     const double X;
     const int Count;
+    typedef ImPlotPoint value_type;
 };
 
 template <typename _Getter>
 struct GetterOverrideY {
     GetterOverrideY(_Getter getter, double y) : Getter(getter), Y(y), Count(getter.Count) { }
-    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
-        ImPlotPoint p = Getter(idx);
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator[](I idx) const {
+        ImPlotPoint p = Getter[idx];
         p.y = Y;
         return p;
     }
     const _Getter Getter;
     const double Y;
     const int Count;
+    typedef ImPlotPoint value_type;
 };
 
 template <typename _Getter>
 struct GetterLoop {
     GetterLoop(_Getter getter) : Getter(getter), Count(getter.Count + 1) { }
-    template <typename I> IMPLOT_INLINE ImPlotPoint operator()(I idx) const {
+    template <typename I> IMPLOT_INLINE ImPlotPoint operator[](I idx) const {
         idx = idx % (Count - 1);
-        return Getter(idx);
+        return Getter[idx];
     }
     const _Getter Getter;
     const int Count;
+    typedef ImPlotPoint value_type;
 };
 
 template <typename T>
@@ -628,7 +668,7 @@ struct GetterError {
         Offset(count ? ImPosMod(offset, count) : 0),
         Stride(stride)
     { }
-    template <typename I> IMPLOT_INLINE ImPlotPointError operator()(I idx) const {
+    template <typename I> IMPLOT_INLINE ImPlotPointError operator[](I idx) const {
         return ImPlotPointError((double)IndexData(Xs,  idx, Count, Offset, Stride),
                                 (double)IndexData(Ys,  idx, Count, Offset, Stride),
                                 (double)IndexData(Neg, idx, Count, Offset, Stride),
@@ -641,6 +681,62 @@ struct GetterError {
     const int Count;
     const int Offset;
     const int Stride;
+    typedef ImPlotPointError value_type;
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Color Getters
+//-----------------------------------------------------------------------------
+
+struct GetterConstColor {
+    GetterConstColor(ImU32 color, float alpha = 1.0f) {
+        ImU32 col = color;
+        if (alpha < 1.0f) {
+            ImVec4 col_vec = ImGui::ColorConvertU32ToFloat4(col);
+            col_vec.w *= alpha;
+            col = ImGui::GetColorU32(col_vec);
+        }
+        Color = col;
+    }
+    template <typename I> IMPLOT_INLINE ImU32 operator[](I) const { return Color; }
+    ImU32 Color;
+};
+
+struct GetterIdxColor {
+    GetterIdxColor(const ImU32* data, int count, float alpha = 1.0f) : Data(data), Count(count), Alpha(alpha) { }
+    template <typename I> IMPLOT_INLINE ImU32 operator[](I idx) const {
+        IM_ASSERT(idx >= 0 && idx < Count);
+        ImU32 col = Data[idx];
+        if (Alpha < 1.0f) {
+            ImVec4 col_vec = ImGui::ColorConvertU32ToFloat4(col);
+            col_vec.w *= Alpha;
+            col = ImGui::GetColorU32(col_vec);
+        }
+        return col;
+    }
+    const ImU32* Data;
+    const int Count;
+    const float Alpha;
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Size Getters
+//-----------------------------------------------------------------------------
+
+struct GetterConstSize {
+    GetterConstSize(float size) : Size(size) { }
+    template <typename I> IMPLOT_INLINE float operator[](I) const { return Size; }
+    float Size;
+};
+
+struct GetterIdxSize {
+    GetterIdxSize(const float* data, int count) : Data(data), Count(count) { }
+    template <typename I> IMPLOT_INLINE float operator[](I idx) const {
+        IM_ASSERT(idx >= 0 && idx < Count);
+        return Data[idx];
+    }
+    const float* Data;
+    const int Count;
 };
 
 //-----------------------------------------------------------------------------
@@ -652,7 +748,7 @@ struct Fitter1 {
     Fitter1(const _Getter1& getter) : Getter(getter) { }
     void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
         for (int i = 0; i < Getter.Count; ++i) {
-            ImPlotPoint p = Getter(i);
+            ImPlotPoint p = Getter[i];
             x_axis.ExtendFitWith(y_axis, p.x, p.y);
             y_axis.ExtendFitWith(x_axis, p.y, p.x);
         }
@@ -661,11 +757,29 @@ struct Fitter1 {
 };
 
 template <typename _Getter1>
+struct FitterBubbles1 {
+  FitterBubbles1(const _Getter1& getter) : Getter(getter) { }
+  void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
+    for (int i = 0; i < Getter.Count; ++i) {
+      ImPlotPoint3D p = Getter(i);
+      double half_size = p.z;
+      // Fit left and right edges
+      x_axis.ExtendFitWith(y_axis, p.x - half_size, p.y);
+      x_axis.ExtendFitWith(y_axis, p.x + half_size, p.y);
+      // Fit top and bottom edges
+      y_axis.ExtendFitWith(x_axis, p.y - half_size, p.x);
+      y_axis.ExtendFitWith(x_axis, p.y + half_size, p.x);
+    }
+  }
+  const _Getter1& Getter;
+};
+
+template <typename _Getter1>
 struct FitterX {
     FitterX(const _Getter1& getter) : Getter(getter) { }
     void Fit(ImPlotAxis& x_axis, ImPlotAxis&) const {
         for (int i = 0; i < Getter.Count; ++i) {
-            ImPlotPoint p = Getter(i);
+            ImPlotPoint p = Getter[i];
             x_axis.ExtendFit(p.x);
         }
     }
@@ -677,7 +791,7 @@ struct FitterY {
     FitterY(const _Getter1& getter) : Getter(getter) { }
     void Fit(ImPlotAxis&, ImPlotAxis& y_axis) const {
         for (int i = 0; i < Getter.Count; ++i) {
-            ImPlotPoint p = Getter(i);
+            ImPlotPoint p = Getter[i];
             y_axis.ExtendFit(p.y);
         }
     }
@@ -689,12 +803,12 @@ struct Fitter2 {
     Fitter2(const _Getter1& getter1, const _Getter2& getter2) : Getter1(getter1), Getter2(getter2) { }
     void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
         for (int i = 0; i < Getter1.Count; ++i) {
-            ImPlotPoint p = Getter1(i);
+            ImPlotPoint p = Getter1[i];
             x_axis.ExtendFitWith(y_axis, p.x, p.y);
             y_axis.ExtendFitWith(x_axis, p.y, p.x);
         }
         for (int i = 0; i < Getter2.Count; ++i) {
-            ImPlotPoint p = Getter2(i);
+            ImPlotPoint p = Getter2[i];
             x_axis.ExtendFitWith(y_axis, p.x, p.y);
             y_axis.ExtendFitWith(x_axis, p.y, p.x);
         }
@@ -713,8 +827,8 @@ struct FitterBarV {
     void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
         int count = ImMin(Getter1.Count, Getter2.Count);
         for (int i = 0; i < count; ++i) {
-            ImPlotPoint p1 = Getter1(i); p1.x -= HalfWidth;
-            ImPlotPoint p2 = Getter2(i); p2.x += HalfWidth;
+            ImPlotPoint p1 = Getter1[i]; p1.x -= HalfWidth;
+            ImPlotPoint p2 = Getter2[i]; p2.x += HalfWidth;
             x_axis.ExtendFitWith(y_axis, p1.x, p1.y);
             y_axis.ExtendFitWith(x_axis, p1.y, p1.x);
             x_axis.ExtendFitWith(y_axis, p2.x, p2.y);
@@ -736,8 +850,8 @@ struct FitterBarH {
     void Fit(ImPlotAxis& x_axis, ImPlotAxis& y_axis) const {
         int count = ImMin(Getter1.Count, Getter2.Count);
         for (int i = 0; i < count; ++i) {
-            ImPlotPoint p1 = Getter1(i); p1.y -= HalfHeight;
-            ImPlotPoint p2 = Getter2(i); p2.y += HalfHeight;
+            ImPlotPoint p1 = Getter1[i]; p1.y -= HalfHeight;
+            ImPlotPoint p2 = Getter2[i]; p2.y += HalfHeight;
             x_axis.ExtendFitWith(y_axis, p1.x, p1.y);
             y_axis.ExtendFitWith(x_axis, p1.y, p1.x);
             x_axis.ExtendFitWith(y_axis, p2.x, p2.y);
@@ -784,7 +898,7 @@ struct Transformer1 {
     { }
 
     template <typename T> IMPLOT_INLINE float operator()(T p) const {
-        if (TransformFwd != NULL) {
+        if (TransformFwd != nullptr) {
             double s = TransformFwd(p, TransformData);
             double t = (s - ScaMin) / (ScaMax - ScaMin);
             p = PltMin + (PltMax - PltMin) * t;
@@ -859,139 +973,143 @@ struct RendererBase {
     const int VtxConsumed;
 };
 
-template <class _Getter>
+template <class _Getter, class _GetterColor>
 struct RendererLineStrip : RendererBase {
-    RendererLineStrip(const _Getter& getter, ImU32 col, float weight) :
+    RendererLineStrip(const _Getter& getter, const _GetterColor& getter_color, float weight) :
         RendererBase(getter.Count - 1, 6, 4),
         Getter(getter),
-        Col(col),
+        GetterColor(getter_color),
         HalfWeight(ImMax(1.0f,weight)*0.5f)
     {
-        P1 = this->Transformer(Getter(0));
+        P1 = this->Transformer(Getter[0]);
     }
     void Init(ImDrawList& draw_list) const {
         GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        ImVec2 P2 = this->Transformer(Getter[prim + 1]);
         if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
             P1 = P2;
             return false;
         }
-        PrimLine(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+        ImU32 col = GetterColor[prim];
+        PrimLine(draw_list,P1,P2,HalfWeight,col,UV0,UV1);
         P1 = P2;
         return true;
     }
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     mutable float HalfWeight;
     mutable ImVec2 P1;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
 
-template <class _Getter>
+template <class _Getter, class _GetterColor>
 struct RendererLineStripSkip : RendererBase {
-    RendererLineStripSkip(const _Getter& getter, ImU32 col, float weight) :
+    RendererLineStripSkip(const _Getter& getter, const _GetterColor& getter_color, float weight) :
         RendererBase(getter.Count - 1, 6, 4),
         Getter(getter),
-        Col(col),
+        GetterColor(getter_color),
         HalfWeight(ImMax(1.0f,weight)*0.5f)
     {
-        P1 = this->Transformer(Getter(0));
+        P1 = this->Transformer(Getter[0]);
     }
     void Init(ImDrawList& draw_list) const {
         GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        ImVec2 P2 = this->Transformer(Getter[prim + 1]);
         if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
             if (!ImNan(P2.x) && !ImNan(P2.y))
                 P1 = P2;
             return false;
         }
-        PrimLine(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+        ImU32 col = GetterColor[prim];
+        PrimLine(draw_list,P1,P2,HalfWeight,col,UV0,UV1);
         if (!ImNan(P2.x) && !ImNan(P2.y))
             P1 = P2;
         return true;
     }
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     mutable float HalfWeight;
     mutable ImVec2 P1;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
 
-template <class _Getter>
+template <class _Getter, class _GetterColor>
 struct RendererLineSegments1 : RendererBase {
-    RendererLineSegments1(const _Getter& getter, ImU32 col, float weight) :
+    RendererLineSegments1(const _Getter& getter, const _GetterColor& getter_color, float weight) :
         RendererBase(getter.Count / 2, 6, 4),
         Getter(getter),
-        Col(col),
+        GetterColor(getter_color),
         HalfWeight(ImMax(1.0f,weight)*0.5f)
     { }
     void Init(ImDrawList& draw_list) const {
         GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P1 = this->Transformer(Getter(prim*2+0));
-        ImVec2 P2 = this->Transformer(Getter(prim*2+1));
+        ImVec2 P1 = this->Transformer(Getter[prim*2+0]);
+        ImVec2 P2 = this->Transformer(Getter[prim*2+1]);
         if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2))))
             return false;
-        PrimLine(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+        ImU32 col = GetterColor[prim*2];
+        PrimLine(draw_list,P1,P2,HalfWeight,col,UV0,UV1);
         return true;
     }
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     mutable float HalfWeight;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
 
-template <class _Getter1, class _Getter2>
+template <class _Getter1, class _Getter2, class _GetterColor>
 struct RendererLineSegments2 : RendererBase {
-    RendererLineSegments2(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, float weight) :
-        RendererBase(ImMin(getter1.Count, getter1.Count), 6, 4),
+    RendererLineSegments2(const _Getter1& getter1, const _Getter2& getter2, const _GetterColor& getter_color, float weight) :
+        RendererBase(ImMin(getter1.Count, getter2.Count), 6, 4),
         Getter1(getter1),
         Getter2(getter2),
-        Col(col),
+        GetterColor(getter_color),
         HalfWeight(ImMax(1.0f,weight)*0.5f)
     {}
     void Init(ImDrawList& draw_list) const {
         GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P1 = this->Transformer(Getter1(prim));
-        ImVec2 P2 = this->Transformer(Getter2(prim));
+        ImVec2 P1 = this->Transformer(Getter1[prim]);
+        ImVec2 P2 = this->Transformer(Getter2[prim]);
         if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2))))
             return false;
-        PrimLine(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+        ImU32 col = GetterColor[prim];
+        PrimLine(draw_list,P1,P2,HalfWeight,col,UV0,UV1);
         return true;
     }
     const _Getter1& Getter1;
     const _Getter2& Getter2;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     mutable float HalfWeight;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
 
-template <class _Getter1, class _Getter2>
+template <class _Getter1, class _Getter2, class _GetterColor>
 struct RendererBarsFillV : RendererBase {
-    RendererBarsFillV(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, double width) :
-        RendererBase(ImMin(getter1.Count, getter1.Count), 6, 4),
+    RendererBarsFillV(const _Getter1& getter1, const _Getter2& getter2, const _GetterColor& getter_color, double width) :
+        RendererBase(ImMin(getter1.Count, getter2.Count), 6, 4),
         Getter1(getter1),
         Getter2(getter2),
-        Col(col),
+        GetterColor(getter_color),
         HalfWidth(width/2)
     {}
     void Init(ImDrawList& draw_list) const {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImPlotPoint p1 = Getter1(prim);
-        ImPlotPoint p2 = Getter2(prim);
+        ImPlotPoint p1 = Getter1[prim];
+        ImPlotPoint p2 = Getter2[prim];
         p1.x += HalfWidth;
         p2.x -= HalfWidth;
         ImVec2 P1 = this->Transformer(p1);
@@ -1005,31 +1123,32 @@ struct RendererBarsFillV : RendererBase {
         ImVec2 PMax = ImMax(P1, P2);
         if (!cull_rect.Overlaps(ImRect(PMin, PMax)))
             return false;
-        PrimRectFill(draw_list,PMin,PMax,Col,UV);
+        ImU32 col = GetterColor[prim];
+        PrimRectFill(draw_list,PMin,PMax,col,UV);
         return true;
     }
     const _Getter1& Getter1;
     const _Getter2& Getter2;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     const double HalfWidth;
     mutable ImVec2 UV;
 };
 
-template <class _Getter1, class _Getter2>
+template <class _Getter1, class _Getter2, class _GetterColor>
 struct RendererBarsFillH : RendererBase {
-    RendererBarsFillH(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, double height) :
-        RendererBase(ImMin(getter1.Count, getter1.Count), 6, 4),
+    RendererBarsFillH(const _Getter1& getter1, const _Getter2& getter2, const _GetterColor& getter_color, double height) :
+        RendererBase(ImMin(getter1.Count, getter2.Count), 6, 4),
         Getter1(getter1),
         Getter2(getter2),
-        Col(col),
+        GetterColor(getter_color),
         HalfHeight(height/2)
     {}
     void Init(ImDrawList& draw_list) const {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImPlotPoint p1 = Getter1(prim);
-        ImPlotPoint p2 = Getter2(prim);
+        ImPlotPoint p1 = Getter1[prim];
+        ImPlotPoint p2 = Getter2[prim];
         p1.y += HalfHeight;
         p2.y -= HalfHeight;
         ImVec2 P1 = this->Transformer(p1);
@@ -1043,23 +1162,24 @@ struct RendererBarsFillH : RendererBase {
         ImVec2 PMax = ImMax(P1, P2);
         if (!cull_rect.Overlaps(ImRect(PMin, PMax)))
             return false;
-        PrimRectFill(draw_list,PMin,PMax,Col,UV);
+        ImU32 col = GetterColor[prim];
+        PrimRectFill(draw_list,PMin,PMax,col,UV);
         return true;
     }
     const _Getter1& Getter1;
     const _Getter2& Getter2;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     const double HalfHeight;
     mutable ImVec2 UV;
 };
 
-template <class _Getter1, class _Getter2>
+template <class _Getter1, class _Getter2, class _GetterColor>
 struct RendererBarsLineV : RendererBase {
-    RendererBarsLineV(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, double width, float weight) :
-        RendererBase(ImMin(getter1.Count, getter1.Count), 24, 8),
+    RendererBarsLineV(const _Getter1& getter1, const _Getter2& getter2, const _GetterColor& getter_color, double width, float weight) :
+        RendererBase(ImMin(getter1.Count, getter2.Count), 24, 8),
         Getter1(getter1),
         Getter2(getter2),
-        Col(col),
+        GetterColor(getter_color),
         HalfWidth(width/2),
         Weight(weight)
     {}
@@ -1067,8 +1187,8 @@ struct RendererBarsLineV : RendererBase {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImPlotPoint p1 = Getter1(prim);
-        ImPlotPoint p2 = Getter2(prim);
+        ImPlotPoint p1 = Getter1[prim];
+        ImPlotPoint p2 = Getter2[prim];
         p1.x += HalfWidth;
         p2.x -= HalfWidth;
         ImVec2 P1 = this->Transformer(p1);
@@ -1082,24 +1202,25 @@ struct RendererBarsLineV : RendererBase {
         ImVec2 PMax = ImMax(P1, P2);
         if (!cull_rect.Overlaps(ImRect(PMin, PMax)))
             return false;
-        PrimRectLine(draw_list,PMin,PMax,Weight,Col,UV);
+        ImU32 col = GetterColor[prim];
+        PrimRectLine(draw_list,PMin,PMax,Weight,col,UV);
         return true;
     }
     const _Getter1& Getter1;
     const _Getter2& Getter2;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     const double HalfWidth;
     const float Weight;
     mutable ImVec2 UV;
 };
 
-template <class _Getter1, class _Getter2>
+template <class _Getter1, class _Getter2, class _GetterColor>
 struct RendererBarsLineH : RendererBase {
-    RendererBarsLineH(const _Getter1& getter1, const _Getter2& getter2, ImU32 col, double height, float weight) :
-        RendererBase(ImMin(getter1.Count, getter1.Count), 24, 8),
+    RendererBarsLineH(const _Getter1& getter1, const _Getter2& getter2, const _GetterColor& getter_color, double height, float weight) :
+        RendererBase(ImMin(getter1.Count, getter2.Count), 24, 8),
         Getter1(getter1),
         Getter2(getter2),
-        Col(col),
+        GetterColor(getter_color),
         HalfHeight(height/2),
         Weight(weight)
     {}
@@ -1107,8 +1228,8 @@ struct RendererBarsLineH : RendererBase {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImPlotPoint p1 = Getter1(prim);
-        ImPlotPoint p2 = Getter2(prim);
+        ImPlotPoint p1 = Getter1[prim];
+        ImPlotPoint p2 = Getter2[prim];
         p1.y += HalfHeight;
         p2.y -= HalfHeight;
         ImVec2 P1 = this->Transformer(p1);
@@ -1122,139 +1243,144 @@ struct RendererBarsLineH : RendererBase {
         ImVec2 PMax = ImMax(P1, P2);
         if (!cull_rect.Overlaps(ImRect(PMin, PMax)))
             return false;
-        PrimRectLine(draw_list,PMin,PMax,Weight,Col,UV);
+        ImU32 col = GetterColor[prim];
+        PrimRectLine(draw_list,PMin,PMax,Weight,col,UV);
         return true;
     }
     const _Getter1& Getter1;
     const _Getter2& Getter2;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     const double HalfHeight;
     const float Weight;
     mutable ImVec2 UV;
 };
 
 
-template <class _Getter>
+template <class _Getter, class _GetterColor>
 struct RendererStairsPre : RendererBase {
-    RendererStairsPre(const _Getter& getter, ImU32 col, float weight) :
+    RendererStairsPre(const _Getter& getter, const _GetterColor& getter_color, float weight) :
         RendererBase(getter.Count - 1, 12, 8),
         Getter(getter),
-        Col(col),
+        GetterColor(getter_color),
         HalfWeight(ImMax(1.0f,weight)*0.5f)
     {
-        P1 = this->Transformer(Getter(0));
+        P1 = this->Transformer(Getter[0]);
     }
     void Init(ImDrawList& draw_list) const {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        ImVec2 P2 = this->Transformer(Getter[prim + 1]);
         if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
             P1 = P2;
             return false;
         }
-        PrimRectFill(draw_list, ImVec2(P1.x - HalfWeight, P1.y), ImVec2(P1.x + HalfWeight, P2.y), Col, UV);
-        PrimRectFill(draw_list, ImVec2(P1.x, P2.y + HalfWeight), ImVec2(P2.x, P2.y - HalfWeight), Col, UV);
+        ImU32 col = GetterColor[prim];
+        PrimRectFill(draw_list, ImVec2(P1.x - HalfWeight, P1.y), ImVec2(P1.x + HalfWeight, P2.y), col, UV);
+        PrimRectFill(draw_list, ImVec2(P1.x, P2.y + HalfWeight), ImVec2(P2.x, P2.y - HalfWeight), col, UV);
         P1 = P2;
         return true;
     }
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     mutable float HalfWeight;
     mutable ImVec2 P1;
     mutable ImVec2 UV;
 };
 
-template <class _Getter>
+template <class _Getter, class _GetterColor>
 struct RendererStairsPost : RendererBase {
-    RendererStairsPost(const _Getter& getter, ImU32 col, float weight) :
+    RendererStairsPost(const _Getter& getter, const _GetterColor& getter_color, float weight) :
         RendererBase(getter.Count - 1, 12, 8),
         Getter(getter),
-        Col(col),
+        GetterColor(getter_color),
         HalfWeight(ImMax(1.0f,weight) * 0.5f)
     {
-        P1 = this->Transformer(Getter(0));
+        P1 = this->Transformer(Getter[0]);
     }
     void Init(ImDrawList& draw_list) const {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        ImVec2 P2 = this->Transformer(Getter[prim + 1]);
         if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
             P1 = P2;
             return false;
         }
-        PrimRectFill(draw_list, ImVec2(P1.x, P1.y + HalfWeight), ImVec2(P2.x, P1.y - HalfWeight), Col, UV);
-        PrimRectFill(draw_list, ImVec2(P2.x - HalfWeight, P2.y), ImVec2(P2.x + HalfWeight, P1.y), Col, UV);
+        ImU32 col = GetterColor[prim];
+        PrimRectFill(draw_list, ImVec2(P1.x, P1.y + HalfWeight), ImVec2(P2.x, P1.y - HalfWeight), col, UV);
+        PrimRectFill(draw_list, ImVec2(P2.x - HalfWeight, P2.y), ImVec2(P2.x + HalfWeight, P1.y), col, UV);
         P1 = P2;
         return true;
     }
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     mutable float HalfWeight;
     mutable ImVec2 P1;
     mutable ImVec2 UV;
 };
 
-template <class _Getter>
+template <class _Getter, class _GetterColor>
 struct RendererStairsPreShaded : RendererBase {
-    RendererStairsPreShaded(const _Getter& getter, ImU32 col) :
+    RendererStairsPreShaded(const _Getter& getter, const _GetterColor& getter_color) :
         RendererBase(getter.Count - 1, 6, 4),
         Getter(getter),
-        Col(col)
+        GetterColor(getter_color)
     {
-        P1 = this->Transformer(Getter(0));
+        P1 = this->Transformer(Getter[0]);
         Y0 = this->Transformer(ImPlotPoint(0,0)).y;
     }
     void Init(ImDrawList& draw_list) const {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        ImVec2 P2 = this->Transformer(Getter[prim + 1]);
         ImVec2 PMin(ImMin(P1.x, P2.x), ImMin(Y0, P2.y));
         ImVec2 PMax(ImMax(P1.x, P2.x), ImMax(Y0, P2.y));
         if (!cull_rect.Overlaps(ImRect(PMin, PMax))) {
             P1 = P2;
             return false;
         }
-        PrimRectFill(draw_list, PMin, PMax, Col, UV);
+        ImU32 col = GetterColor[prim];
+        PrimRectFill(draw_list, PMin, PMax, col, UV);
         P1 = P2;
         return true;
     }
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     float Y0;
     mutable ImVec2 P1;
     mutable ImVec2 UV;
 };
 
-template <class _Getter>
+template <class _Getter, class _GetterColor>
 struct RendererStairsPostShaded : RendererBase {
-    RendererStairsPostShaded(const _Getter& getter, ImU32 col) :
+    RendererStairsPostShaded(const _Getter& getter, const _GetterColor& getter_color) :
         RendererBase(getter.Count - 1, 6, 4),
         Getter(getter),
-        Col(col)
+        GetterColor(getter_color)
     {
-        P1 = this->Transformer(Getter(0));
+        P1 = this->Transformer(Getter[0]);
         Y0 = this->Transformer(ImPlotPoint(0,0)).y;
     }
     void Init(ImDrawList& draw_list) const {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P2 = this->Transformer(Getter(prim + 1));
+        ImVec2 P2 = this->Transformer(Getter[prim + 1]);
         ImVec2 PMin(ImMin(P1.x, P2.x), ImMin(P1.y, Y0));
         ImVec2 PMax(ImMax(P1.x, P2.x), ImMax(P1.y, Y0));
         if (!cull_rect.Overlaps(ImRect(PMin, PMax))) {
             P1 = P2;
             return false;
         }
-        PrimRectFill(draw_list, PMin, PMax, Col, UV);
+        ImU32 col = GetterColor[prim];
+        PrimRectFill(draw_list, PMin, PMax, col, UV);
         P1 = P2;
         return true;
     }
     const _Getter& Getter;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     float Y0;
     mutable ImVec2 P1;
     mutable ImVec2 UV;
@@ -1262,46 +1388,47 @@ struct RendererStairsPostShaded : RendererBase {
 
 
 
-template <class _Getter1, class _Getter2>
+template <class _Getter1, class _Getter2, class _GetterColor>
 struct RendererShaded : RendererBase {
-    RendererShaded(const _Getter1& getter1, const _Getter2& getter2, ImU32 col) :
+    RendererShaded(const _Getter1& getter1, const _Getter2& getter2, const _GetterColor& getter_color) :
         RendererBase(ImMin(getter1.Count, getter2.Count) - 1, 6, 5),
         Getter1(getter1),
         Getter2(getter2),
-        Col(col)
+        GetterColor(getter_color)
     {
-        P11 = this->Transformer(Getter1(0));
-        P12 = this->Transformer(Getter2(0));
+        P11 = this->Transformer(Getter1[0]);
+        P12 = this->Transformer(Getter2[0]);
     }
     void Init(ImDrawList& draw_list) const {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 P21 = this->Transformer(Getter1(prim+1));
-        ImVec2 P22 = this->Transformer(Getter2(prim+1));
+        ImVec2 P21 = this->Transformer(Getter1[prim+1]);
+        ImVec2 P22 = this->Transformer(Getter2[prim+1]);
         ImRect rect(ImMin(ImMin(ImMin(P11,P12),P21),P22), ImMax(ImMax(ImMax(P11,P12),P21),P22));
         if (!cull_rect.Overlaps(rect)) {
             P11 = P21;
             P12 = P22;
             return false;
         }
+        ImU32 col = GetterColor[prim];
         const int intersect = (P11.y > P12.y && P22.y > P21.y) || (P12.y > P11.y && P21.y > P22.y);
-        ImVec2 intersection = Intersection(P11,P21,P12,P22);
+        const ImVec2 intersection = intersect == 0 ? ImVec2(0,0) : Intersection(P11,P21,P12,P22);
         draw_list._VtxWritePtr[0].pos = P11;
         draw_list._VtxWritePtr[0].uv  = UV;
-        draw_list._VtxWritePtr[0].col = Col;
+        draw_list._VtxWritePtr[0].col = col;
         draw_list._VtxWritePtr[1].pos = P21;
         draw_list._VtxWritePtr[1].uv  = UV;
-        draw_list._VtxWritePtr[1].col = Col;
+        draw_list._VtxWritePtr[1].col = col;
         draw_list._VtxWritePtr[2].pos = intersection;
         draw_list._VtxWritePtr[2].uv  = UV;
-        draw_list._VtxWritePtr[2].col = Col;
+        draw_list._VtxWritePtr[2].col = col;
         draw_list._VtxWritePtr[3].pos = P12;
         draw_list._VtxWritePtr[3].uv  = UV;
-        draw_list._VtxWritePtr[3].col = Col;
+        draw_list._VtxWritePtr[3].col = col;
         draw_list._VtxWritePtr[4].pos = P22;
         draw_list._VtxWritePtr[4].uv  = UV;
-        draw_list._VtxWritePtr[4].col = Col;
+        draw_list._VtxWritePtr[4].col = col;
         draw_list._VtxWritePtr += 5;
         draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
         draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1 + intersect);
@@ -1317,7 +1444,7 @@ struct RendererShaded : RendererBase {
     }
     const _Getter1& Getter1;
     const _Getter2& Getter2;
-    const ImU32 Col;
+    const _GetterColor& GetterColor;
     mutable ImVec2 P11;
     mutable ImVec2 P12;
     mutable ImVec2 UV;
@@ -1339,7 +1466,7 @@ struct RendererRectC : RendererBase {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        RectC rect = Getter(prim);
+        RectC rect = Getter[prim];
         ImVec2 P1 = this->Transformer(rect.Pos.x - rect.HalfSize.x , rect.Pos.y - rect.HalfSize.y);
         ImVec2 P2 = this->Transformer(rect.Pos.x + rect.HalfSize.x , rect.Pos.y + rect.HalfSize.y);
         if ((rect.Color & IM_COL32_A_MASK) == 0 || !cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2))))
@@ -1409,31 +1536,40 @@ void RenderPrimitives2(const _Getter1& getter1, const _Getter2& getter2, Args...
     RenderPrimitivesEx(_Renderer<_Getter1,_Getter2>(getter1,getter2,args...), draw_list, cull_rect);
 }
 
+template <template <class,class,class> class _Renderer, class _Getter1, class _Getter2, class _Getter3, typename ...Args>
+void RenderPrimitives3(const _Getter1& getter1, const _Getter2& getter2, const _Getter3& getter3, Args... args) {
+    ImDrawList& draw_list = *GetPlotDrawList();
+    const ImRect& cull_rect = GetCurrentPlot()->PlotRect;
+    RenderPrimitivesEx(_Renderer<_Getter1,_Getter2,_Getter3>(getter1,getter2,getter3,args...), draw_list, cull_rect);
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] Markers
 //-----------------------------------------------------------------------------
 
-template <class _Getter>
+template <class _Getter, class _GetterColor, class _GetterSize>
 struct RendererMarkersFill : RendererBase {
-    RendererMarkersFill(const _Getter& getter, const ImVec2* marker, int count, float size, ImU32 col) :
+    RendererMarkersFill(const _Getter& getter, const _GetterColor& getter_color, const _GetterSize& getter_size, const ImVec2* marker, int count) :
         RendererBase(getter.Count, (count-2)*3, count),
         Getter(getter),
+        GetterColor(getter_color),
+        GetterSize(getter_size),
         Marker(marker),
-        Count(count),
-        Size(size),
-        Col(col)
+        Count(count)
     { }
     void Init(ImDrawList& draw_list) const {
         UV = draw_list._Data->TexUvWhitePixel;
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 p = this->Transformer(Getter(prim));
+        ImVec2 p = this->Transformer(Getter[prim]);
         if (p.x >= cull_rect.Min.x && p.y >= cull_rect.Min.y && p.x <= cull_rect.Max.x && p.y <= cull_rect.Max.y) {
+            ImU32 col = GetterColor[prim];
+            float size = GetterSize[prim];
             for (int i = 0; i < Count; i++) {
-                draw_list._VtxWritePtr[0].pos.x = p.x + Marker[i].x * Size;
-                draw_list._VtxWritePtr[0].pos.y = p.y + Marker[i].y * Size;
+                draw_list._VtxWritePtr[0].pos.x = p.x + Marker[i].x * size;
+                draw_list._VtxWritePtr[0].pos.y = p.y + Marker[i].y * size;
                 draw_list._VtxWritePtr[0].uv = UV;
-                draw_list._VtxWritePtr[0].col = Col;
+                draw_list._VtxWritePtr[0].col = col;
                 draw_list._VtxWritePtr++;
             }
             for (int i = 2; i < Count; i++) {
@@ -1448,46 +1584,200 @@ struct RendererMarkersFill : RendererBase {
         return false;
     }
     const _Getter& Getter;
+    const _GetterColor& GetterColor;
+    const _GetterSize& GetterSize;
     const ImVec2* Marker;
     const int Count;
-    const float Size;
-    const ImU32 Col;
     mutable ImVec2 UV;
 };
 
 
-template <class _Getter>
+template <class _Getter, class _GetterColor, class _GetterSize>
 struct RendererMarkersLine : RendererBase {
-    RendererMarkersLine(const _Getter& getter, const ImVec2* marker, int count, float size, float weight, ImU32 col) :
+    RendererMarkersLine(const _Getter& getter, const _GetterColor& getter_color, const _GetterSize& getter_size, const ImVec2* marker, int count, float weight) :
         RendererBase(getter.Count, count/2*6, count/2*4),
         Getter(getter),
+        GetterColor(getter_color),
+        GetterSize(getter_size),
         Marker(marker),
         Count(count),
-        HalfWeight(ImMax(1.0f,weight)*0.5f),
-        Size(size),
-        Col(col)
+        HalfWeight(ImMax(1.0f,weight)*0.5f)
     { }
     void Init(ImDrawList& draw_list) const {
         GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
     }
     IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
-        ImVec2 p = this->Transformer(Getter(prim));
+        ImVec2 p = this->Transformer(Getter[prim]);
         if (p.x >= cull_rect.Min.x && p.y >= cull_rect.Min.y && p.x <= cull_rect.Max.x && p.y <= cull_rect.Max.y) {
+            ImU32 col = GetterColor[prim];
+            float size = GetterSize[prim];
             for (int i = 0; i < Count; i = i + 2) {
-                ImVec2 p1(p.x + Marker[i].x * Size, p.y + Marker[i].y * Size);
-                ImVec2 p2(p.x + Marker[i+1].x * Size, p.y + Marker[i+1].y * Size);
-                PrimLine(draw_list, p1, p2, HalfWeight, Col, UV0, UV1);
+                ImVec2 p1(p.x + Marker[i].x * size, p.y + Marker[i].y * size);
+                ImVec2 p2(p.x + Marker[i+1].x * size, p.y + Marker[i+1].y * size);
+                PrimLine(draw_list, p1, p2, HalfWeight, col, UV0, UV1);
             }
             return true;
         }
         return false;
     }
     const _Getter& Getter;
+    const _GetterColor& GetterColor;
+    const _GetterSize& GetterSize;
     const ImVec2* Marker;
     const int Count;
     mutable float HalfWeight;
-    const float Size;
-    const ImU32 Col;
+    mutable ImVec2 UV0;
+    mutable ImVec2 UV1;
+};
+
+template <class _Getter, class _GetterColor>
+struct RendererCircleFill : RendererBase {
+    RendererCircleFill(const _Getter& getter, const _GetterColor& getter_color) :
+        RendererBase(getter.Count, 62*3, 64),
+        Getter(getter),
+        GetterColor(getter_color)
+    { }
+    void Init(ImDrawList& draw_list) const {
+        UV = draw_list._Data->TexUvWhitePixel;
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImPlotPoint3D p3D = Getter(prim);
+        float size_in_plot_coords = (float)p3D.z;
+        float radius_in_plot_coords = size_in_plot_coords;
+
+        // Compute approximate radius in pixels for LOD
+        float approx_radius_pixels = (float)ImAbs(radius_in_plot_coords * this->Transformer.Tx.M);
+        int num_segments = ImClamp((int)(approx_radius_pixels), 10, 64);
+
+        // Compute bounding box of the bubble in plot coordinates
+        ImPlotPoint plot_min(p3D.x - radius_in_plot_coords, p3D.y - radius_in_plot_coords);
+        ImPlotPoint plot_max(p3D.x + radius_in_plot_coords, p3D.y + radius_in_plot_coords);
+
+        // Transform bounding box to pixel coordinates
+        ImVec2 pixel_min = this->Transformer(plot_min);
+        ImVec2 pixel_max = this->Transformer(plot_max);
+
+        // Create bounding rectangle (handle axis inversion)
+        ImRect bbox(ImMin(pixel_min, pixel_max), ImMax(pixel_min, pixel_max));
+
+        // Check if bounding box overlaps with cull rectangle
+        if (cull_rect.Overlaps(bbox)) {
+            ImU32 col = GetterColor[prim];
+
+            const float a_max = IM_PI * 2.0f;
+            const float a_step = a_max / num_segments;
+
+            ImDrawIdx vtx_base = (ImDrawIdx)draw_list._VtxCurrentIdx;
+
+            for (int i = 0; i < num_segments; i++) {
+                float angle = a_step * i;
+                float cos_a = ImCos(angle);
+                float sin_a = ImSin(angle);
+
+                // Compute point in plot coordinates
+                ImPlotPoint plot_point(p3D.x + cos_a * radius_in_plot_coords,
+                                      p3D.y + sin_a * radius_in_plot_coords);
+                // Transform to pixel coordinates
+                ImVec2 pixel_pos = this->Transformer(plot_point);
+
+                draw_list._VtxWritePtr[0].pos = pixel_pos;
+                draw_list._VtxWritePtr[0].uv = UV;
+                draw_list._VtxWritePtr[0].col = col;
+                draw_list._VtxWritePtr++;
+            }
+
+            for (int i = 2; i < num_segments; i++) {
+                draw_list._IdxWritePtr[0] = vtx_base;
+                draw_list._IdxWritePtr[1] = (ImDrawIdx)(vtx_base + i - 1);
+                draw_list._IdxWritePtr[2] = (ImDrawIdx)(vtx_base + i);
+                draw_list._IdxWritePtr += 3;
+            }
+
+            draw_list._VtxCurrentIdx += num_segments;
+
+            int unused_vtx = 64 - num_segments;
+            int unused_idx = (62 - (num_segments - 2)) * 3;
+            if (unused_vtx > 0 || unused_idx > 0) {
+                draw_list.PrimUnreserve(unused_idx, unused_vtx);
+            }
+
+            return true;
+        }
+        return false;
+    }
+    const _Getter& Getter;
+    const _GetterColor& GetterColor;
+    mutable ImVec2 UV;
+};
+
+template <class _Getter, class _GetterColor>
+struct RendererCircleLine : RendererBase {
+  RendererCircleLine(const _Getter& getter, const _GetterColor& getter_color, float weight) :
+      RendererBase(getter.Count, 64*6, 64*4),
+      Getter(getter),
+      HalfWeight(ImMax(1.0f,weight)*0.5f),
+      GetterColor(getter_color)
+    { }
+    void Init(ImDrawList& draw_list) const {
+      GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImPlotPoint3D p3D = Getter(prim);
+        float size_in_plot_coords = (float)p3D.z;
+        float radius_in_plot_coords = size_in_plot_coords;
+
+        // Compute approximate radius in pixels for LOD
+        float approx_radius_pixels = (float)ImAbs(radius_in_plot_coords * this->Transformer.Tx.M);
+        int num_segments = ImClamp((int)(approx_radius_pixels), 10, 64);
+
+        // Compute bounding box of the bubble in plot coordinates
+        ImPlotPoint plot_min(p3D.x - radius_in_plot_coords, p3D.y - radius_in_plot_coords);
+        ImPlotPoint plot_max(p3D.x + radius_in_plot_coords, p3D.y + radius_in_plot_coords);
+
+        // Transform bounding box to pixel coordinates
+        ImVec2 pixel_min = this->Transformer(plot_min);
+        ImVec2 pixel_max = this->Transformer(plot_max);
+
+        // Create bounding rectangle (handle axis inversion)
+        ImRect bbox(ImMin(pixel_min, pixel_max), ImMax(pixel_min, pixel_max));
+
+        // Check if bounding box overlaps with cull rectangle
+        if (cull_rect.Overlaps(bbox)) {
+            ImU32 col = GetterColor[prim];
+
+            const float a_max = IM_PI * 2.0f;
+            const float a_step = a_max / num_segments;
+
+            for (int i = 0; i < num_segments; i++) {
+                float angle1 = a_step * i;
+                float angle2 = a_step * ((i + 1) % num_segments);
+
+                // Compute points in plot coordinates
+                ImPlotPoint plot_point1(p3D.x + ImCos(angle1) * radius_in_plot_coords,
+                                       p3D.y + ImSin(angle1) * radius_in_plot_coords);
+                ImPlotPoint plot_point2(p3D.x + ImCos(angle2) * radius_in_plot_coords,
+                                       p3D.y + ImSin(angle2) * radius_in_plot_coords);
+
+                // Transform to pixel coordinates
+                ImVec2 p1 = this->Transformer(plot_point1);
+                ImVec2 p2 = this->Transformer(plot_point2);
+
+                PrimLine(draw_list, p1, p2, HalfWeight, col, UV0, UV1);
+            }
+
+            int unused_vtx = (64 - num_segments) * 4;
+            int unused_idx = (64 - num_segments) * 6;
+            if (unused_vtx > 0 || unused_idx > 0) {
+                draw_list.PrimUnreserve(unused_idx, unused_vtx);
+            }
+
+            return true;
+        }
+        return false;
+    }
+    const _Getter& Getter;
+    mutable float HalfWeight;
+    const _GetterColor& GetterColor;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
 };
@@ -1522,41 +1812,91 @@ static const ImVec2 MARKER_LINE_CIRCLE[20]  = {
     ImVec2(0.80901694f, -0.5877853f),
     ImVec2(1.0f, 0.0f)
 };
-static const ImVec2 MARKER_LINE_SQUARE[8]   = {ImVec2(SQRT_1_2,SQRT_1_2), ImVec2(SQRT_1_2,-SQRT_1_2), ImVec2(SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,SQRT_1_2), ImVec2(-SQRT_1_2,SQRT_1_2), ImVec2(SQRT_1_2,SQRT_1_2)};
-static const ImVec2 MARKER_LINE_DIAMOND[8]  = {ImVec2(1, 0), ImVec2(0, -1), ImVec2(0, -1), ImVec2(-1, 0), ImVec2(-1, 0), ImVec2(0, 1), ImVec2(0, 1), ImVec2(1, 0)};
-static const ImVec2 MARKER_LINE_UP[6]       = {ImVec2(SQRT_3_2,0.5f), ImVec2(0,-1),ImVec2(0,-1),ImVec2(-SQRT_3_2,0.5f),ImVec2(-SQRT_3_2,0.5f),ImVec2(SQRT_3_2,0.5f)};
-static const ImVec2 MARKER_LINE_DOWN[6]     = {ImVec2(SQRT_3_2,-0.5f),ImVec2(0,1),ImVec2(0,1),ImVec2(-SQRT_3_2,-0.5f), ImVec2(-SQRT_3_2,-0.5f), ImVec2(SQRT_3_2,-0.5f)};
-static const ImVec2 MARKER_LINE_LEFT[6]     = {ImVec2(-1,0), ImVec2(0.5, SQRT_3_2),  ImVec2(0.5, SQRT_3_2),  ImVec2(0.5, -SQRT_3_2) , ImVec2(0.5, -SQRT_3_2) , ImVec2(-1,0) };
-static const ImVec2 MARKER_LINE_RIGHT[6]    = {ImVec2(1,0),  ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, -SQRT_3_2), ImVec2(-0.5, -SQRT_3_2), ImVec2(1,0) };
-static const ImVec2 MARKER_LINE_ASTERISK[6] = {ImVec2(-SQRT_3_2, -0.5f), ImVec2(SQRT_3_2, 0.5f),  ImVec2(-SQRT_3_2, 0.5f), ImVec2(SQRT_3_2, -0.5f), ImVec2(0, -1), ImVec2(0, 1)};
-static const ImVec2 MARKER_LINE_PLUS[4]     = {ImVec2(-1, 0), ImVec2(1, 0), ImVec2(0, -1), ImVec2(0, 1)};
-static const ImVec2 MARKER_LINE_CROSS[4]    = {ImVec2(-SQRT_1_2,-SQRT_1_2),ImVec2(SQRT_1_2,SQRT_1_2),ImVec2(SQRT_1_2,-SQRT_1_2),ImVec2(-SQRT_1_2,SQRT_1_2)};
+constexpr ImVec2 MARKER_LINE_SQUARE[8]   = {ImVec2(SQRT_1_2,SQRT_1_2), ImVec2(SQRT_1_2,-SQRT_1_2), ImVec2(SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,-SQRT_1_2), ImVec2(-SQRT_1_2,SQRT_1_2), ImVec2(-SQRT_1_2,SQRT_1_2), ImVec2(SQRT_1_2,SQRT_1_2)};
+constexpr ImVec2 MARKER_LINE_DIAMOND[8]  = {ImVec2(1, 0), ImVec2(0, -1), ImVec2(0, -1), ImVec2(-1, 0), ImVec2(-1, 0), ImVec2(0, 1), ImVec2(0, 1), ImVec2(1, 0)};
+constexpr ImVec2 MARKER_LINE_UP[6]       = {ImVec2(SQRT_3_2,0.5f), ImVec2(0,-1),ImVec2(0,-1),ImVec2(-SQRT_3_2,0.5f),ImVec2(-SQRT_3_2,0.5f),ImVec2(SQRT_3_2,0.5f)};
+constexpr ImVec2 MARKER_LINE_DOWN[6]     = {ImVec2(SQRT_3_2,-0.5f),ImVec2(0,1),ImVec2(0,1),ImVec2(-SQRT_3_2,-0.5f), ImVec2(-SQRT_3_2,-0.5f), ImVec2(SQRT_3_2,-0.5f)};
+constexpr ImVec2 MARKER_LINE_LEFT[6]     = {ImVec2(-1,0), ImVec2(0.5, SQRT_3_2),  ImVec2(0.5, SQRT_3_2),  ImVec2(0.5, -SQRT_3_2) , ImVec2(0.5, -SQRT_3_2) , ImVec2(-1,0) };
+constexpr ImVec2 MARKER_LINE_RIGHT[6]    = {ImVec2(1,0),  ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, SQRT_3_2), ImVec2(-0.5, -SQRT_3_2), ImVec2(-0.5, -SQRT_3_2), ImVec2(1,0) };
+constexpr ImVec2 MARKER_LINE_ASTERISK[6] = {ImVec2(-SQRT_3_2, -0.5f), ImVec2(SQRT_3_2, 0.5f),  ImVec2(-SQRT_3_2, 0.5f), ImVec2(SQRT_3_2, -0.5f), ImVec2(0, -1), ImVec2(0, 1)};
+constexpr ImVec2 MARKER_LINE_PLUS[4]     = {ImVec2(-1, 0), ImVec2(1, 0), ImVec2(0, -1), ImVec2(0, 1)};
+constexpr ImVec2 MARKER_LINE_CROSS[4]    = {ImVec2(-SQRT_1_2,-SQRT_1_2),ImVec2(SQRT_1_2,SQRT_1_2),ImVec2(SQRT_1_2,-SQRT_1_2),ImVec2(-SQRT_1_2,SQRT_1_2)};
+constexpr ImVec2 MARKER_LINE_VERTICAL[2] = {ImVec2(0, -1), ImVec2(0, 1)};
+constexpr ImVec2 MARKER_LINE_HORIZONTAL[2] = {ImVec2(-1, 0), ImVec2(1, 0)};
 
-template <typename _Getter>
-void RenderMarkers(const _Getter& getter, ImPlotMarker marker, float size, bool rend_fill, ImU32 col_fill, bool rend_line, ImU32 col_line, float weight) {
+template <typename _Getter, typename _GetterFillColor, typename _GetterLineColor, typename _GetterSize>
+void RenderMarkers(const _Getter& getter, ImPlotMarker marker, bool rend_fill, const _GetterFillColor& col_fill_getter, bool rend_line, const _GetterLineColor& col_line_getter, const _GetterSize& size_getter, float weight) {
     if (rend_fill) {
         switch (marker) {
-            case ImPlotMarker_Circle  : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_CIRCLE,10,size,col_fill); break;
-            case ImPlotMarker_Square  : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_SQUARE, 4,size,col_fill); break;
-            case ImPlotMarker_Diamond : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_DIAMOND,4,size,col_fill); break;
-            case ImPlotMarker_Up      : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_UP,     3,size,col_fill); break;
-            case ImPlotMarker_Down    : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_DOWN,   3,size,col_fill); break;
-            case ImPlotMarker_Left    : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_LEFT,   3,size,col_fill); break;
-            case ImPlotMarker_Right   : RenderPrimitives1<RendererMarkersFill>(getter,MARKER_FILL_RIGHT,  3,size,col_fill); break;
+            case ImPlotMarker_Circle  : RenderPrimitives3<RendererMarkersFill>(getter,col_fill_getter,size_getter,MARKER_FILL_CIRCLE,10); break;
+            case ImPlotMarker_Square  : RenderPrimitives3<RendererMarkersFill>(getter,col_fill_getter,size_getter,MARKER_FILL_SQUARE, 4); break;
+            case ImPlotMarker_Diamond : RenderPrimitives3<RendererMarkersFill>(getter,col_fill_getter,size_getter,MARKER_FILL_DIAMOND,4); break;
+            case ImPlotMarker_Up      : RenderPrimitives3<RendererMarkersFill>(getter,col_fill_getter,size_getter,MARKER_FILL_UP,     3); break;
+            case ImPlotMarker_Down    : RenderPrimitives3<RendererMarkersFill>(getter,col_fill_getter,size_getter,MARKER_FILL_DOWN,   3); break;
+            case ImPlotMarker_Left    : RenderPrimitives3<RendererMarkersFill>(getter,col_fill_getter,size_getter,MARKER_FILL_LEFT,   3); break;
+            case ImPlotMarker_Right   : RenderPrimitives3<RendererMarkersFill>(getter,col_fill_getter,size_getter,MARKER_FILL_RIGHT,  3); break;
         }
     }
     if (rend_line) {
         switch (marker) {
-            case ImPlotMarker_Circle    : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_CIRCLE, 20,size,weight,col_line); break;
-            case ImPlotMarker_Square    : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_SQUARE,  8,size,weight,col_line); break;
-            case ImPlotMarker_Diamond   : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_DIAMOND, 8,size,weight,col_line); break;
-            case ImPlotMarker_Up        : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_UP,      6,size,weight,col_line); break;
-            case ImPlotMarker_Down      : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_DOWN,    6,size,weight,col_line); break;
-            case ImPlotMarker_Left      : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_LEFT,    6,size,weight,col_line); break;
-            case ImPlotMarker_Right     : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_RIGHT,   6,size,weight,col_line); break;
-            case ImPlotMarker_Asterisk  : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_ASTERISK,6,size,weight,col_line); break;
-            case ImPlotMarker_Plus      : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_PLUS,    4,size,weight,col_line); break;
-            case ImPlotMarker_Cross     : RenderPrimitives1<RendererMarkersLine>(getter,MARKER_LINE_CROSS,   4,size,weight,col_line); break;
+            case ImPlotMarker_Circle    : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_CIRCLE, 20,weight); break;
+            case ImPlotMarker_Square    : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_SQUARE,  8,weight); break;
+            case ImPlotMarker_Diamond   : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_DIAMOND, 8,weight); break;
+            case ImPlotMarker_Up        : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_UP,      6,weight); break;
+            case ImPlotMarker_Down      : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_DOWN,    6,weight); break;
+            case ImPlotMarker_Left      : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_LEFT,    6,weight); break;
+            case ImPlotMarker_Right     : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_RIGHT,   6,weight); break;
+            case ImPlotMarker_Asterisk  : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_ASTERISK,6,weight); break;
+            case ImPlotMarker_Plus      : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_PLUS,    4,weight); break;
+            case ImPlotMarker_Cross     : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_CROSS,   4,weight); break;
+            case ImPlotMarker_Vertical  : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_VERTICAL,2,weight); break;
+            case ImPlotMarker_Horizontal: RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_HORIZONTAL,2,weight); break;
+        }
+    }
+}
+
+template <typename _Getter>
+void RenderColoredMarkers(const _Getter& getter, const ImPlotNextItemData& s) {
+    const ImU32 col_line = ImGui::GetColorU32(s.Spec.MarkerLineColor);
+    const ImU32 col_fill = ImGui::GetColorU32(s.Spec.MarkerFillColor);
+
+    if (s.Spec.MarkerSizes != nullptr) {
+        GetterIdxSize size_getter(s.Spec.MarkerSizes, getter.Count);
+        if (s.Spec.MarkerFillColors != nullptr && s.Spec.MarkerLineColors != nullptr) {
+            GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
+            GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
+            RenderMarkers<_Getter>(getter, s.Spec.Marker, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, size_getter, s.Spec.LineWeight);
+        } else if (s.Spec.MarkerFillColors != nullptr) {
+            GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
+            GetterConstColor line_getter(col_line);
+            RenderMarkers<_Getter>(getter, s.Spec.Marker, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, size_getter, s.Spec.LineWeight);
+        } else if (s.Spec.MarkerLineColors != nullptr) {
+            GetterConstColor fill_getter(col_fill);
+            GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
+            RenderMarkers<_Getter>(getter, s.Spec.Marker, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, size_getter, s.Spec.LineWeight);
+        } else {
+            GetterConstColor fill_getter(col_fill);
+            GetterConstColor line_getter(col_line);
+            RenderMarkers<_Getter>(getter, s.Spec.Marker, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, size_getter, s.Spec.LineWeight);
+        }
+    } else {
+        GetterConstSize size_getter(s.Spec.MarkerSize);
+        if (s.Spec.MarkerFillColors != nullptr && s.Spec.MarkerLineColors != nullptr) {
+            GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
+            GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
+            RenderMarkers<_Getter>(getter, s.Spec.Marker, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, size_getter, s.Spec.LineWeight);
+        } else if (s.Spec.MarkerFillColors != nullptr) {
+            GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
+            GetterConstColor line_getter(col_line);
+            RenderMarkers<_Getter>(getter, s.Spec.Marker, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, size_getter, s.Spec.LineWeight);
+        } else if (s.Spec.MarkerLineColors != nullptr) {
+            GetterConstColor fill_getter(col_fill);
+            GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
+            RenderMarkers<_Getter>(getter, s.Spec.Marker, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, size_getter, s.Spec.LineWeight);
+        } else {
+            GetterConstColor fill_getter(col_fill);
+            GetterConstColor line_getter(col_line);
+            RenderMarkers<_Getter>(getter, s.Spec.Marker, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, size_getter, s.Spec.LineWeight);
         }
     }
 }
@@ -1566,70 +1906,102 @@ void RenderMarkers(const _Getter& getter, ImPlotMarker marker, float size, bool 
 //-----------------------------------------------------------------------------
 
 template <typename _Getter>
-void PlotLineEx(const char* label_id, const _Getter& getter, ImPlotLineFlags flags) {
-    if (BeginItemEx(label_id, Fitter1<_Getter>(getter), flags, ImPlotCol_Line)) {
+void PlotLineEx(const char* label_id, const _Getter& getter, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, Fitter1<_Getter>(getter), spec, spec.LineColor, spec.Marker)) {
+        if (getter.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
         if (getter.Count > 1) {
-            if (ImHasFlag(flags, ImPlotLineFlags_Shaded) && s.RenderFill) {
-                const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
+            if (ImHasFlag(spec.Flags, ImPlotLineFlags_Shaded) && s.RenderFill) {
                 GetterOverrideY<_Getter> getter2(getter, 0);
-                RenderPrimitives2<RendererShaded>(getter,getter2,col_fill);
+                if (s.Spec.FillColors != nullptr) {
+                    GetterIdxColor color_getter(s.Spec.FillColors, getter.Count, s.Spec.FillAlpha);
+                    RenderPrimitives3<RendererShaded>(getter,getter2,color_getter);
+                } else {
+                    const ImU32 col_fill = ImGui::GetColorU32(s.Spec.FillColor);
+                    GetterConstColor color_getter(col_fill, s.Spec.FillAlpha);
+                    RenderPrimitives3<RendererShaded>(getter,getter2,color_getter);
+                }
             }
             if (s.RenderLine) {
-                const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
-                if (ImHasFlag(flags,ImPlotLineFlags_Segments)) {
-                    RenderPrimitives1<RendererLineSegments1>(getter,col_line,s.LineWeight);
+                const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
+                if (ImHasFlag(spec.Flags,ImPlotLineFlags_Segments)) {
+                    if (s.Spec.LineColors != nullptr) {
+                        GetterIdxColor color_getter(s.Spec.LineColors, getter.Count);
+                        RenderPrimitives2<RendererLineSegments1>(getter,color_getter,s.Spec.LineWeight);
+                    } else {
+                        GetterConstColor color_getter(col_line);
+                        RenderPrimitives2<RendererLineSegments1>(getter,color_getter,s.Spec.LineWeight);
+                    }
                 }
-                else if (ImHasFlag(flags, ImPlotLineFlags_Loop)) {
-                    if (ImHasFlag(flags, ImPlotLineFlags_SkipNaN))
-                        RenderPrimitives1<RendererLineStripSkip>(GetterLoop<_Getter>(getter),col_line,s.LineWeight);
-                    else
-                        RenderPrimitives1<RendererLineStrip>(GetterLoop<_Getter>(getter),col_line,s.LineWeight);
+                else if (ImHasFlag(spec.Flags, ImPlotLineFlags_Loop)) {
+                    if (s.Spec.LineColors != nullptr) {
+                        GetterIdxColor color_getter(s.Spec.LineColors, getter.Count);
+                        if (ImHasFlag(spec.Flags, ImPlotLineFlags_SkipNaN))
+                            RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter),color_getter,s.Spec.LineWeight);
+                        else
+                            RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter),color_getter,s.Spec.LineWeight);
+                    } else {
+                        GetterConstColor color_getter(col_line);
+                        if (ImHasFlag(spec.Flags, ImPlotLineFlags_SkipNaN))
+                            RenderPrimitives2<RendererLineStripSkip>(GetterLoop<_Getter>(getter),color_getter,s.Spec.LineWeight);
+                        else
+                            RenderPrimitives2<RendererLineStrip>(GetterLoop<_Getter>(getter),color_getter,s.Spec.LineWeight);
+                    }
                 }
                 else {
-                    if (ImHasFlag(flags, ImPlotLineFlags_SkipNaN))
-                        RenderPrimitives1<RendererLineStripSkip>(getter,col_line,s.LineWeight);
-                    else
-                        RenderPrimitives1<RendererLineStrip>(getter,col_line,s.LineWeight);
+                    if (s.Spec.LineColors != nullptr) {
+                        GetterIdxColor color_getter(s.Spec.LineColors, getter.Count);
+                        if (ImHasFlag(spec.Flags, ImPlotLineFlags_SkipNaN))
+                            RenderPrimitives2<RendererLineStripSkip>(getter,color_getter,s.Spec.LineWeight);
+                        else
+                            RenderPrimitives2<RendererLineStrip>(getter,color_getter,s.Spec.LineWeight);
+                    } else {
+                        GetterConstColor color_getter(col_line);
+                        if (ImHasFlag(spec.Flags, ImPlotLineFlags_SkipNaN))
+                            RenderPrimitives2<RendererLineStripSkip>(getter,color_getter,s.Spec.LineWeight);
+                        else
+                            RenderPrimitives2<RendererLineStrip>(getter,color_getter,s.Spec.LineWeight);
+                    }
                 }
             }
         }
         // render markers
-        if (s.Marker != ImPlotMarker_None) {
-            if (ImHasFlag(flags, ImPlotLineFlags_NoClip)) {
+        if (s.RenderMarkers) {
+            if (ImHasFlag(spec.Flags, ImPlotLineFlags_NoClip)) {
                 PopPlotClipRect();
-                PushPlotClipRect(s.MarkerSize);
+                PushPlotClipRect(s.Spec.MarkerSize);
             }
-            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
-            const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
-            RenderMarkers<_Getter>(getter, s.Marker, s.MarkerSize, s.RenderMarkerFill, col_fill, s.RenderMarkerLine, col_line, s.MarkerWeight);
+            RenderColoredMarkers(getter, s);
         }
         EndItem();
     }
 }
 
 template <typename T>
-void PlotLine(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride) {
-    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
-    PlotLineEx(label_id, getter, flags);
+void PlotLine(const char* label_id, const T* values, int count, double xscale, double x0, const ImPlotSpec& spec) {
+    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),count);
+    PlotLineEx(label_id, getter, spec);
 }
 
 template <typename T>
-void PlotLine(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride) {
-    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-    PlotLineEx(label_id, getter, flags);
+void PlotLine(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+    PlotLineEx(label_id, getter, spec);
 }
 
 #define INSTANTIATE_MACRO(T) \
-    template IMPLOT_API void PlotLine<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride); \
-    template IMPLOT_API void PlotLine<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride);
+    template IMPLOT_API void PlotLine<T> (const char* label_id, const T* values, int count, double xscale, double x0, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotLine<T>(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
 // custom
-void PlotLineG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotLineFlags flags) {
+void PlotLineG(const char* label_id, ImPlotGetter getter_func, void* data, int count, const ImPlotSpec& spec) {
     GetterFuncPtr getter(getter_func,data, count);
-    PlotLineEx(label_id, getter, flags);
+    PlotLineEx(label_id, getter, spec);
 }
 
 //-----------------------------------------------------------------------------
@@ -1637,105 +2009,255 @@ void PlotLineG(const char* label_id, ImPlotGetter getter_func, void* data, int c
 //-----------------------------------------------------------------------------
 
 template <typename Getter>
-void PlotScatterEx(const char* label_id, const Getter& getter, ImPlotScatterFlags flags) {
-    if (BeginItemEx(label_id, Fitter1<Getter>(getter), flags, ImPlotCol_MarkerOutline)) {
+void PlotScatterEx(const char* label_id, const Getter& getter, const ImPlotSpec& spec) {
+    // force scatter to render a marker even if none
+    ImPlotMarker marker = spec.Marker == ImPlotMarker_None ? ImPlotMarker_Auto: spec.Marker;
+    if (BeginItemEx(label_id, Fitter1<Getter>(getter), spec, spec.MarkerLineColor, marker)) {
+        if (getter.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
-        ImPlotMarker marker = s.Marker == ImPlotMarker_None ? ImPlotMarker_Circle: s.Marker;
-        if (marker != ImPlotMarker_None) {
-            if (ImHasFlag(flags,ImPlotScatterFlags_NoClip)) {
+        if (s.RenderMarkers) {
+            if (ImHasFlag(spec.Flags,ImPlotScatterFlags_NoClip)) {
                 PopPlotClipRect();
-                PushPlotClipRect(s.MarkerSize);
+                PushPlotClipRect(s.Spec.MarkerSize);
             }
-            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
-            const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
-            RenderMarkers<Getter>(getter, marker, s.MarkerSize, s.RenderMarkerFill, col_fill, s.RenderMarkerLine, col_line, s.MarkerWeight);
+            RenderColoredMarkers(getter, s);
         }
         EndItem();
     }
 }
 
 template <typename T>
-void PlotScatter(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride) {
-    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
-    PlotScatterEx(label_id, getter, flags);
+void PlotScatter(const char* label_id, const T* values, int count, double xscale, double x0, const ImPlotSpec& spec) {
+    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,spec.Offset, Stride<T>(spec)),count);
+    PlotScatterEx(label_id, getter, spec);
 }
 
 template <typename T>
-void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride) {
-    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-    return PlotScatterEx(label_id, getter, flags);
+void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,spec.Offset, Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset, Stride<T>(spec)),count);
+    return PlotScatterEx(label_id, getter, spec);
 }
 
 #define INSTANTIATE_MACRO(T) \
-    template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride); \
-    template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
+    template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* values, int count, double xscale, double x0, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
 // custom
-void PlotScatterG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotScatterFlags flags) {
+void PlotScatterG(const char* label_id, ImPlotGetter getter_func, void* data, int count, const ImPlotSpec& spec) {
     GetterFuncPtr getter(getter_func,data, count);
-    return PlotScatterEx(label_id, getter, flags);
+    return PlotScatterEx(label_id, getter, spec);
 }
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotBubbles
+//-----------------------------------------------------------------------------
+
+template <typename Getter>
+void PlotBubblesEx(const char* label_id, const Getter& getter, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, FitterBubbles1<Getter>(getter), spec, spec.FillColor, spec.Marker)) {
+        if (getter.Count <= 0) {
+            EndItem();
+            return;
+        }
+        const ImPlotNextItemData& s = GetItemData();
+
+        if (s.RenderFill) {
+            const ImU32 col_fill = ImGui::GetColorU32(s.Spec.FillColor);
+            if (s.Spec.FillColors != nullptr) {
+                GetterIdxColor fill_getter(s.Spec.FillColors, getter.Count, s.Spec.FillAlpha);
+                RenderPrimitives2<RendererCircleFill>(getter, fill_getter);
+            } else {
+                GetterConstColor fill_getter(col_fill);
+                RenderPrimitives2<RendererCircleFill>(getter, fill_getter);
+            }
+        }
+        if (s.RenderLine) {
+            const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
+            if (s.Spec.LineColors != nullptr) {
+                GetterIdxColor line_getter(s.Spec.LineColors, getter.Count);
+                RenderPrimitives2<RendererCircleLine>(getter, line_getter, s.Spec.LineWeight);
+            } else {
+                GetterConstColor line_getter(col_line);
+                RenderPrimitives2<RendererCircleLine>(getter, line_getter, s.Spec.LineWeight);
+            }
+        }
+
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotBubbles(const char* label_id, const T* values, const T* szs, int count, double xscale, double x0, const ImPlotSpec& spec) {
+  GetterXYZ<IndexerLin,IndexerIdx<T>,IndexerIdx<T>> getter(IndexerLin(xscale,x0), IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)), IndexerIdx<T>(szs,count,spec.Offset,Stride<T>(spec)),count);
+  PlotBubblesEx(label_id, getter, spec);
+}
+
+template <typename T>
+void PlotBubbles(const char* label_id, const T* xs, const T* ys, const T* szs, int count, const ImPlotSpec& spec) {
+  GetterXYZ<IndexerIdx<T>,IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)), IndexerIdx<T>(szs,count,spec.Offset,Stride<T>(spec)),count);
+  return PlotBubblesEx(label_id, getter, spec);
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotBubbles<T>(const char* label_id, const T* values, const T* szs, int count, double xscale, double x0, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotBubbles<T>(const char* label_id, const T* xs, const T* ys, const T* szs, int count, const ImPlotSpec& spec);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+//-----------------------------------------------------------------------------
+// [SECTION] PlotPolygon
+//-----------------------------------------------------------------------------
+
+template <typename Getter>
+void PlotPolygonEx(const char* label_id, const Getter& getter, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, Fitter1<Getter>(getter), spec, spec.FillColor, spec.Marker)) {
+        if (getter.Count < 2) {
+            EndItem();
+            return;
+        }
+        const ImPlotNextItemData& s = GetItemData();
+        const bool is_concave = ImHasFlag(spec.Flags, ImPlotPolygonFlags_Concave);
+
+        ImDrawList& draw_list = *GetPlotDrawList();
+        const ImPlotAxis& x_axis = GetCurrentPlot()->Axes[GetCurrentPlot()->CurrentX];
+        const ImPlotAxis& y_axis = GetCurrentPlot()->Axes[GetCurrentPlot()->CurrentY];
+        Transformer2 transformer(x_axis, y_axis);
+
+        // Flip points to make sure they are in counter-clockwise order for correct filling when one axis is inverted
+        bool x_inv = ImHasFlag(x_axis.Flags, ImPlotAxisFlags_Invert);
+        bool y_inv = ImHasFlag(y_axis.Flags, ImPlotAxisFlags_Invert);
+        bool flip = !((x_inv ? 1 : 0) ^ (y_inv ? 1 : 0));
+
+        // Transform all points to screen space
+        ImVec2* points = (ImVec2*)IM_ALLOC(getter.Count * sizeof(ImVec2));
+        for (int i = 0; i < getter.Count; ++i) {
+            ImPlotPoint p = flip ? getter[getter.Count - 1 - i] : getter[i];
+            points[i] = transformer(p);
+        }
+
+        if (s.RenderFill && getter.Count >= 3) {
+            const ImU32 col_fill = ImGui::GetColorU32(s.Spec.FillColor);
+            if (is_concave)
+                draw_list.AddConcavePolyFilled(points, getter.Count, col_fill);
+            else
+                draw_list.AddConvexPolyFilled(points, getter.Count, col_fill);
+        }
+        if (s.RenderLine && getter.Count >= 2) {
+            const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
+#if IMGUI_VERSION_NUM < 19276
+            draw_list.AddPolyline(points, getter.Count, col_line, ImDrawFlags_Closed, s.Spec.LineWeight);
+#else
+            draw_list.AddPolyline(points, getter.Count, col_line, s.Spec.LineWeight, ImDrawFlags_Closed);
+#endif
+        }
+        IM_FREE(points);
+
+        EndItem();
+    }
+}
+
+template <typename T>
+void PlotPolygon(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+    return PlotPolygonEx(label_id, getter, spec);
+}
+
+#define INSTANTIATE_MACRO(T) \
+    template IMPLOT_API void PlotPolygon<T>(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotStairs
 //-----------------------------------------------------------------------------
 
 template <typename Getter>
-void PlotStairsEx(const char* label_id, const Getter& getter, ImPlotStairsFlags flags) {
-    if (BeginItemEx(label_id, Fitter1<Getter>(getter), flags, ImPlotCol_Line)) {
+void PlotStairsEx(const char* label_id, const Getter& getter, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, Fitter1<Getter>(getter), spec, spec.LineColor, spec.Marker)) {
+        if (getter.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
-        if (getter.Count > 1 ) {
-            if (s.RenderFill && ImHasFlag(flags,ImPlotStairsFlags_Shaded)) {
-                const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
-                if (ImHasFlag(flags, ImPlotStairsFlags_PreStep))
-                    RenderPrimitives1<RendererStairsPreShaded>(getter,col_fill);
-                else
-                    RenderPrimitives1<RendererStairsPostShaded>(getter,col_fill);
+        if (getter.Count > 1) {
+            if (s.RenderFill && ImHasFlag(spec.Flags,ImPlotStairsFlags_Shaded)) {
+                const ImU32 col_fill = ImGui::GetColorU32(s.Spec.FillColor);
+                if (ImHasFlag(spec.Flags, ImPlotStairsFlags_PreStep)) {
+                    if (s.Spec.FillColors != nullptr) {
+                        GetterIdxColor color_getter(s.Spec.FillColors, getter.Count, s.Spec.FillAlpha);
+                        RenderPrimitives2<RendererStairsPreShaded>(getter, color_getter);
+                    } else {
+                        GetterConstColor color_getter(col_fill, s.Spec.FillAlpha);
+                        RenderPrimitives2<RendererStairsPreShaded>(getter, color_getter);
+                    }
+                } else {
+                    if (s.Spec.FillColors != nullptr) {
+                        GetterIdxColor color_getter(s.Spec.FillColors, getter.Count, s.Spec.FillAlpha);
+                        RenderPrimitives2<RendererStairsPostShaded>(getter, color_getter);
+                    } else {
+                        GetterConstColor color_getter(col_fill, s.Spec.FillAlpha);
+                        RenderPrimitives2<RendererStairsPostShaded>(getter, color_getter);
+                    }
+                }
             }
             if (s.RenderLine) {
-                const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
-                if (ImHasFlag(flags, ImPlotStairsFlags_PreStep))
-                    RenderPrimitives1<RendererStairsPre>(getter,col_line,s.LineWeight);
-                else
-                    RenderPrimitives1<RendererStairsPost>(getter,col_line,s.LineWeight);
+                const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
+                if (ImHasFlag(spec.Flags, ImPlotStairsFlags_PreStep)) {
+                    if (s.Spec.LineColors != nullptr) {
+                        GetterIdxColor color_getter(s.Spec.LineColors, getter.Count);
+                        RenderPrimitives2<RendererStairsPre>(getter, color_getter, s.Spec.LineWeight);
+                    } else {
+                        GetterConstColor color_getter(col_line);
+                        RenderPrimitives2<RendererStairsPre>(getter, color_getter, s.Spec.LineWeight);
+                    }
+                } else {
+                    if (s.Spec.LineColors != nullptr) {
+                        GetterIdxColor color_getter(s.Spec.LineColors, getter.Count);
+                        RenderPrimitives2<RendererStairsPost>(getter, color_getter, s.Spec.LineWeight);
+                    } else {
+                        GetterConstColor color_getter(col_line);
+                        RenderPrimitives2<RendererStairsPost>(getter, color_getter, s.Spec.LineWeight);
+                    }
+                }
             }
         }
         // render markers
-        if (s.Marker != ImPlotMarker_None) {
+        if (s.RenderMarkers) {
             PopPlotClipRect();
-            PushPlotClipRect(s.MarkerSize);
-            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
-            const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
-            RenderMarkers<Getter>(getter, s.Marker, s.MarkerSize, s.RenderMarkerFill, col_fill, s.RenderMarkerLine, col_line, s.MarkerWeight);
+            PushPlotClipRect(s.Spec.MarkerSize);
+            RenderColoredMarkers(getter, s);
         }
         EndItem();
     }
 }
 
 template <typename T>
-void PlotStairs(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride) {
-    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
-    PlotStairsEx(label_id, getter, flags);
+void PlotStairs(const char* label_id, const T* values, int count, double xscale, double x0, const ImPlotSpec& spec) {
+    GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),count);
+    PlotStairsEx(label_id, getter, spec);
 }
 
 template <typename T>
-void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride) {
-    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-    return PlotStairsEx(label_id, getter, flags);
+void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+    return PlotStairsEx(label_id, getter, spec);
 }
 
 #define INSTANTIATE_MACRO(T) \
-    template IMPLOT_API void PlotStairs<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride); \
-    template IMPLOT_API void PlotStairs<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
+    template IMPLOT_API void PlotStairs<T> (const char* label_id, const T* values, int count, double xscale, double x0, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotStairs<T>(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
 // custom
-void PlotStairsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotStairsFlags flags) {
+void PlotStairsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, const ImPlotSpec& spec) {
     GetterFuncPtr getter(getter_func,data, count);
-    return PlotStairsEx(label_id, getter, flags);
+    return PlotStairsEx(label_id, getter, spec);
 }
 
 //-----------------------------------------------------------------------------
@@ -1743,59 +2265,69 @@ void PlotStairsG(const char* label_id, ImPlotGetter getter_func, void* data, int
 //-----------------------------------------------------------------------------
 
 template <typename Getter1, typename Getter2>
-void PlotShadedEx(const char* label_id, const Getter1& getter1, const Getter2& getter2, ImPlotShadedFlags flags) {
-    if (BeginItemEx(label_id, Fitter2<Getter1,Getter2>(getter1,getter2), flags, ImPlotCol_Fill)) {
+void PlotShadedEx(const char* label_id, const Getter1& getter1, const Getter2& getter2, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, Fitter2<Getter1,Getter2>(getter1,getter2), spec, spec.FillColor)) {
+        if (getter1.Count <= 0 || getter2.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
         if (s.RenderFill) {
-            const ImU32 col = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
-            RenderPrimitives2<RendererShaded>(getter1,getter2,col);
+            if (s.Spec.FillColors != nullptr) {
+                GetterIdxColor color_getter(s.Spec.FillColors, getter1.Count, s.Spec.FillAlpha);
+                RenderPrimitives3<RendererShaded>(getter1,getter2,color_getter);
+            } else {
+                const ImU32 col = ImGui::GetColorU32(s.Spec.FillColor);
+                GetterConstColor color_getter(col, s.Spec.FillAlpha);
+                RenderPrimitives3<RendererShaded>(getter1,getter2,color_getter);
+            }
         }
         EndItem();
     }
 }
 
 template <typename T>
-void PlotShaded(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride) {
+void PlotShaded(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, const ImPlotSpec& spec) {
     if (!(y_ref > -DBL_MAX))
         y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Min;
     if (!(y_ref < DBL_MAX))
         y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Max;
-    GetterXY<IndexerLin,IndexerIdx<T>> getter1(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
+    GetterXY<IndexerLin,IndexerIdx<T>> getter1(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),count);
     GetterXY<IndexerLin,IndexerConst>  getter2(IndexerLin(xscale,x0),IndexerConst(y_ref),count);
-    PlotShadedEx(label_id, getter1, getter2, flags);
+    PlotShadedEx(label_id, getter1, getter2, spec);
 }
 
 template <typename T>
-void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride) {
+void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double y_ref, const ImPlotSpec& spec) {
     if (y_ref == -HUGE_VAL)
         y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Min;
     if (y_ref == HUGE_VAL)
         y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Max;
-    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-    GetterXY<IndexerIdx<T>,IndexerConst>  getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerConst(y_ref),count);
-    PlotShadedEx(label_id, getter1, getter2, flags);
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+    GetterXY<IndexerIdx<T>,IndexerConst>  getter2(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerConst(y_ref),count);
+    PlotShadedEx(label_id, getter1, getter2, spec);
 }
 
 
 template <typename T>
-void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride) {
-    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys1,count,offset,stride),count);
-    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys2,count,offset,stride),count);
-    PlotShadedEx(label_id, getter1, getter2, flags);
+void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, const ImPlotSpec& spec) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys1,count,spec.Offset,Stride<T>(spec)),count);
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter2(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys2,count,spec.Offset,Stride<T>(spec)),count);
+    PlotShadedEx(label_id, getter1, getter2, spec);
 }
 
 #define INSTANTIATE_MACRO(T) \
-    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride); \
-    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride); \
-    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys, int count, double y_ref, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
 // custom
-void PlotShadedG(const char* label_id, ImPlotGetter getter_func1, void* data1, ImPlotGetter getter_func2, void* data2, int count, ImPlotShadedFlags flags) {
+void PlotShadedG(const char* label_id, ImPlotGetter getter_func1, void* data1, ImPlotGetter getter_func2, void* data2, int count, const ImPlotSpec& spec) {
     GetterFuncPtr getter1(getter_func1, data1, count);
     GetterFuncPtr getter2(getter_func2, data2, count);
-    PlotShadedEx(label_id, getter1, getter2, flags);
+    PlotShadedEx(label_id, getter1, getter2, spec);
 }
 
 //-----------------------------------------------------------------------------
@@ -1803,89 +2335,121 @@ void PlotShadedG(const char* label_id, ImPlotGetter getter_func1, void* data1, I
 //-----------------------------------------------------------------------------
 
 template <typename Getter1, typename Getter2>
-void PlotBarsVEx(const char* label_id, const Getter1& getter1, const Getter2 getter2, double width, ImPlotBarsFlags flags) {
-    if (BeginItemEx(label_id, FitterBarV<Getter1,Getter2>(getter1,getter2,width), flags, ImPlotCol_Fill)) {
+void PlotBarsVEx(const char* label_id, const Getter1& getter1, const Getter2 getter2, double width, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, FitterBarV<Getter1,Getter2>(getter1,getter2,width), spec, spec.FillColor)) {
+        if (getter1.Count <= 0 || getter2.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
-        const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
-        const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+        const ImU32 col_fill = ImGui::GetColorU32(s.Spec.FillColor);
+        const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
         bool rend_fill = s.RenderFill;
         bool rend_line = s.RenderLine;
         if (rend_fill) {
-            RenderPrimitives2<RendererBarsFillV>(getter1,getter2,col_fill,width);
+            if (s.Spec.FillColors != nullptr) {
+                GetterIdxColor fill_getter(s.Spec.FillColors, getter1.Count, s.Spec.FillAlpha);
+                RenderPrimitives3<RendererBarsFillV>(getter1, getter2, fill_getter, width);
+            } else {
+                GetterConstColor fill_getter(col_fill, s.Spec.FillAlpha);
+                RenderPrimitives3<RendererBarsFillV>(getter1, getter2, fill_getter, width);
+            }
             if (rend_line && col_fill == col_line)
                 rend_line = false;
         }
         if (rend_line) {
-            RenderPrimitives2<RendererBarsLineV>(getter1,getter2,col_line,width,s.LineWeight);
+            if (s.Spec.LineColors != nullptr) {
+                GetterIdxColor line_getter(s.Spec.LineColors, getter1.Count);
+                RenderPrimitives3<RendererBarsLineV>(getter1, getter2, line_getter, width, s.Spec.LineWeight);
+            } else {
+                GetterConstColor line_getter(col_line);
+                RenderPrimitives3<RendererBarsLineV>(getter1, getter2, line_getter, width, s.Spec.LineWeight);
+            }
         }
         EndItem();
     }
 }
 
 template <typename Getter1, typename Getter2>
-void PlotBarsHEx(const char* label_id, const Getter1& getter1, const Getter2& getter2, double height, ImPlotBarsFlags flags) {
-    if (BeginItemEx(label_id, FitterBarH<Getter1,Getter2>(getter1,getter2,height), flags, ImPlotCol_Fill)) {
+void PlotBarsHEx(const char* label_id, const Getter1& getter1, const Getter2& getter2, double height, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, FitterBarH<Getter1,Getter2>(getter1,getter2,height), spec, spec.FillColor)) {
+        if (getter1.Count <= 0 || getter2.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
-        const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]);
-        const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
+        const ImU32 col_fill = ImGui::GetColorU32(s.Spec.FillColor);
+        const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
         bool rend_fill = s.RenderFill;
         bool rend_line = s.RenderLine;
         if (rend_fill) {
-            RenderPrimitives2<RendererBarsFillH>(getter1,getter2,col_fill,height);
+            if (s.Spec.FillColors != nullptr) {
+                GetterIdxColor fill_getter(s.Spec.FillColors, getter1.Count, s.Spec.FillAlpha);
+                RenderPrimitives3<RendererBarsFillH>(getter1, getter2, fill_getter, height);
+            } else {
+                GetterConstColor fill_getter(col_fill, s.Spec.FillAlpha);
+                RenderPrimitives3<RendererBarsFillH>(getter1, getter2, fill_getter, height);
+            }
             if (rend_line && col_fill == col_line)
                 rend_line = false;
         }
         if (rend_line) {
-            RenderPrimitives2<RendererBarsLineH>(getter1,getter2,col_line,height,s.LineWeight);
+            if (s.Spec.LineColors != nullptr) {
+                GetterIdxColor line_getter(s.Spec.LineColors, getter1.Count);
+                RenderPrimitives3<RendererBarsLineH>(getter1, getter2, line_getter, height, s.Spec.LineWeight);
+            } else {
+                GetterConstColor line_getter(col_line);
+                RenderPrimitives3<RendererBarsLineH>(getter1, getter2, line_getter, height, s.Spec.LineWeight);
+            }
         }
         EndItem();
     }
 }
 
 template <typename T>
-void PlotBars(const char* label_id, const T* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride) {
-    if (ImHasFlag(flags, ImPlotBarsFlags_Horizontal)) {
-        GetterXY<IndexerIdx<T>,IndexerLin> getter1(IndexerIdx<T>(values,count,offset,stride),IndexerLin(1.0,shift),count);
+void PlotBars(const char* label_id, const T* values, int count, double bar_size, double shift, const ImPlotSpec& spec) {
+    if (ImHasFlag(spec.Flags, ImPlotBarsFlags_Horizontal)) {
+        GetterXY<IndexerIdx<T>,IndexerLin> getter1(IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),IndexerLin(1.0,shift),count);
         GetterXY<IndexerConst,IndexerLin>  getter2(IndexerConst(0),IndexerLin(1.0,shift),count);
-        PlotBarsHEx(label_id, getter1, getter2, bar_size, flags);
+        PlotBarsHEx(label_id, getter1, getter2, bar_size, spec);
     }
     else {
-        GetterXY<IndexerLin,IndexerIdx<T>> getter1(IndexerLin(1.0,shift),IndexerIdx<T>(values,count,offset,stride),count);
+        GetterXY<IndexerLin,IndexerIdx<T>> getter1(IndexerLin(1.0,shift),IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),count);
         GetterXY<IndexerLin,IndexerConst>  getter2(IndexerLin(1.0,shift),IndexerConst(0),count);
-        PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
+        PlotBarsVEx(label_id, getter1, getter2, bar_size, spec);
     }
 }
 
 template <typename T>
-void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride) {
-    if (ImHasFlag(flags, ImPlotBarsFlags_Horizontal)) {
-        GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-        GetterXY<IndexerConst, IndexerIdx<T>> getter2(IndexerConst(0),IndexerIdx<T>(ys,count,offset,stride),count);
-        PlotBarsHEx(label_id, getter1, getter2, bar_size, flags);
+void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double bar_size, const ImPlotSpec& spec) {
+    if (ImHasFlag(spec.Flags, ImPlotBarsFlags_Horizontal)) {
+        GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+        GetterXY<IndexerConst, IndexerIdx<T>> getter2(IndexerConst(0),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+        PlotBarsHEx(label_id, getter1, getter2, bar_size, spec);
     }
     else {
-        GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-        GetterXY<IndexerIdx<T>,IndexerConst>  getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerConst(0),count);
-        PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
+        GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter1(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+        GetterXY<IndexerIdx<T>,IndexerConst>  getter2(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerConst(0),count);
+        PlotBarsVEx(label_id, getter1, getter2, bar_size, spec);
     }
 }
 
 #define INSTANTIATE_MACRO(T) \
-    template IMPLOT_API void PlotBars<T>(const char* label_id, const T* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride); \
-    template IMPLOT_API void PlotBars<T>(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
+    template IMPLOT_API void PlotBars<T>(const char* label_id, const T* values, int count, double bar_size, double shift, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotBars<T>(const char* label_id, const T* xs, const T* ys, int count, double bar_size, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
-void PlotBarsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, double bar_size, ImPlotBarsFlags flags) {
-    if (ImHasFlag(flags, ImPlotBarsFlags_Horizontal)) {
+void PlotBarsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, double bar_size, const ImPlotSpec& spec) {
+    if (ImHasFlag(spec.Flags, ImPlotBarsFlags_Horizontal)) {
         GetterFuncPtr getter1(getter_func, data, count);
         GetterOverrideX<GetterFuncPtr> getter2(getter1,0);
-        PlotBarsHEx(label_id, getter1, getter2, bar_size, flags);
+        PlotBarsHEx(label_id, getter1, getter2, bar_size, spec);
     }
     else {
         GetterFuncPtr getter1(getter_func, data, count);
         GetterOverrideY<GetterFuncPtr> getter2(getter1,0);
-        PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
+        PlotBarsVEx(label_id, getter1, getter2, bar_size, spec);
     }
 }
 
@@ -1894,13 +2458,17 @@ void PlotBarsG(const char* label_id, ImPlotGetter getter_func, void* data, int c
 //-----------------------------------------------------------------------------
 
 template <typename T>
-void PlotBarGroups(const char* const label_ids[], const T* values, int item_count, int group_count, double group_size, double shift, ImPlotBarGroupsFlags flags) {
-    const bool horz = ImHasFlag(flags, ImPlotBarGroupsFlags_Horizontal);
-    const bool stack = ImHasFlag(flags, ImPlotBarGroupsFlags_Stacked);
+void PlotBarGroups(const char* const label_ids[], const T* values, int item_count, int group_count, double group_size, double shift, const ImPlotSpec& spec) {
+    IndexerIdx<T> indexer(values,item_count*group_count,spec.Offset,Stride<T>(spec));
+    const bool horz = ImHasFlag(spec.Flags, ImPlotBarGroupsFlags_Horizontal);
+    const bool stack = ImHasFlag(spec.Flags, ImPlotBarGroupsFlags_Stacked);
+    ImPlotSpec spec_bars = spec;
+    spec_bars.Flags = 0;
     if (stack) {
         SetupLock();
-        GImPlot->TempDouble1.resize(4*group_count);
-        double* temp = GImPlot->TempDouble1.Data;
+        ImPlotContext& gp = *GImPlot;
+        gp.TempDouble1.resize(4*group_count);
+        double* temp = gp.TempDouble1.Data;
         double* neg =      &temp[0];
         double* pos =      &temp[group_count];
         double* curr_min = &temp[group_count*2];
@@ -1911,7 +2479,7 @@ void PlotBarGroups(const char* const label_ids[], const T* values, int item_coun
             for (int i = 0; i < item_count; ++i) {
                 if (!IsItemHidden(label_ids[i])) {
                     for (int g = 0; g < group_count; ++g) {
-                        double v = (double)values[i*group_count+g];
+                        double v = indexer[i*group_count+g];
                         if (v > 0) {
                             curr_min[g] = pos[g];
                             curr_max[g] = curr_min[g] + v;
@@ -1926,14 +2494,14 @@ void PlotBarGroups(const char* const label_ids[], const T* values, int item_coun
                 }
                 GetterXY<IndexerIdx<double>,IndexerLin> getter1(IndexerIdx<double>(curr_min,group_count),IndexerLin(1.0,shift),group_count);
                 GetterXY<IndexerIdx<double>,IndexerLin> getter2(IndexerIdx<double>(curr_max,group_count),IndexerLin(1.0,shift),group_count);
-                PlotBarsHEx(label_ids[i],getter1,getter2,group_size,0);
+                PlotBarsHEx(label_ids[i],getter1,getter2,group_size,spec_bars);
             }
         }
         else {
             for (int i = 0; i < item_count; ++i) {
                 if (!IsItemHidden(label_ids[i])) {
                     for (int g = 0; g < group_count; ++g) {
-                        double v = (double)values[i*group_count+g];
+                        double v = indexer[i*group_count+g];
                         if (v > 0) {
                             curr_min[g] = pos[g];
                             curr_max[g] = curr_min[g] + v;
@@ -1948,28 +2516,29 @@ void PlotBarGroups(const char* const label_ids[], const T* values, int item_coun
                 }
                 GetterXY<IndexerLin,IndexerIdx<double>> getter1(IndexerLin(1.0,shift),IndexerIdx<double>(curr_min,group_count),group_count);
                 GetterXY<IndexerLin,IndexerIdx<double>> getter2(IndexerLin(1.0,shift),IndexerIdx<double>(curr_max,group_count),group_count);
-                PlotBarsVEx(label_ids[i],getter1,getter2,group_size,0);
+                PlotBarsVEx(label_ids[i],getter1,getter2,group_size,spec_bars);
             }
         }
     }
     else {
         const double subsize = group_size / item_count;
         if (horz) {
+            spec_bars.Flags = ImPlotBarsFlags_Horizontal;
             for (int i = 0; i < item_count; ++i) {
                 const double subshift = (i+0.5)*subsize - group_size/2;
-                PlotBars(label_ids[i],&values[i*group_count],group_count,subsize,subshift+shift,ImPlotBarsFlags_Horizontal);
+                PlotBars(label_ids[i],&values[i*group_count],group_count,subsize,subshift+shift,spec_bars);
             }
         }
         else {
             for (int i = 0; i < item_count; ++i) {
                 const double subshift = (i+0.5)*subsize - group_size/2;
-                PlotBars(label_ids[i],&values[i*group_count],group_count,subsize,subshift+shift);
+                PlotBars(label_ids[i],&values[i*group_count],group_count,subsize,subshift+shift,spec_bars);
             }
         }
     }
 }
 
-#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotBarGroups<T>(const char* const label_ids[], const T* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotBarGroups<T>(const char* const label_ids[], const T* values, int items, int groups, double width, double shift, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
@@ -1978,20 +2547,24 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 //-----------------------------------------------------------------------------
 
 template <typename _GetterPos, typename _GetterNeg>
-void PlotErrorBarsVEx(const char* label_id, const _GetterPos& getter_pos, const _GetterNeg& getter_neg, ImPlotErrorBarsFlags flags) {
-    if (BeginItemEx(label_id, Fitter2<_GetterPos,_GetterNeg>(getter_pos, getter_neg), flags, IMPLOT_AUTO)) {
+void PlotErrorBarsVEx(const char* label_id, const _GetterPos& getter_pos, const _GetterNeg& getter_neg, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, Fitter2<_GetterPos,_GetterNeg>(getter_pos, getter_neg), spec, IMPLOT_AUTO_COL)) {
+        if (getter_pos.Count <= 0 || getter_neg.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
         ImDrawList& draw_list = *GetPlotDrawList();
-        const ImU32 col = ImGui::GetColorU32(s.Colors[ImPlotCol_ErrorBar]);
-        const bool rend_whisker  = s.ErrorBarSize > 0;
-        const float half_whisker = s.ErrorBarSize * 0.5f;
+        const ImU32 col = ImGui::GetColorU32( IsColorAuto(spec.LineColor) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : s.Spec.LineColor );
+        const bool rend_whisker  = s.Spec.Size > 0;
+        const float half_whisker = s.Spec.Size * 0.5f;
         for (int i = 0; i < getter_pos.Count; ++i) {
-            ImVec2 p1 = PlotToPixels(getter_neg(i),IMPLOT_AUTO,IMPLOT_AUTO);
-            ImVec2 p2 = PlotToPixels(getter_pos(i),IMPLOT_AUTO,IMPLOT_AUTO);
-            draw_list.AddLine(p1,p2,col, s.ErrorBarWeight);
+            ImVec2 p1 = PlotToPixels(getter_neg[i],IMPLOT_AUTO,IMPLOT_AUTO);
+            ImVec2 p2 = PlotToPixels(getter_pos[i],IMPLOT_AUTO,IMPLOT_AUTO);
+            draw_list.AddLine(p1,p2,col, s.Spec.LineWeight);
             if (rend_whisker) {
-                draw_list.AddLine(p1 - ImVec2(half_whisker, 0), p1 + ImVec2(half_whisker, 0), col, s.ErrorBarWeight);
-                draw_list.AddLine(p2 - ImVec2(half_whisker, 0), p2 + ImVec2(half_whisker, 0), col, s.ErrorBarWeight);
+                draw_list.AddLine(p1 - ImVec2(half_whisker, 0), p1 + ImVec2(half_whisker, 0), col, s.Spec.LineWeight);
+                draw_list.AddLine(p2 - ImVec2(half_whisker, 0), p2 + ImVec2(half_whisker, 0), col, s.Spec.LineWeight);
             }
         }
         EndItem();
@@ -1999,20 +2572,24 @@ void PlotErrorBarsVEx(const char* label_id, const _GetterPos& getter_pos, const 
 }
 
 template <typename _GetterPos, typename _GetterNeg>
-void PlotErrorBarsHEx(const char* label_id, const _GetterPos& getter_pos, const _GetterNeg& getter_neg, ImPlotErrorBarsFlags flags) {
-    if (BeginItemEx(label_id, Fitter2<_GetterPos,_GetterNeg>(getter_pos, getter_neg), flags, IMPLOT_AUTO)) {
+void PlotErrorBarsHEx(const char* label_id, const _GetterPos& getter_pos, const _GetterNeg& getter_neg, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, Fitter2<_GetterPos,_GetterNeg>(getter_pos, getter_neg), spec, IMPLOT_AUTO_COL)) {
+        if (getter_pos.Count <= 0 || getter_neg.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
         ImDrawList& draw_list = *GetPlotDrawList();
-        const ImU32 col = ImGui::GetColorU32(s.Colors[ImPlotCol_ErrorBar]);
-        const bool rend_whisker  = s.ErrorBarSize > 0;
-        const float half_whisker = s.ErrorBarSize * 0.5f;
+        const ImU32 col = ImGui::GetColorU32( IsColorAuto(spec.LineColor) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : s.Spec.LineColor );
+        const bool rend_whisker  = s.Spec.Size > 0;
+        const float half_whisker = s.Spec.Size * 0.5f;
         for (int i = 0; i < getter_pos.Count; ++i) {
-            ImVec2 p1 = PlotToPixels(getter_neg(i),IMPLOT_AUTO,IMPLOT_AUTO);
-            ImVec2 p2 = PlotToPixels(getter_pos(i),IMPLOT_AUTO,IMPLOT_AUTO);
-            draw_list.AddLine(p1, p2, col, s.ErrorBarWeight);
+            ImVec2 p1 = PlotToPixels(getter_neg[i],IMPLOT_AUTO,IMPLOT_AUTO);
+            ImVec2 p2 = PlotToPixels(getter_pos[i],IMPLOT_AUTO,IMPLOT_AUTO);
+            draw_list.AddLine(p1, p2, col, s.Spec.LineWeight);
             if (rend_whisker) {
-                draw_list.AddLine(p1 - ImVec2(0, half_whisker), p1 + ImVec2(0, half_whisker), col, s.ErrorBarWeight);
-                draw_list.AddLine(p2 - ImVec2(0, half_whisker), p2 + ImVec2(0, half_whisker), col, s.ErrorBarWeight);
+                draw_list.AddLine(p1 - ImVec2(0, half_whisker), p1 + ImVec2(0, half_whisker), col, s.Spec.LineWeight);
+                draw_list.AddLine(p2 - ImVec2(0, half_whisker), p2 + ImVec2(0, half_whisker), col, s.Spec.LineWeight);
             }
         }
         EndItem();
@@ -2020,36 +2597,36 @@ void PlotErrorBarsHEx(const char* label_id, const _GetterPos& getter_pos, const 
 }
 
 template <typename T>
-void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride) {
-    PlotErrorBars(label_id, xs, ys, err, err, count, flags, offset, stride);
+void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, const ImPlotSpec& spec) {
+    PlotErrorBars(label_id, xs, ys, err, err, count, spec);
 }
 
 template <typename T>
-void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride) {
-    IndexerIdx<T> indexer_x(xs, count,offset,stride);
-    IndexerIdx<T> indexer_y(ys, count,offset,stride);
-    IndexerIdx<T> indexer_n(neg,count,offset,stride);
-    IndexerIdx<T> indexer_p(pos,count,offset,stride);
-    GetterError<T> getter(xs, ys, neg, pos, count, offset, stride);
-    if (ImHasFlag(flags, ImPlotErrorBarsFlags_Horizontal)) {
+void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, const ImPlotSpec& spec) {
+    IndexerIdx<T> indexer_x(xs, count,spec.Offset,Stride<T>(spec));
+    IndexerIdx<T> indexer_y(ys, count,spec.Offset,Stride<T>(spec));
+    IndexerIdx<T> indexer_n(neg,count,spec.Offset,Stride<T>(spec));
+    IndexerIdx<T> indexer_p(pos,count,spec.Offset,Stride<T>(spec));
+    GetterError<T> getter(xs, ys, neg, pos, count, spec.Offset, Stride<T>(spec));
+    if (ImHasFlag(spec.Flags, ImPlotErrorBarsFlags_Horizontal)) {
         IndexerAdd<IndexerIdx<T>,IndexerIdx<T>> indexer_xp(indexer_x, indexer_p, 1,  1);
         IndexerAdd<IndexerIdx<T>,IndexerIdx<T>> indexer_xn(indexer_x, indexer_n, 1, -1);
         GetterXY<IndexerAdd<IndexerIdx<T>,IndexerIdx<T>>,IndexerIdx<T>> getter_p(indexer_xp, indexer_y, count);
         GetterXY<IndexerAdd<IndexerIdx<T>,IndexerIdx<T>>,IndexerIdx<T>> getter_n(indexer_xn, indexer_y, count);
-        PlotErrorBarsHEx(label_id, getter_p, getter_n, flags);
+        PlotErrorBarsHEx(label_id, getter_p, getter_n, spec);
     }
     else {
         IndexerAdd<IndexerIdx<T>,IndexerIdx<T>> indexer_yp(indexer_y, indexer_p, 1,  1);
         IndexerAdd<IndexerIdx<T>,IndexerIdx<T>> indexer_yn(indexer_y, indexer_n, 1, -1);
         GetterXY<IndexerIdx<T>,IndexerAdd<IndexerIdx<T>,IndexerIdx<T>>> getter_p(indexer_x, indexer_yp, count);
         GetterXY<IndexerIdx<T>,IndexerAdd<IndexerIdx<T>,IndexerIdx<T>>> getter_n(indexer_x, indexer_yn, count);
-        PlotErrorBarsVEx(label_id, getter_p, getter_n, flags);
+        PlotErrorBarsVEx(label_id, getter_p, getter_n, spec);
     }
 }
 
 #define INSTANTIATE_MACRO(T) \
-    template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride); \
-    template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
+    template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* err, int count, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
@@ -2058,57 +2635,65 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 //-----------------------------------------------------------------------------
 
 template <typename _GetterM, typename _GetterB>
-void PlotStemsEx(const char* label_id, const _GetterM& get_mark, const _GetterB& get_base, ImPlotStemsFlags flags) {
-    if (BeginItemEx(label_id, Fitter2<_GetterM,_GetterB>(get_mark,get_base), flags, ImPlotCol_Line)) {
+void PlotStemsEx(const char* label_id, const _GetterM& getter_mark, const _GetterB& getter_base, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, Fitter2<_GetterM,_GetterB>(getter_mark,getter_base), spec, spec.LineColor, spec.Marker)) {
+        if (getter_mark.Count <= 0 || getter_base.Count <= 0) {
+            EndItem();
+            return;
+        }
         const ImPlotNextItemData& s = GetItemData();
         // render stems
         if (s.RenderLine) {
-            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
-            RenderPrimitives2<RendererLineSegments2>(get_mark, get_base, col_line, s.LineWeight);
+            const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
+            if (s.Spec.LineColors != nullptr) {
+                GetterIdxColor color_getter(s.Spec.LineColors, getter_mark.Count);
+                RenderPrimitives3<RendererLineSegments2>(getter_mark, getter_base, color_getter, s.Spec.LineWeight);
+            } else {
+                GetterConstColor color_getter(col_line);
+                RenderPrimitives3<RendererLineSegments2>(getter_mark, getter_base, color_getter, s.Spec.LineWeight);
+            }
         }
         // render markers
-        if (s.Marker != ImPlotMarker_None) {
+        if (s.RenderMarkers) {
             PopPlotClipRect();
-            PushPlotClipRect(s.MarkerSize);
-            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
-            const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
-            RenderMarkers<_GetterM>(get_mark, s.Marker, s.MarkerSize, s.RenderMarkerFill, col_fill, s.RenderMarkerLine, col_line, s.MarkerWeight);
+            PushPlotClipRect(s.Spec.MarkerSize);
+            RenderColoredMarkers(getter_mark, s);
         }
         EndItem();
     }
 }
 
 template <typename T>
-void PlotStems(const char* label_id, const T* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride) {
-    if (ImHasFlag(flags, ImPlotStemsFlags_Horizontal)) {
-        GetterXY<IndexerIdx<T>,IndexerLin> get_mark(IndexerIdx<T>(values,count,offset,stride),IndexerLin(scale,start),count);
+void PlotStems(const char* label_id, const T* values, int count, double ref, double scale, double start, const ImPlotSpec& spec) {
+    if (ImHasFlag(spec.Flags, ImPlotStemsFlags_Horizontal)) {
+        GetterXY<IndexerIdx<T>,IndexerLin> get_mark(IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),IndexerLin(scale,start),count);
         GetterXY<IndexerConst,IndexerLin>  get_base(IndexerConst(ref),IndexerLin(scale,start),count);
-        PlotStemsEx(label_id, get_mark, get_base, flags);
+        PlotStemsEx(label_id, get_mark, get_base, spec);
     }
     else {
-        GetterXY<IndexerLin,IndexerIdx<T>> get_mark(IndexerLin(scale,start),IndexerIdx<T>(values,count,offset,stride),count);
+        GetterXY<IndexerLin,IndexerIdx<T>> get_mark(IndexerLin(scale,start),IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),count);
         GetterXY<IndexerLin,IndexerConst>  get_base(IndexerLin(scale,start),IndexerConst(ref),count);
-        PlotStemsEx(label_id, get_mark, get_base, flags);
+        PlotStemsEx(label_id, get_mark, get_base, spec);
     }
 }
 
 template <typename T>
-void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride) {
-    if (ImHasFlag(flags, ImPlotStemsFlags_Horizontal)) {
-        GetterXY<IndexerIdx<T>,IndexerIdx<T>> get_mark(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-        GetterXY<IndexerConst,IndexerIdx<T>>  get_base(IndexerConst(ref),IndexerIdx<T>(ys,count,offset,stride),count);
-        PlotStemsEx(label_id, get_mark, get_base, flags);
+void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double ref, const ImPlotSpec& spec) {
+    if (ImHasFlag(spec.Flags, ImPlotStemsFlags_Horizontal)) {
+        GetterXY<IndexerIdx<T>,IndexerIdx<T>> get_mark(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+        GetterXY<IndexerConst,IndexerIdx<T>>  get_base(IndexerConst(ref),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+        PlotStemsEx(label_id, get_mark, get_base, spec);
     }
     else {
-        GetterXY<IndexerIdx<T>,IndexerIdx<T>> get_mark(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-        GetterXY<IndexerIdx<T>,IndexerConst>  get_base(IndexerIdx<T>(xs,count,offset,stride),IndexerConst(ref),count);
-        PlotStemsEx(label_id, get_mark, get_base, flags);
+        GetterXY<IndexerIdx<T>,IndexerIdx<T>> get_mark(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+        GetterXY<IndexerIdx<T>,IndexerConst>  get_base(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerConst(ref),count);
+        PlotStemsEx(label_id, get_mark, get_base, spec);
     }
 }
 
 #define INSTANTIATE_MACRO(T) \
-    template IMPLOT_API void PlotStems<T>(const char* label_id, const T* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride); \
-    template IMPLOT_API void PlotStems<T>(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
+    template IMPLOT_API void PlotStems<T>(const char* label_id, const T* values, int count, double ref, double scale, double start, const ImPlotSpec& spec); \
+    template IMPLOT_API void PlotStems<T>(const char* label_id, const T* xs, const T* ys, int count, double ref, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
@@ -2118,32 +2703,54 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 //-----------------------------------------------------------------------------
 
 template <typename T>
-void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLinesFlags flags, int offset, int stride) {
+void PlotInfLines(const char* label_id, const T* values, int count, const ImPlotSpec& spec) {
     const ImPlotRect lims = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO);
-    if (ImHasFlag(flags, ImPlotInfLinesFlags_Horizontal)) {
-        GetterXY<IndexerConst,IndexerIdx<T>> get_min(IndexerConst(lims.X.Min),IndexerIdx<T>(values,count,offset,stride),count);
-        GetterXY<IndexerConst,IndexerIdx<T>> get_max(IndexerConst(lims.X.Max),IndexerIdx<T>(values,count,offset,stride),count);
-        if (BeginItemEx(label_id, FitterY<GetterXY<IndexerConst,IndexerIdx<T>>>(get_min), flags, ImPlotCol_Line)) {
+    if (ImHasFlag(spec.Flags, ImPlotInfLinesFlags_Horizontal)) {
+        GetterXY<IndexerConst,IndexerIdx<T>> getter_min(IndexerConst(lims.X.Min),IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),count);
+        GetterXY<IndexerConst,IndexerIdx<T>> getter_max(IndexerConst(lims.X.Max),IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),count);
+        if (BeginItemEx(label_id, FitterY<GetterXY<IndexerConst,IndexerIdx<T>>>(getter_min), spec, spec.LineColor)) {
+            if (count <= 0) {
+                EndItem();
+                return;
+            }
             const ImPlotNextItemData& s = GetItemData();
-            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
-            if (s.RenderLine)
-                RenderPrimitives2<RendererLineSegments2>(get_min, get_max, col_line, s.LineWeight);
+            const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
+            if (s.RenderLine) {
+                if (s.Spec.LineColors != nullptr) {
+                    GetterIdxColor color_getter(s.Spec.LineColors, count);
+                    RenderPrimitives3<RendererLineSegments2>(getter_min, getter_max, color_getter, s.Spec.LineWeight);
+                } else {
+                    GetterConstColor color_getter(col_line);
+                    RenderPrimitives3<RendererLineSegments2>(getter_min, getter_max, color_getter, s.Spec.LineWeight);
+                }
+            }
             EndItem();
         }
     }
     else {
-        GetterXY<IndexerIdx<T>,IndexerConst> get_min(IndexerIdx<T>(values,count,offset,stride),IndexerConst(lims.Y.Min),count);
-        GetterXY<IndexerIdx<T>,IndexerConst> get_max(IndexerIdx<T>(values,count,offset,stride),IndexerConst(lims.Y.Max),count);
-        if (BeginItemEx(label_id, FitterX<GetterXY<IndexerIdx<T>,IndexerConst>>(get_min), flags, ImPlotCol_Line)) {
+        GetterXY<IndexerIdx<T>,IndexerConst> get_min(IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),IndexerConst(lims.Y.Min),count);
+        GetterXY<IndexerIdx<T>,IndexerConst> get_max(IndexerIdx<T>(values,count,spec.Offset,Stride<T>(spec)),IndexerConst(lims.Y.Max),count);
+        if (BeginItemEx(label_id, FitterX<GetterXY<IndexerIdx<T>,IndexerConst>>(get_min), spec, spec.LineColor)) {
+            if (count <= 0) {
+                EndItem();
+                return;
+            }
             const ImPlotNextItemData& s = GetItemData();
-            const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_Line]);
-            if (s.RenderLine)
-                RenderPrimitives2<RendererLineSegments2>(get_min, get_max, col_line, s.LineWeight);
+            const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
+            if (s.RenderLine) {
+                if (s.Spec.LineColors != nullptr) {
+                    GetterIdxColor color_getter(s.Spec.LineColors, count);
+                    RenderPrimitives3<RendererLineSegments2>(get_min, get_max, color_getter, s.Spec.LineWeight);
+                } else {
+                    GetterConstColor color_getter(col_line);
+                    RenderPrimitives3<RendererLineSegments2>(get_min, get_max, color_getter, s.Spec.LineWeight);
+                }
+            }
             EndItem();
         }
     }
 }
-#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotInfLines<T>(const char* label_id, const T* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotInfLines<T>(const char* label_id, const T* xs, int count, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
@@ -2151,76 +2758,272 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 // [SECTION] PlotPieChart
 //-----------------------------------------------------------------------------
 
-IMPLOT_INLINE void RenderPieSlice(ImDrawList& draw_list, const ImPlotPoint& center, double radius, double a0, double a1, ImU32 col) {
+IMPLOT_INLINE void PrimPieSliceFill(ImDrawList& draw_list, const ImVec2* points, int count, ImU32 col, const ImVec2& uv) {
+    // Write vertices
+    for (int i = 0; i < count; ++i) {
+        draw_list._VtxWritePtr[i].pos = points[i];
+        draw_list._VtxWritePtr[i].uv = uv;
+        draw_list._VtxWritePtr[i].col = col;
+    }
+    draw_list._VtxWritePtr += count;
+
+    // Write indices as a triangle fan (all triangles share first vertex - the center)
+    for (int i = 2; i < count; ++i) {
+        draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+        draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + i - 1);
+        draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + i);
+        draw_list._IdxWritePtr += 3;
+    }
+    draw_list._VtxCurrentIdx += count;
+}
+
+IMPLOT_INLINE void PrimPieSliceLine(ImDrawList& draw_list, const ImVec2* points, int count, ImU32 col, float half_weight, const ImVec2& tex_uv0, const ImVec2& tex_uv1) {
+    // Create a thick polyline by drawing quads between each segment
+    const int segments = count - 1;
+
+    for (int i = 0; i < segments; ++i) {
+        const ImVec2& p1 = points[i];
+        const ImVec2& p2 = points[i + 1];
+
+        // Calculate perpendicular vector for line thickness (same as PrimLine)
+        float dx = p2.x - p1.x;
+        float dy = p2.y - p1.y;
+        IMPLOT_NORMALIZE2F_OVER_ZERO(dx, dy);
+        dx *= half_weight;
+        dy *= half_weight;
+
+        // Four vertices for the quad (same layout as PrimLine)
+        draw_list._VtxWritePtr[0].pos.x = p1.x + dy;
+        draw_list._VtxWritePtr[0].pos.y = p1.y - dx;
+        draw_list._VtxWritePtr[0].uv = tex_uv0;
+        draw_list._VtxWritePtr[0].col = col;
+
+        draw_list._VtxWritePtr[1].pos.x = p2.x + dy;
+        draw_list._VtxWritePtr[1].pos.y = p2.y - dx;
+        draw_list._VtxWritePtr[1].uv = tex_uv0;
+        draw_list._VtxWritePtr[1].col = col;
+
+        draw_list._VtxWritePtr[2].pos.x = p2.x - dy;
+        draw_list._VtxWritePtr[2].pos.y = p2.y + dx;
+        draw_list._VtxWritePtr[2].uv = tex_uv1;
+        draw_list._VtxWritePtr[2].col = col;
+
+        draw_list._VtxWritePtr[3].pos.x = p1.x - dy;
+        draw_list._VtxWritePtr[3].pos.y = p1.y + dx;
+        draw_list._VtxWritePtr[3].uv = tex_uv1;
+        draw_list._VtxWritePtr[3].col = col;
+
+        draw_list._VtxWritePtr += 4;
+
+        // Two triangles for the quad
+        const ImDrawIdx vtx_idx = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+        draw_list._IdxWritePtr[0] = vtx_idx;
+        draw_list._IdxWritePtr[1] = vtx_idx + 1;
+        draw_list._IdxWritePtr[2] = vtx_idx + 2;
+        draw_list._IdxWritePtr[3] = vtx_idx;
+        draw_list._IdxWritePtr[4] = vtx_idx + 2;
+        draw_list._IdxWritePtr[5] = vtx_idx + 3;
+        draw_list._IdxWritePtr += 6;
+
+        draw_list._VtxCurrentIdx += 4;
+    }
+}
+
+IMPLOT_INLINE void RenderPieSliceFill(ImDrawList& draw_list, ImVec2* buffer, int count, ImU32 col) {
+    const ImVec2 uv = draw_list._Data->TexUvWhitePixel;
+    // Reserve space for vertices and indices
+    // Triangle fan: n-2 triangles for n vertices, so (n-2)*3 indices
+    const int idx_count = (count - 2) * 3;
+    draw_list.PrimReserve(idx_count, count);
+    PrimPieSliceFill(draw_list, buffer, count, col, uv);
+}
+
+IMPLOT_INLINE void RenderPieSliceLine(ImDrawList& draw_list, ImVec2* buffer, int count, ImU32 col) {
+    float half_weight = 1.0f;  // Weight of 2.0f -> half_weight of 1.0f
+    ImVec2 tex_uv0, tex_uv1;
+    GetLineRenderProps(draw_list, half_weight, tex_uv0, tex_uv1);
+
+    // Polyline with n points has n-1 segments, each needs 4 vertices and 6 indices
+    const int segments = count - 1;
+    const int vtx_count = segments * 4;
+    const int idx_count = segments * 6;
+    draw_list.PrimReserve(idx_count, vtx_count);
+    PrimPieSliceLine(draw_list, buffer, count, col, half_weight, tex_uv0, tex_uv1);
+}
+
+IMPLOT_INLINE void RenderPieSlice(ImDrawList& draw_list, const ImPlotPoint& center, double radius, double a0, double a1, ImU32 col, ImPlotPieChartFlags flags, bool detached = false) {
     const float resolution = 50 / (2 * IM_PI);
     ImVec2 buffer[52];
-    buffer[0] = PlotToPixels(center,IMPLOT_AUTO,IMPLOT_AUTO);
+
     int n = ImMax(3, (int)((a1 - a0) * resolution));
     double da = (a1 - a0) / (n - 1);
     int i = 0;
-    for (; i < n; ++i) {
-        double a = a0 + i * da;
-        buffer[i + 1] = PlotToPixels(center.x + radius * cos(a), center.y + radius * sin(a),IMPLOT_AUTO,IMPLOT_AUTO);
+
+    if (detached) {
+        const double offset = 0.08; // Offset of the detached slice
+        const double width_scale = 0.95; // Scale factor for the width of the detached slice
+
+        double a_mid = (a0 + a1) / 2;
+        double new_a0 = a_mid - (a1 - a0) * width_scale / 2;
+        double new_a1 = a_mid + (a1 - a0) * width_scale / 2;
+        double new_da = (new_a1 - new_a0) / (n - 1);
+
+        ImPlotPoint offsetCenter(center.x + offset * cos(a_mid), center.y + offset * sin(a_mid));
+
+        // Start point (center of the offset)
+        buffer[0] = PlotToPixels(offsetCenter, IMPLOT_AUTO, IMPLOT_AUTO);
+
+        for (; i < n; ++i) {
+            double a = new_a0 + i * new_da;
+            buffer[i + 1] = PlotToPixels(
+                offsetCenter.x + (radius + offset/2) * cos(a),
+                offsetCenter.y + (radius + offset/2) * sin(a),
+                IMPLOT_AUTO, IMPLOT_AUTO
+            );
+        }
+
+    } else {
+        buffer[0] = PlotToPixels(center, IMPLOT_AUTO, IMPLOT_AUTO);
+        for (; i < n; ++i) {
+            double a = a0 + i * da;
+            buffer[i + 1] = PlotToPixels(
+                center.x + radius * cos(a),
+                center.y + radius * sin(a),
+                IMPLOT_AUTO, IMPLOT_AUTO);
+        }
     }
-    buffer[i+1] = buffer[0];
+    // Close the shape
+    buffer[i + 1] = buffer[0];
+
     // fill
-    draw_list.AddConvexPolyFilled(buffer, n + 1, col);
+    RenderPieSliceFill(draw_list, buffer, n + 2, col);
+
     // border (for AA)
-    draw_list.AddPolyline(buffer, n + 2, col, 0, 2.0f);
+    if (!ImHasFlag(flags, ImPlotPieChartFlags_NoSliceBorder))
+        RenderPieSliceLine(draw_list, buffer, n + 2, col);
 }
 
 template <typename T>
-void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "PlotPieChart() needs to be called between BeginPlot() and EndPlot()!");
-    ImDrawList & draw_list = *GetPlotDrawList();
+double PieChartSum(IndexerIdx<T> indexer, bool ignore_hidden) {
     double sum = 0;
-    for (int i = 0; i < count; ++i)
-        sum += (double)values[i];
-    const bool normalize = ImHasFlag(flags,ImPlotPieChartFlags_Normalize) || sum > 1.0;
-    ImPlotPoint center(x,y);
-    PushPlotClipRect();
+    if (ignore_hidden) {
+        ImPlotContext& gp = *GImPlot;
+        ImPlotItemGroup& Items = *gp.CurrentItems;
+        for (int i = 0; i < indexer.Count; ++i) {
+            if (i >= Items.GetItemCount())
+                break;
+
+            ImPlotItem* item = Items.GetItemByIndex(i);
+            IM_ASSERT(item != nullptr);
+            if (item->Show) {
+                sum += (double)indexer[i];
+            }
+        }
+    }
+    else {
+        for (int i = 0; i < indexer.Count; ++i) {
+            sum += (double)indexer[i];
+        }
+    }
+    return sum;
+}
+
+template <typename T>
+void PlotPieChartEx(const char* const label_ids[], IndexerIdx<T> indexer, ImPlotPoint center, double radius, double angle0, const ImPlotSpec& spec) {
+    ImDrawList& draw_list  = *GetPlotDrawList();
+
+    const bool ignore_hidden = ImHasFlag(spec.Flags, ImPlotPieChartFlags_IgnoreHidden);
+    const double sum         = PieChartSum(indexer, ignore_hidden);
+    const bool normalize     = ImHasFlag(spec.Flags, ImPlotPieChartFlags_Normalize) || sum > 1.0;
+
     double a0 = angle0 * 2 * IM_PI / 360.0;
     double a1 = angle0 * 2 * IM_PI / 360.0;
-    ImPlotPoint Pmin = ImPlotPoint(x-radius,y-radius);
-    ImPlotPoint Pmax = ImPlotPoint(x+radius,y+radius);
-    for (int i = 0; i < count; ++i) {
-        double percent = normalize ? (double)values[i] / sum : (double)values[i];
-        a1 = a0 + 2 * IM_PI * percent;
-        if (BeginItemEx(label_ids[i], FitterRect(Pmin,Pmax))) {
-            ImU32 col = GetCurrentItem()->Color;
-            if (percent < 0.5) {
-                RenderPieSlice(draw_list, center, radius, a0, a1, col);
-            }
-            else  {
-                RenderPieSlice(draw_list, center, radius, a0, a0 + (a1 - a0) * 0.5, col);
-                RenderPieSlice(draw_list, center, radius, a0 + (a1 - a0) * 0.5, a1, col);
+    ImPlotPoint Pmin = ImPlotPoint(center.x - radius, center.y - radius);
+    ImPlotPoint Pmax = ImPlotPoint(center.x + radius, center.y + radius);
+    for (int i = 0; i < indexer.Count; ++i) {
+        ImPlotItem* item = GetItem(label_ids[i]);
+
+        const double percent = normalize ? (double)indexer[i] / sum : (double)indexer[i];
+        const bool skip      = sum <= 0.0 || (ignore_hidden && item != nullptr && !item->Show);
+        if (!skip)
+            a1 = a0 + 2 * IM_PI * percent;
+
+        if (BeginItemEx(label_ids[i], FitterRect(Pmin, Pmax), spec)) {
+            const bool hovered = ImPlot::IsLegendEntryHovered(label_ids[i]) && ImHasFlag(spec.Flags, ImPlotPieChartFlags_Exploding);
+            if (sum > 0.0) {
+                ImU32 col = GetCurrentItem()->Color;
+                if (percent < 0.5) {
+                    RenderPieSlice(draw_list, center, radius, a0, a1, col, spec.Flags, hovered);
+                }
+                else {
+                    RenderPieSlice(draw_list, center, radius, a0, a0 + (a1 - a0) * 0.5, col, spec.Flags, hovered);
+                    RenderPieSlice(draw_list, center, radius, a0 + (a1 - a0) * 0.5, a1, col, spec.Flags, hovered);
+                }
             }
             EndItem();
         }
-        a0 = a1;
+        if (!skip)
+            a0 = a1;
     }
-    if (fmt != NULL) {
-        a0 = angle0 * 2 * IM_PI / 360.0;
-        a1 = angle0 * 2 * IM_PI / 360.0;
+}
+
+int PieChartFormatter(double value, char* buff, int size, void* data) {
+    const char* fmt = (const char*)data;
+    return snprintf(buff, size, fmt, value);
+}
+
+template <typename T>
+void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, const ImPlotSpec& spec) {
+    PlotPieChart<T>(label_ids, values, count, x, y, radius, PieChartFormatter, (void*)fmt, angle0, spec);
+}
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotPieChart<T>(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, const ImPlotSpec& spec);
+CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
+#undef INSTANTIATE_MACRO
+
+template <typename T>
+void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, ImPlotFormatter fmt, void* fmt_data, double angle0, const ImPlotSpec& spec) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "PlotPieChart() needs to be called between BeginPlot() and EndPlot()!");
+    ImDrawList& draw_list = *GetPlotDrawList();
+
+    IndexerIdx<T> indexer(values,count,spec.Offset,Stride<T>(spec));
+
+    const bool ignore_hidden = ImHasFlag(spec.Flags, ImPlotPieChartFlags_IgnoreHidden);
+    const double sum = PieChartSum(indexer, ignore_hidden);
+    const bool normalize = ImHasFlag(spec.Flags, ImPlotPieChartFlags_Normalize) || sum > 1.0;
+    ImPlotPoint center(x, y);
+
+    PushPlotClipRect();
+    PlotPieChartEx(label_ids, indexer, center, radius, angle0, spec);
+    if (fmt != nullptr) {
+        double a0 = angle0 * 2 * IM_PI / 360.0;
+        double a1 = angle0 * 2 * IM_PI / 360.0;
         char buffer[32];
         for (int i = 0; i < count; ++i) {
             ImPlotItem* item = GetItem(label_ids[i]);
-            double percent = normalize ? (double)values[i] / sum : (double)values[i];
-            a1 = a0 + 2 * IM_PI * percent;
-            if (item->Show) {
-                ImFormatString(buffer, 32, fmt, (double)values[i]);
-                ImVec2 size = ImGui::CalcTextSize(buffer);
-                double angle = a0 + (a1 - a0) * 0.5;
-                ImVec2 pos = PlotToPixels(center.x + 0.5 * radius * cos(angle), center.y + 0.5 * radius * sin(angle),IMPLOT_AUTO,IMPLOT_AUTO);
-                ImU32 col  = CalcTextColor(ImGui::ColorConvertU32ToFloat4(item->Color));
-                draw_list.AddText(pos - size * 0.5f, col, buffer);
+            IM_ASSERT(item != nullptr);
+
+            const double percent = normalize ? (double)indexer[i] / sum : (double)indexer[i];
+            const bool skip = ignore_hidden && item != nullptr && !item->Show;
+
+            if (!skip) {
+                a1 = a0 + 2 * IM_PI * percent;
+                if (item->Show) {
+                    fmt((double)indexer[i], buffer, 32, fmt_data);
+                    ImVec2 size = ImGui::CalcTextSize(buffer);
+                    double angle = a0 + (a1 - a0) * 0.5;
+                    const bool hovered = ImPlot::IsLegendEntryHovered(label_ids[i]) && ImHasFlag(spec.Flags, ImPlotPieChartFlags_Exploding);
+                    const double offset = (hovered ? 0.6 : 0.5) * radius;
+                    ImVec2 pos = PlotToPixels(center.x + offset * cos(angle), center.y + offset * sin(angle), IMPLOT_AUTO, IMPLOT_AUTO);
+                    ImU32 col = CalcTextColor(ImGui::ColorConvertU32ToFloat4(item->Color));
+                    draw_list.AddText(pos - size * 0.5f, col, buffer);
+                }
+                a0 = a1;
             }
-            a0 = a1;
         }
     }
     PopPlotClipRect();
 }
-#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotPieChart<T>(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, ImPlotFormatter fmt, void* fmt_data, double angle0, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
@@ -2228,10 +3031,10 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 // [SECTION] PlotHeatmap
 //-----------------------------------------------------------------------------
 
-template <typename T>
+template <typename _Indexer>
 struct GetterHeatmapRowMaj {
-    GetterHeatmapRowMaj(const T* values, int rows, int cols, double scale_min, double scale_max, double width, double height, double xref, double yref, double ydir) :
-        Values(values),
+    GetterHeatmapRowMaj(_Indexer indexer, int rows, int cols, double scale_min, double scale_max, double width, double height, double xref, double yref, double ydir) :
+        Indexer(indexer),
         Count(rows*cols),
         Rows(rows),
         Cols(cols),
@@ -2244,8 +3047,8 @@ struct GetterHeatmapRowMaj {
         YDir(ydir),
         HalfSize(Width*0.5, Height*0.5)
     { }
-    template <typename I> IMPLOT_INLINE RectC operator()(I idx) const {
-        double val = (double)Values[idx];
+    template <typename I> IMPLOT_INLINE RectC operator[](I idx) const {
+        double val = (double)Indexer[idx];
         const int r = idx / Cols;
         const int c = idx % Cols;
         const ImPlotPoint p(XRef + HalfSize.x + c*Width, YRef + YDir * (HalfSize.y + r*Height));
@@ -2253,19 +3056,21 @@ struct GetterHeatmapRowMaj {
         rect.Pos = p;
         rect.HalfSize = HalfSize;
         const float t = ImClamp((float)ImRemap01(val, ScaleMin, ScaleMax),0.0f,1.0f);
-        rect.Color = GImPlot->ColormapData.LerpTable(GImPlot->Style.Colormap, t);
+        ImPlotContext& gp = *GImPlot;
+        rect.Color = gp.ColormapData.LerpTable(gp.Style.Colormap, t);
         return rect;
     }
-    const T* const Values;
+    const _Indexer Indexer;
     const int Count, Rows, Cols;
     const double ScaleMin, ScaleMax, Width, Height, XRef, YRef, YDir;
     const ImPlotPoint HalfSize;
+    typedef RectC value_type;
 };
 
-template <typename T>
+template <typename _Indexer>
 struct GetterHeatmapColMaj {
-    GetterHeatmapColMaj(const T* values, int rows, int cols, double scale_min, double scale_max, double width, double height, double xref, double yref, double ydir) :
-        Values(values),
+    GetterHeatmapColMaj(_Indexer indexer, int rows, int cols, double scale_min, double scale_max, double width, double height, double xref, double yref, double ydir) :
+        Indexer(indexer),
         Count(rows*cols),
         Rows(rows),
         Cols(cols),
@@ -2278,33 +3083,33 @@ struct GetterHeatmapColMaj {
         YDir(ydir),
         HalfSize(Width*0.5, Height*0.5)
     { }
-    template <typename I> IMPLOT_INLINE RectC operator()(I idx) const {
-        double val = (double)Values[idx];
-        const int r = idx % Cols;
-        const int c = idx / Cols;
+    template <typename I> IMPLOT_INLINE RectC operator[](I idx) const {
+        double val = (double)Indexer[idx];
+        const int r = idx % Rows;
+        const int c = idx / Rows;
         const ImPlotPoint p(XRef + HalfSize.x + c*Width, YRef + YDir * (HalfSize.y + r*Height));
         RectC rect;
         rect.Pos = p;
         rect.HalfSize = HalfSize;
         const float t = ImClamp((float)ImRemap01(val, ScaleMin, ScaleMax),0.0f,1.0f);
-        rect.Color = GImPlot->ColormapData.LerpTable(GImPlot->Style.Colormap, t);
+        ImPlotContext& gp = *GImPlot;
+        rect.Color = gp.ColormapData.LerpTable(gp.Style.Colormap, t);
         return rect;
     }
-    const T* const Values;
+    // const T* const Values;
+    const _Indexer Indexer;
     const int Count, Rows, Cols;
     const double ScaleMin, ScaleMax, Width, Height, XRef, YRef, YDir;
     const ImPlotPoint HalfSize;
+    typedef RectC value_type;
 };
 
 template <typename T>
-void RenderHeatmap(ImDrawList& draw_list, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, bool reverse_y, bool col_maj) {
+void RenderHeatmap(ImDrawList& draw_list, IndexerIdx<T> indexer, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, bool reverse_y, bool col_maj) {
     ImPlotContext& gp = *GImPlot;
     Transformer2 transformer;
     if (scale_min == 0 && scale_max == 0) {
-        T temp_min, temp_max;
-        ImMinMaxArray(values,rows*cols,&temp_min,&temp_max);
-        scale_min = (double)temp_min;
-        scale_max = (double)temp_max;
+        ImMinMaxIndexer(indexer,rows*cols,&scale_min,&scale_max);
     }
     if (scale_min == scale_max) {
         ImVec2 a = transformer(bounds_min);
@@ -2316,15 +3121,15 @@ void RenderHeatmap(ImDrawList& draw_list, const T* values, int rows, int cols, d
     const double yref = reverse_y ? bounds_max.y : bounds_min.y;
     const double ydir = reverse_y ? -1 : 1;
     if (col_maj) {
-        GetterHeatmapColMaj<T> getter(values, rows, cols, scale_min, scale_max, (bounds_max.x - bounds_min.x) / cols, (bounds_max.y - bounds_min.y) / rows, bounds_min.x, yref, ydir);
+        GetterHeatmapColMaj<IndexerIdx<T>> getter(indexer, rows, cols, scale_min, scale_max, (bounds_max.x - bounds_min.x) / cols, (bounds_max.y - bounds_min.y) / rows, bounds_min.x, yref, ydir);
         RenderPrimitives1<RendererRectC>(getter);
     }
     else {
-        GetterHeatmapRowMaj<T> getter(values, rows, cols, scale_min, scale_max, (bounds_max.x - bounds_min.x) / cols, (bounds_max.y - bounds_min.y) / rows, bounds_min.x, yref, ydir);
+        GetterHeatmapRowMaj<IndexerIdx<T>> getter(indexer, rows, cols, scale_min, scale_max, (bounds_max.x - bounds_min.x) / cols, (bounds_max.y - bounds_min.y) / rows, bounds_min.x, yref, ydir);
         RenderPrimitives1<RendererRectC>(getter);
     }
     // labels
-    if (fmt != NULL) {
+    if (fmt != nullptr) {
         const double w = (bounds_max.x - bounds_min.x) / cols;
         const double h = (bounds_max.y - bounds_min.y) / rows;
         const ImPlotPoint half_size(w*0.5,h*0.5);
@@ -2337,9 +3142,9 @@ void RenderHeatmap(ImDrawList& draw_list, const T* values, int rows, int cols, d
                     p.y = yref + ydir * (0.5*h + r*h);
                     ImVec2 px = transformer(p);
                     char buff[32];
-                    ImFormatString(buff, 32, fmt, values[i]);
+                    ImFormatString(buff, 32, fmt, indexer[i]);
                     ImVec2 size = ImGui::CalcTextSize(buff);
-                    double t = ImClamp(ImRemap01((double)values[i], scale_min, scale_max),0.0,1.0);
+                    double t = ImClamp(ImRemap01((double)indexer[i], scale_min, scale_max),0.0,1.0);
                     ImVec4 color = SampleColormap((float)t);
                     ImU32 col = CalcTextColor(color);
                     draw_list.AddText(px - size * 0.5f, col, buff);
@@ -2355,9 +3160,9 @@ void RenderHeatmap(ImDrawList& draw_list, const T* values, int rows, int cols, d
                     p.y = yref + ydir * (0.5*h + r*h);
                     ImVec2 px = transformer(p);
                     char buff[32];
-                    ImFormatString(buff, 32, fmt, values[i]);
+                    ImFormatString(buff, 32, fmt, indexer[i]);
                     ImVec2 size = ImGui::CalcTextSize(buff);
-                    double t = ImClamp(ImRemap01((double)values[i], scale_min, scale_max),0.0,1.0);
+                    double t = ImClamp(ImRemap01((double)indexer[i], scale_min, scale_max),0.0,1.0);
                     ImVec4 color = SampleColormap((float)t);
                     ImU32 col = CalcTextColor(color);
                     draw_list.AddText(px - size * 0.5f, col, buff);
@@ -2369,15 +3174,20 @@ void RenderHeatmap(ImDrawList& draw_list, const T* values, int rows, int cols, d
 }
 
 template <typename T>
-void PlotHeatmap(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags) {
-    if (BeginItemEx(label_id, FitterRect(bounds_min, bounds_max))) {
+void PlotHeatmap(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImPlotSpec& spec) {
+    if (BeginItemEx(label_id, FitterRect(bounds_min, bounds_max), spec)) {
+        if (rows <= 0 || cols <= 0) {
+            EndItem();
+            return;
+        }
         ImDrawList& draw_list = *GetPlotDrawList();
-        const bool col_maj = ImHasFlag(flags, ImPlotHeatmapFlags_ColMajor);
-        RenderHeatmap(draw_list, values, rows, cols, scale_min, scale_max, fmt, bounds_min, bounds_max, true, col_maj);
+        const bool col_maj = ImHasFlag(spec.Flags, ImPlotHeatmapFlags_ColMajor);
+        IndexerIdx<T> indexer(values,rows*cols,spec.Offset,Stride<T>(spec));
+        RenderHeatmap(draw_list, indexer, rows, cols, scale_min, scale_max, fmt, bounds_min, bounds_max, true, col_maj);
         EndItem();
     }
 }
-#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotHeatmap<T>(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotHeatmap<T>(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
@@ -2386,30 +3196,30 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 //-----------------------------------------------------------------------------
 
 template <typename T>
-double PlotHistogram(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags) {
+double PlotHistogram(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, const ImPlotSpec& spec) {
 
-    const bool cumulative = ImHasFlag(flags, ImPlotHistogramFlags_Cumulative);
-    const bool density    = ImHasFlag(flags, ImPlotHistogramFlags_Density);
-    const bool outliers   = !ImHasFlag(flags, ImPlotHistogramFlags_NoOutliers);
+    const bool cumulative = ImHasFlag(spec.Flags, ImPlotHistogramFlags_Cumulative);
+    const bool density    = ImHasFlag(spec.Flags, ImPlotHistogramFlags_Density);
+    const bool outliers   = !ImHasFlag(spec.Flags, ImPlotHistogramFlags_NoOutliers);
+
+    IndexerIdx<T> indexer(values,count,spec.Offset,Stride<T>(spec));
 
     if (count <= 0 || bins == 0)
         return 0;
 
     if (range.Min == 0 && range.Max == 0) {
-        T Min, Max;
-        ImMinMaxArray(values, count, &Min, &Max);
-        range.Min = (double)Min;
-        range.Max = (double)Max;
+        ImMinMaxIndexer(indexer, count, &range.Min, &range.Max);
     }
 
     double width;
     if (bins < 0)
-        CalculateBins(values, count, bins, range, bins, width);
+        CalculateBins(indexer, count, bins, range, bins, width);
     else
         width = range.Size() / bins;
 
-    ImVector<double>& bin_centers = GImPlot->TempDouble1;
-    ImVector<double>& bin_counts  = GImPlot->TempDouble2;
+    ImPlotContext& gp = *GImPlot;
+    ImVector<double>& bin_centers = gp.TempDouble1;
+    ImVector<double>& bin_counts  = gp.TempDouble2;
     bin_centers.resize(bins);
     bin_counts.resize(bins);
     int below = 0;
@@ -2421,7 +3231,7 @@ double PlotHistogram(const char* label_id, const T* values, int count, int bins,
     int counted = 0;
     double max_count = 0;
     for (int i = 0; i < count; ++i) {
-        double val = (double)values[i];
+        double val = indexer[i];
         if (range.Contains(val)) {
             const int b = ImClamp((int)((val - range.Min) / width), 0, bins - 1);
             bin_counts[b] += 1.0;
@@ -2456,13 +3266,18 @@ double PlotHistogram(const char* label_id, const T* values, int count, int bins,
             bin_counts[b] *= scale;
         max_count *= scale;
     }
-    if (ImHasFlag(flags, ImPlotHistogramFlags_Horizontal))
-        PlotBars(label_id, &bin_counts.Data[0], &bin_centers.Data[0], bins, bar_scale*width, ImPlotBarsFlags_Horizontal);
-    else
-        PlotBars(label_id, &bin_centers.Data[0], &bin_counts.Data[0], bins, bar_scale*width);
+    ImPlotSpec spec_bars = spec;
+    if (ImHasFlag(spec.Flags, ImPlotHistogramFlags_Horizontal)) {
+        spec_bars.Flags = ImPlotBarsFlags_Horizontal;
+        PlotBars(label_id, &bin_counts.Data[0], &bin_centers.Data[0], bins, bar_scale*width, spec_bars);
+    }
+    else {
+        spec_bars.Flags = 0;
+        PlotBars(label_id, &bin_centers.Data[0], &bin_counts.Data[0], bins, bar_scale*width, spec_bars);
+    }
     return max_count;
 }
-#define INSTANTIATE_MACRO(T) template IMPLOT_API double PlotHistogram<T>(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
+#define INSTANTIATE_MACRO(T) template IMPLOT_API double PlotHistogram<T>(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
@@ -2471,42 +3286,40 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 //-----------------------------------------------------------------------------
 
 template <typename T>
-double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags) {
+double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count, int x_bins, int y_bins, ImPlotRect range, const ImPlotSpec& spec) {
 
     // const bool cumulative = ImHasFlag(flags, ImPlotHistogramFlags_Cumulative); NOT SUPPORTED
-    const bool density  = ImHasFlag(flags, ImPlotHistogramFlags_Density);
-    const bool outliers = !ImHasFlag(flags, ImPlotHistogramFlags_NoOutliers);
-    const bool col_maj  = ImHasFlag(flags, ImPlotHistogramFlags_ColMajor);
+    const bool density  = ImHasFlag(spec.Flags, ImPlotHistogramFlags_Density);
+    const bool outliers = !ImHasFlag(spec.Flags, ImPlotHistogramFlags_NoOutliers);
+    const bool col_maj  = ImHasFlag(spec.Flags, ImPlotHistogramFlags_ColMajor);
+
+    IndexerIdx<T> indexer_x(xs,count,spec.Offset,Stride<T>(spec));
+    IndexerIdx<T> indexer_y(ys,count,spec.Offset,Stride<T>(spec));
 
     if (count <= 0 || x_bins == 0 || y_bins == 0)
         return 0;
 
     if (range.X.Min == 0 && range.X.Max == 0) {
-        T Min, Max;
-        ImMinMaxArray(xs, count, &Min, &Max);
-        range.X.Min = (double)Min;
-        range.X.Max = (double)Max;
+        ImMinMaxIndexer(indexer_x, count, &range.X.Min, &range.X.Min);
     }
     if (range.Y.Min == 0 && range.Y.Max == 0) {
-        T Min, Max;
-        ImMinMaxArray(ys, count, &Min, &Max);
-        range.Y.Min = (double)Min;
-        range.Y.Max = (double)Max;
+        ImMinMaxIndexer(indexer_y, count, &range.Y.Min, &range.Y.Max);
     }
 
     double width, height;
     if (x_bins < 0)
-        CalculateBins(xs, count, x_bins, range.X, x_bins, width);
+        CalculateBins(indexer_x, count, x_bins, range.X, x_bins, width);
     else
         width = range.X.Size() / x_bins;
     if (y_bins < 0)
-        CalculateBins(ys, count, y_bins, range.Y, y_bins, height);
+        CalculateBins(indexer_y, count, y_bins, range.Y, y_bins, height);
     else
         height = range.Y.Size() / y_bins;
 
     const int bins = x_bins * y_bins;
 
-    ImVector<double>& bin_counts = GImPlot->TempDouble1;
+    ImPlotContext& gp = *GImPlot;
+    ImVector<double>& bin_counts = gp.TempDouble1;
     bin_counts.resize(bins);
 
     for (int b = 0; b < bins; ++b)
@@ -2515,9 +3328,9 @@ double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count
     int counted = 0;
     double max_count = 0;
     for (int i = 0; i < count; ++i) {
-        if (range.Contains((double)xs[i], (double)ys[i])) {
-            const int xb = ImClamp( (int)((double)(xs[i] - range.X.Min) / width)  , 0, x_bins - 1);
-            const int yb = ImClamp( (int)((double)(ys[i] - range.Y.Min) / height) , 0, y_bins - 1);
+        if (range.Contains(indexer_x[i], indexer_y[i])) {
+            const int xb = ImClamp( (int)((indexer_x[i] - range.X.Min) / width)  , 0, x_bins - 1);
+            const int yb = ImClamp( (int)((indexer_y[i] - range.Y.Min) / height) , 0, y_bins - 1);
             const int b  = yb * x_bins + xb;
             bin_counts[b] += 1.0;
             if (bin_counts[b] > max_count)
@@ -2532,14 +3345,19 @@ double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count
         max_count *= scale;
     }
 
-    if (BeginItemEx(label_id, FitterRect(range))) {
+    if (BeginItemEx(label_id, FitterRect(range), spec)) {
+        if (y_bins <= 0 || x_bins <= 0) {
+            EndItem();
+            return max_count;
+        }
         ImDrawList& draw_list = *GetPlotDrawList();
-        RenderHeatmap(draw_list, &bin_counts.Data[0], y_bins, x_bins, 0, max_count, NULL, range.Min(), range.Max(), false, col_maj);
+        IndexerIdx<double> indexer_bin(bin_counts.begin(), y_bins*x_bins, 0, sizeof(double));
+        RenderHeatmap(draw_list, indexer_bin, y_bins, x_bins, 0, max_count, nullptr, range.Min(), range.Max(), false, col_maj);
         EndItem();
     }
     return max_count;
 }
-#define INSTANTIATE_MACRO(T) template IMPLOT_API double PlotHistogram2D<T>(const char* label_id,   const T*   xs, const T*   ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
+#define INSTANTIATE_MACRO(T) template IMPLOT_API double PlotHistogram2D<T>(const char* label_id,   const T*   xs, const T*   ys, int count, int x_bins, int y_bins, ImPlotRect range, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
@@ -2548,10 +3366,11 @@ CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 //-----------------------------------------------------------------------------
 
 // TODO: Make this behave like all the other plot types (.e. not fixed in y axis)
+// TODO: Currently broken if x or y axis is inverted! (what should happen in this case, anyway?)
 
 template <typename Getter>
-void PlotDigitalEx(const char* label_id, Getter getter, ImPlotDigitalFlags flags) {
-    if (BeginItem(label_id, flags, ImPlotCol_Fill)) {
+void PlotDigitalEx(const char* label_id, Getter getter, const ImPlotSpec& spec) {
+    if (BeginItem(label_id, spec, spec.FillColor)) {
         ImPlotContext& gp = *GImPlot;
         ImDrawList& draw_list = *GetPlotDrawList();
         const ImPlotNextItemData& s = GetItemData();
@@ -2561,43 +3380,43 @@ void PlotDigitalEx(const char* label_id, Getter getter, ImPlotDigitalFlags flags
             ImPlotAxis& y_axis = plot.Axes[plot.CurrentY];
 
             int pixYMax = 0;
-            ImPlotPoint itemData1 = getter(0);
+            ImPlotPoint itemData1 = getter[0];
             for (int i = 0; i < getter.Count; ++i) {
-                ImPlotPoint itemData2 = getter(i);
+                ImPlotPoint itemData2 = getter[i];
                 if (ImNanOrInf(itemData1.y)) {
                     itemData1 = itemData2;
                     continue;
                 }
-                if (ImNanOrInf(itemData2.y)) itemData2.y = ImConstrainNan(ImConstrainInf(itemData2.y));
-                int pixY_0 = (int)(s.LineWeight);
+                if (ImNanOrInf(itemData2.y)) {
+                    itemData2.y = ImConstrainNan(ImConstrainInf(itemData2.y));
+                }
+                int pixY_0 = (int)(s.Spec.LineWeight);
                 itemData1.y = ImMax(0.0, itemData1.y);
-                float pixY_1_float = s.DigitalBitHeight * (float)itemData1.y;
-                int pixY_1 = (int)(pixY_1_float); //allow only positive values
-                int pixY_chPosOffset = (int)(ImMax(s.DigitalBitHeight, pixY_1_float) + s.DigitalBitGap);
+                const float pixY_1 = s.Spec.Size * (float)itemData1.y;
+                const int pixY_chPosOffset = (int)(ImMax(s.Spec.Size, pixY_1) + gp.Style.DigitalSpacing);
                 pixYMax = ImMax(pixYMax, pixY_chPosOffset);
                 ImVec2 pMin = PlotToPixels(itemData1,IMPLOT_AUTO,IMPLOT_AUTO);
                 ImVec2 pMax = PlotToPixels(itemData2,IMPLOT_AUTO,IMPLOT_AUTO);
-                int pixY_Offset = 0; //20 pixel from bottom due to mouse cursor label
-                pMin.y = (y_axis.PixelMin) + ((-gp.DigitalPlotOffset)                   - pixY_Offset);
-                pMax.y = (y_axis.PixelMin) + ((-gp.DigitalPlotOffset) - pixY_0 - pixY_1 - pixY_Offset);
+                const int pixY_Offset = (int)gp.Style.DigitalPadding;
+                const float y_ref = y_axis.IsInverted() ? y_axis.PixelMax : y_axis.PixelMin;
+                pMin.y = y_ref - (gp.DigitalPlotOffset + pixY_Offset);
+                pMax.y = y_ref - (gp.DigitalPlotOffset + pixY_0 + (int)pixY_1 + pixY_Offset);
                 //plot only one rectangle for same digital state
                 while (((i+2) < getter.Count) && (itemData1.y == itemData2.y)) {
                     const int in = (i + 1);
-                    itemData2 = getter(in);
+                    itemData2 = getter[in];
                     if (ImNanOrInf(itemData2.y)) break;
                     pMax.x = PlotToPixels(itemData2,IMPLOT_AUTO,IMPLOT_AUTO).x;
                     i++;
                 }
-                //do not extend plot outside plot range
-                if (pMin.x < x_axis.PixelMin) pMin.x = x_axis.PixelMin;
-                if (pMax.x < x_axis.PixelMin) pMax.x = x_axis.PixelMin;
-                if (pMin.x > x_axis.PixelMax) pMin.x = x_axis.PixelMax;
-                if (pMax.x > x_axis.PixelMax) pMax.x = x_axis.PixelMax;
+                // do not extend plot outside plot range
+                pMin.x = ImClamp(pMin.x, !x_axis.IsInverted() ? x_axis.PixelMin : x_axis.PixelMax, !x_axis.IsInverted() ? x_axis.PixelMax - 1 : x_axis.PixelMin - 1);
+                pMax.x = ImClamp(pMax.x, !x_axis.IsInverted() ? x_axis.PixelMin : x_axis.PixelMax, !x_axis.IsInverted() ? x_axis.PixelMax - 1 : x_axis.PixelMin - 1);
                 //plot a rectangle that extends up to x2 with y1 height
-                if ((pMax.x > pMin.x) && (gp.CurrentPlot->PlotRect.Contains(pMin) || gp.CurrentPlot->PlotRect.Contains(pMax))) {
+                if ((gp.CurrentPlot->PlotRect.Contains(pMin) || gp.CurrentPlot->PlotRect.Contains(pMax))) {
                     // ImVec4 colAlpha = item->Color;
                     // colAlpha.w = item->Highlight ? 1.0f : 0.9f;
-                    draw_list.AddRectFilled(pMin, pMax, ImGui::GetColorU32(s.Colors[ImPlotCol_Fill]));
+                    draw_list.AddRectFilled(pMin, pMax, ImGui::GetColorU32(s.Spec.FillColor));
                 }
                 itemData1 = itemData2;
             }
@@ -2610,33 +3429,37 @@ void PlotDigitalEx(const char* label_id, Getter getter, ImPlotDigitalFlags flags
 
 
 template <typename T>
-void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags, int offset, int stride) {
-    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
-    return PlotDigitalEx(label_id, getter, flags);
+void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec) {
+    GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,spec.Offset,Stride<T>(spec)),IndexerIdx<T>(ys,count,spec.Offset,Stride<T>(spec)),count);
+    return PlotDigitalEx(label_id, getter, spec);
 }
-#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotDigital<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
+#define INSTANTIATE_MACRO(T) template IMPLOT_API void PlotDigital<T>(const char* label_id, const T* xs, const T* ys, int count, const ImPlotSpec& spec);
 CALL_INSTANTIATE_FOR_NUMERIC_TYPES()
 #undef INSTANTIATE_MACRO
 
 // custom
-void PlotDigitalG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotDigitalFlags flags) {
+void PlotDigitalG(const char* label_id, ImPlotGetter getter_func, void* data, int count, const ImPlotSpec& spec) {
     GetterFuncPtr getter(getter_func,data,count);
-    return PlotDigitalEx(label_id, getter, flags);
+    return PlotDigitalEx(label_id, getter, spec);
 }
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotImage
 //-----------------------------------------------------------------------------
 
-void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bmin, const ImPlotPoint& bmax, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, ImPlotImageFlags) {
-    if (BeginItemEx(label_id, FitterRect(bmin,bmax))) {
+#ifdef IMGUI_HAS_TEXTURES
+void PlotImage(const char* label_id, ImTextureRef tex_ref, const ImPlotPoint& bmin, const ImPlotPoint& bmax, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImPlotSpec& spec) {
+#else
+void PlotImage(const char* label_id, ImTextureID tex_ref, const ImPlotPoint& bmin, const ImPlotPoint& bmax, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImPlotSpec& spec) {
+#endif
+    if (BeginItemEx(label_id, FitterRect(bmin,bmax), spec)) {
         ImU32 tint_col32 = ImGui::ColorConvertFloat4ToU32(tint_col);
         GetCurrentItem()->Color = tint_col32;
         ImDrawList& draw_list = *GetPlotDrawList();
         ImVec2 p1 = PlotToPixels(bmin.x, bmax.y,IMPLOT_AUTO,IMPLOT_AUTO);
         ImVec2 p2 = PlotToPixels(bmax.x, bmin.y,IMPLOT_AUTO,IMPLOT_AUTO);
         PushPlotClipRect();
-        draw_list.AddImage(user_texture_id, p1, p2, uv0, uv1, tint_col32);
+        draw_list.AddImage(tex_ref, p1, p2, uv0, uv1, tint_col32);
         PopPlotClipRect();
         EndItem();
     }
@@ -2646,17 +3469,17 @@ void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPo
 // [SECTION] PlotText
 //-----------------------------------------------------------------------------
 
-void PlotText(const char* text, double x, double y, const ImVec2& pixel_offset, ImPlotTextFlags flags) {
-    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != NULL, "PlotText() needs to be called between BeginPlot() and EndPlot()!");
+void PlotText(const char* text, double x, double y, const ImVec2& pixel_offset, const ImPlotSpec& spec) {
+    IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "PlotText() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
     ImDrawList & draw_list = *GetPlotDrawList();
     PushPlotClipRect();
     ImU32 colTxt = GetStyleColorU32(ImPlotCol_InlayText);
-    if (ImHasFlag(flags,ImPlotTextFlags_Vertical)) {
+    if (ImHasFlag(spec.Flags,ImPlotTextFlags_Vertical)) {
         ImVec2 siz = CalcTextSizeVertical(text) * 0.5f;
         ImVec2 ctr = siz * 0.5f;
         ImVec2 pos = PlotToPixels(ImPlotPoint(x,y),IMPLOT_AUTO,IMPLOT_AUTO) + ImVec2(-ctr.x, ctr.y) + pixel_offset;
-        if (FitThisFrame()) {
+        if (FitThisFrame() && !ImHasFlag(spec.Flags, ImPlotItemFlags_NoFit)) {
             FitPoint(PixelsToPlot(pos));
             FitPoint(PixelsToPlot(pos.x + siz.x, pos.y - siz.y));
         }
@@ -2665,7 +3488,7 @@ void PlotText(const char* text, double x, double y, const ImVec2& pixel_offset, 
     else {
         ImVec2 siz = ImGui::CalcTextSize(text);
         ImVec2 pos = PlotToPixels(ImPlotPoint(x,y),IMPLOT_AUTO,IMPLOT_AUTO) - siz * 0.5f + pixel_offset;
-        if (FitThisFrame()) {
+        if (FitThisFrame() && !ImHasFlag(spec.Flags, ImPlotItemFlags_NoFit)) {
             FitPoint(PixelsToPlot(pos));
             FitPoint(PixelsToPlot(pos+siz));
         }
@@ -2678,9 +3501,19 @@ void PlotText(const char* text, double x, double y, const ImVec2& pixel_offset, 
 // [SECTION] PlotDummy
 //-----------------------------------------------------------------------------
 
-void PlotDummy(const char* label_id, ImPlotDummyFlags flags) {
-    if (BeginItem(label_id, flags, ImPlotCol_Line))
+void PlotDummy(const char* label_id, const ImPlotSpec& spec) {
+    // Pick the first non-auto color from the spec to override the legend icon color
+    ImVec4 item_col = spec.LineColor;
+    if (IsColorAuto(item_col))
+        item_col = spec.FillColor;
+    if (IsColorAuto(item_col))
+        item_col = spec.MarkerLineColor;
+    if (IsColorAuto(item_col))
+        item_col = spec.MarkerFillColor;
+    if (BeginItem(label_id, spec, item_col, spec.Marker))
         EndItem();
 }
 
 } // namespace ImPlot
+
+#endif // #ifndef IMGUI_DISABLE

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -93,6 +93,10 @@ add_file_folder("Test Util"
     util/test_util.h
 )
 
+add_file_folder("Tracing"
+    tracing/test_frame_profiler.cpp
+)
+
 add_file_folder("Utils"
     utils/HeapAllocatorTest.cpp
 )

--- a/test/src/tracing/test_frame_profiler.cpp
+++ b/test/src/tracing/test_frame_profiler.cpp
@@ -18,16 +18,13 @@ trace_event make_event(const Category& category, EventType type, uint64_t timest
 	return evt;
 }
 
-// Small helper to size the output buffers and run the function under test.
+// Small helper to run the function under test and look results up by category.
 struct self_time_result {
 	SCP_vector<uint64_t> by_id;
-	SCP_vector<const Category*> category_by_id;
 	uint64_t total = 0;
 
-	explicit self_time_result(const SCP_vector<trace_event>& events)
-		: by_id(static_cast<size_t>(Category::getCount()), 0),
-		  category_by_id(static_cast<size_t>(Category::getCount()), nullptr) {
-		accumulate_self_times(events, by_id, category_by_id, total);
+	explicit self_time_result(const SCP_vector<trace_event>& events) {
+		total = accumulate_self_times(events, by_id);
 	}
 
 	uint64_t self(const Category& c) const { return by_id[static_cast<size_t>(c.getId())]; }
@@ -122,4 +119,44 @@ TEST(FrameProfilerSelfTime, empty_input)
 	SCP_vector<trace_event> events;
 	self_time_result r(events);
 	EXPECT_EQ(r.total, 0u);
+}
+
+// The output buffer is meant to be reused across frames, so a run must not see the previous run's
+// totals. (processFrame() keeps one buffer alive for the life of the profiler.)
+TEST(FrameProfilerSelfTime, reused_buffer_is_cleared)
+{
+	SCP_vector<uint64_t> by_id;
+
+	SCP_vector<trace_event> first{
+		make_event(Physics, EventType::Begin, 0),
+		make_event(Physics, EventType::End, 10),
+	};
+	EXPECT_EQ(accumulate_self_times(first, by_id), 10u);
+	EXPECT_EQ(by_id[static_cast<size_t>(Physics.getId())], 10u);
+
+	SCP_vector<trace_event> second{
+		make_event(Physics, EventType::Begin, 0),
+		make_event(Physics, EventType::End, 3),
+	};
+	EXPECT_EQ(accumulate_self_times(second, by_id), 3u);
+	EXPECT_EQ(by_id[static_cast<size_t>(Physics.getId())], 3u);
+
+	// An empty frame must zero it rather than leave the previous frame's numbers behind.
+	SCP_vector<trace_event> empty;
+	EXPECT_EQ(accumulate_self_times(empty, by_id), 0u);
+	EXPECT_EQ(by_id[static_cast<size_t>(Physics.getId())], 0u);
+}
+
+// Ids are dense and the registry round-trips them, which is what lets the overlay snapshot drop
+// the parallel id -> Category* array.
+TEST(TracingCategory, id_round_trips_through_registry)
+{
+	ASSERT_GT(Category::getCount(), 0);
+
+	for (int id = 0; id < Category::getCount(); id++) {
+		EXPECT_EQ(Category::getById(id).getId(), id);
+	}
+
+	EXPECT_EQ(&Category::getById(Physics.getId()), &Physics);
+	EXPECT_EQ(&Category::getById(PostMove.getId()), &PostMove);
 }

--- a/test/src/tracing/test_frame_profiler.cpp
+++ b/test/src/tracing/test_frame_profiler.cpp
@@ -1,0 +1,125 @@
+//
+//
+
+#include <gtest/gtest.h>
+
+#include "tracing/FrameProfiler.h"
+#include "tracing/categories.h"
+
+using namespace tracing;
+
+namespace {
+
+trace_event make_event(const Category& category, EventType type, uint64_t timestamp) {
+	trace_event evt;
+	evt.category = &category;
+	evt.type = type;
+	evt.timestamp = timestamp;
+	return evt;
+}
+
+// Small helper to size the output buffers and run the function under test.
+struct self_time_result {
+	SCP_vector<uint64_t> by_id;
+	SCP_vector<const Category*> category_by_id;
+	uint64_t total = 0;
+
+	explicit self_time_result(const SCP_vector<trace_event>& events)
+		: by_id(static_cast<size_t>(Category::getCount()), 0),
+		  category_by_id(static_cast<size_t>(Category::getCount()), nullptr) {
+		accumulate_self_times(events, by_id, category_by_id, total);
+	}
+
+	uint64_t self(const Category& c) const { return by_id[static_cast<size_t>(c.getId())]; }
+};
+
+} // namespace
+
+// Parent fully contains a child: the child's interval is exclusive to the child, the rest is the
+// parent's self-time.
+TEST(FrameProfilerSelfTime, nested_scope)
+{
+	SCP_vector<trace_event> events{
+		make_event(Physics, EventType::Begin, 0),
+		make_event(PostMove, EventType::Begin, 5),
+		make_event(PostMove, EventType::End, 8),
+		make_event(Physics, EventType::End, 10),
+	};
+
+	self_time_result r(events);
+
+	EXPECT_EQ(r.self(Physics), 7u);  // [0,5) + [8,10)
+	EXPECT_EQ(r.self(PostMove), 3u); // [5,8)
+	EXPECT_EQ(r.total, 10u);
+}
+
+// Two top-level scopes with an idle gap between them: the gap belongs to no scope and must be
+// excluded from both the per-category totals and the frame total.
+TEST(FrameProfilerSelfTime, gap_between_top_level_scopes)
+{
+	SCP_vector<trace_event> events{
+		make_event(Physics, EventType::Begin, 0),
+		make_event(Physics, EventType::End, 3),
+		// gap [3, 10)
+		make_event(PostMove, EventType::Begin, 10),
+		make_event(PostMove, EventType::End, 15),
+	};
+
+	self_time_result r(events);
+
+	EXPECT_EQ(r.self(Physics), 3u);
+	EXPECT_EQ(r.self(PostMove), 5u);
+	EXPECT_EQ(r.total, 8u); // gap of 7 excluded
+}
+
+// The same category nested within itself (recursion). All time is still attributed to that one
+// category; the old tree-based path would have tripped its "max 1 open" assert here.
+TEST(FrameProfilerSelfTime, recursion_same_category)
+{
+	SCP_vector<trace_event> events{
+		make_event(Physics, EventType::Begin, 0),
+		make_event(Physics, EventType::Begin, 3),
+		make_event(Physics, EventType::End, 7),
+		make_event(Physics, EventType::End, 10),
+	};
+
+	self_time_result r(events);
+
+	EXPECT_EQ(r.self(Physics), 10u);
+	EXPECT_EQ(r.total, 10u);
+}
+
+// A parent with two sibling children. Verifies the parent's self-time correctly excludes both
+// children and that the frame total equals the sum of every category's self-time.
+TEST(FrameProfilerSelfTime, siblings_sum_to_total)
+{
+	SCP_vector<trace_event> events{
+		make_event(MoveObjects, EventType::Begin, 0),
+		make_event(Physics, EventType::Begin, 2),
+		make_event(Physics, EventType::End, 7),
+		make_event(PostMove, EventType::Begin, 10),
+		make_event(PostMove, EventType::End, 14),
+		make_event(MoveObjects, EventType::End, 20),
+	};
+
+	self_time_result r(events);
+
+	EXPECT_EQ(r.self(Physics), 5u);
+	EXPECT_EQ(r.self(PostMove), 4u);
+	EXPECT_EQ(r.self(MoveObjects), 11u); // [0,2) + [7,10) + [14,20)
+
+	uint64_t sum = 0;
+	for (uint64_t v : r.by_id) {
+		sum += v;
+	}
+	EXPECT_EQ(sum, r.total);
+	EXPECT_EQ(r.total, 20u);
+}
+
+// Empty input must be handled gracefully.
+TEST(FrameProfilerSelfTime, empty_input)
+{
+	SCP_vector<trace_event> events;
+	self_time_result r(events);
+	EXPECT_EQ(r.total, 0u);
+}

--- a/test/src/utils/HeapAllocatorTest.cpp
+++ b/test/src/utils/HeapAllocatorTest.cpp
@@ -24,6 +24,40 @@ TEST(HeapAllocatorTests, simpleAllocate) {
 	ASSERT_EQ((size_t)0, allocator.numAllocations());
 }
 
+TEST(HeapAllocatorTests, usedBytesAndHeapSize) {
+	HeapAllocator allocator(dummyResizer);
+
+	ASSERT_EQ((size_t)0, allocator.usedBytes());
+	ASSERT_GT(allocator.heapSize(), (size_t)0);
+
+	auto initialHeapSize = allocator.heapSize();
+
+	auto offsetA = allocator.allocate(200);
+	ASSERT_EQ((size_t)200, allocator.usedBytes());
+
+	auto offsetB = allocator.allocate(300);
+	ASSERT_EQ((size_t)500, allocator.usedBytes());
+
+	// Allocations within the initial heap size shouldn't have triggered a resize
+	ASSERT_EQ(initialHeapSize, allocator.heapSize());
+
+	allocator.free(offsetA);
+	ASSERT_EQ((size_t)300, allocator.usedBytes());
+
+	allocator.free(offsetB);
+	ASSERT_EQ((size_t)0, allocator.usedBytes());
+
+	// Force at least one resize and make sure usedBytes tracks the live allocation, not the
+	// (now larger) heap size
+	auto offsetC = allocator.allocate(30 * 1024 * 1024);
+	ASSERT_EQ((size_t)30 * 1024 * 1024, allocator.usedBytes());
+	ASSERT_GT(allocator.heapSize(), initialHeapSize);
+	ASSERT_GE(allocator.heapSize(), allocator.usedBytes());
+
+	allocator.free(offsetC);
+	ASSERT_EQ((size_t)0, allocator.usedBytes());
+}
+
 TEST(HeapAllocatorTests, manySmallAllocations) {
 	HeapAllocator allocator(dummyResizer);
 


### PR DESCRIPTION
This branch contains two related pieces of work: an in-game ImGui frame profiler
overlay, and a Vulkan descriptor-set optimisation that the overlay was used to
find and verify.

## 1. ImGui frame profiler overlay

Vendors ImPlot (`lib/implot/`, updated to the v1.1 WIP) and adds a runtime frame
profiler overlay on top of the existing `tracing` infrastructure:

- `code/tracing/ProfilerOverlay.{h,cpp}` — the overlay itself: a frametime history
  plot plus a breakdown of the biggest per-category contributors to the frame.
- `FrameProfiler` gains `accumulate_self_times()`, computing per-category
  *exclusive* (self) time for a frame's trace events in a single pass over the
  event stream, rather than building a tree and comparing strings. Split out so it
  can be unit-tested directly — see `test/src/tracing/test_frame_profiler.cpp`.
- Toggleable at runtime via the `Game.ProfilerOverlay` option; `-profile_frame_time`
  still works and now seeds the same toggle.
- Adds graphics/Vulkan debug counters (draw calls, descriptor sets and writes,
  pipeline count) to the overlay.

## 2. Vulkan: stop per-draw descriptor set churn

The Material and PerDraw descriptor sets were being reallocated and fully
rewritten on essentially every draw call. `model_draw_list::render_buffer` rebinds
`ModelData` with a fresh uniform buffer offset for each queued draw, and that
offset was part of the Material set's memoization key, so the cache in
`VulkanDrawManager::applyMaterial` missed every time — taking a frame-pool
allocation, a full template write, the 16-entry material texture resolution and a
`vkUpdateDescriptorSets` with it. `GenericData`/`Matrices` did the same to the
PerDraw set. `renderShadowDraw` was worse still: all three sets allocated and
rewritten per shadow draw, with no memoization at all.

The fix declares the bindings whose offset moves per draw
(`MaterialBinding::ModelData`, `MaterialBinding::ShadowMapData`,
`PerDrawBinding::GenericData`, `PerDrawBinding::Matrices`) as
`eUniformBufferDynamic`. `DescriptorWriter::setBuffer` splits a dynamic binding's
offset out of the descriptor — writing `{buffer, 0, range}` and stashing the offset
for `vkCmdBindDescriptorSets`' `pDynamicOffsets` — so an offset-only change leaves
the set's contents identical and the memoization caches start hitting.
**Shader sources are unchanged.**

`VulkanStateTracker::bindDescriptorSet` now compares the dynamic offsets as well as
the set handle. That part is required rather than an optimisation: the common case
is now the *same* set rebound with a new offset, and the old handle-only redundancy
check would have skipped that bind and fed every draw the previous draw's uniforms.

Also switches `allocateFrameSet` to the non-allocating `allocateDescriptorSets`
overload (the vector-returning one heap-allocated once per set, thousands of times
a frame). `MAX_SETS_PER_POOL` is deliberately left at 1024 — the per-frame pool
growth it used to log was a symptom of the churn, and one chunk now covers a dense
scene outright.

### Measured

Solaris mission 21 (large asteroid field, ~1370 model draws/frame), RTX 4080 SUPER
at 1080p. Debug build, A/B on the same tree with and without the change:

| | before | after |
|---|---|---|
| descriptor sets / frame | 2566 | **250–345** |
| descriptor writes / frame | 19107 | **~1700–2300** |
| median frametime (2 runs each) | 92.9 / 83.6 ms | **72.0 / 66.5 ms** |
| `Render Buffer` (overlay) | 24.68 ms (30.8%) | **12.73 ms (18.4%)** |
| `Build Shadow Map` (overlay) | 5.44 ms | off the top-5 entirely |
| `frame pool exhausted` log lines | every frame | 0 |

Release builds already inlined most of this per-draw work away and are unchanged
within run-to-run noise, which is the expected result — `Render Buffer` costs only
~1.4 µs/draw there. Worth noting: neither Release run happened to reach the heavy
>600-draw stretch of the mission, so Release behaviour at very high draw counts is
untested; the draw-count bins that do overlap show no regression.

### Testing

- Renders identically before/after at the same mission point (models, lighting,
  HUD, shadows) — no wrong-uniform corruption.
- Run under `-gr_sync_validation -gr_debug`: the set of reported VUIDs is identical
  to the same build without the change. No descriptor or dynamic-offset VUIDs.
- `unittests` 233/233 pass.
- Compiles warning-clean with `-DFSO_FATAL_WARNINGS=ON` (GCC).
- OpenGL is untouched by part 2.
