### PR TITLE
QtFRED fix and align keyboard shortcuts with FRED2

### DIFF
--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -1297,7 +1297,9 @@ void FredView::initializeTransformBar() {
 	_transformLocalBtn->setCheckable(true);
 	_transformLocalBtn->setToolButtonStyle(Qt::ToolButtonIconOnly);
 	_transformLocalBtn->setFixedSize(28, 24);
-	_transformLocalBtn->setToolTip(tr("Local mode: in multi-selection, apply position/orientation as a delta to each object rather than setting all to the same absolute value."));
+	_transformLocalBtn->setToolTip(tr("Local mode: in multi-selection, apply position/orientation as a delta to each object rather than setting all to the same absolute value. (X)"));
+	// FRED2 bound "Rotate Locally" to the X key; route it through the button so the per-mode local memory stays in sync.
+	_transformLocalBtn->setShortcut(QKeySequence(Qt::Key_X));
 	bindThemeIcon(_transformLocalBtn, QStringLiteral("rotlocal"));
 	_transformToolBar->addWidget(_transformLocalBtn);
 	connect(_transformLocalBtn, &QToolButton::toggled, this, [this](bool checked) {
@@ -2427,6 +2429,16 @@ void FredView::on_actionCurrent_Ship_triggered(bool enabled) {
 
 		_viewport->needsUpdate();
 	}
+}
+void FredView::on_actionToggle_Viewpoint_triggered(bool) {
+	// Flip between the camera viewpoint (0) and the current ship's viewpoint (1).
+	if (_viewport->camera.getViewpoint() != 0 || !query_valid_object(fred->currentObject)) {
+		_viewport->camera.setViewpoint(0);
+	} else {
+		_viewport->camera.setViewpoint(1);
+		_viewport->camera.setViewObj(fred->currentObject);
+	}
+	_viewport->needsUpdate();
 }
 void FredView::on_actionControlModeCamera_triggered(bool enabled) {
 	if (enabled) {

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -114,6 +114,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 
 	void on_actionCamera_triggered(bool enabled);
 	void on_actionCurrent_Ship_triggered(bool enabled);
+	void on_actionToggle_Viewpoint_triggered(bool);
 
 	void on_actionMission_Events_triggered(bool);
 	void on_actionMission_Cutscenes_triggered(bool);

--- a/qtfred/src/ui/dialogs/JumpNodeEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/JumpNodeEditorDialog.cpp
@@ -1,5 +1,7 @@
 #include "ui/dialogs/JumpNodeEditorDialog.h"
 #include "ui/util/SignalBlockers.h"
+
+#include <QShortcut>
 #include "ui_JumpNodeEditorDialog.h"
 
 #include <globalincs/globals.h>
@@ -15,6 +17,12 @@ JumpNodeEditorDialog::JumpNodeEditorDialog(FredView* parent, EditorViewport* vie
 {
 	this->setFocus();
 	ui->setupUi(this);
+
+	// F6 / Shift+F6 cycle to the next / previous jump node, mirroring the Next/Prev buttons.
+	auto* nextShortcut = new QShortcut(QKeySequence(Qt::Key_F6), this);
+	connect(nextShortcut, &QShortcut::activated, this, [this] { ui->nextNodeButton->click(); });
+	auto* prevShortcut = new QShortcut(QKeySequence(QStringLiteral("Shift+F6")), this);
+	connect(prevShortcut, &QShortcut::activated, this, [this] { ui->prevNodeButton->click(); });
 
 	ui->nameLineEdit->setMaxLength(NAME_LENGTH - 1);
 	ui->displayNameLineEdit->setMaxLength(NAME_LENGTH - 1);

--- a/qtfred/src/ui/dialogs/MissionCutscenesDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionCutscenesDialog.cpp
@@ -1,4 +1,5 @@
 #include <QtWidgets/QMessageBox>
+#include <QShortcut>
 #include "MissionCutscenesDialog.h"
 
 #include "ui/util/SignalBlockers.h"
@@ -22,6 +23,12 @@ MissionCutscenesDialog::MissionCutscenesDialog(QWidget* parent, EditorViewport* 
 
 	ui->helpTextBox->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 	ui->helpTextBox->setVisible(viewport->Show_sexp_help_mission_cutscenes);
+
+	// Shift+F1 toggles the sexp help pane for this session without changing the saved preference.
+	auto* helpToggle = new QShortcut(QKeySequence(QStringLiteral("Shift+F1")), this);
+	connect(helpToggle, &QShortcut::activated, this, [this] {
+		ui->helpTextBox->setVisible(!ui->helpTextBox->isVisible());
+	});
 
 	connect(_model.get(), &MissionCutscenesDialogModel::modelChanged, this, &MissionCutscenesDialog::updateUi);
 	connect(ui->cutsceneEventTree, &sexp_tree_view::modified, this, [this] { _model->setModified(); });

--- a/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
@@ -1,5 +1,7 @@
 #include "MissionEventsDialog.h"
 #include "ui_MissionEventsDialog.h"
+
+#include <QShortcut>
 #include "ui/Theme.h"
 #include "ui/util/default_dir.h"
 #include "ui/util/SignalBlockers.h"
@@ -205,6 +207,14 @@ void MissionEventsDialog::initEventWidgets() {
 
 	ui->miniHelpBox->setVisible(_viewport->Show_sexp_help_mission_events);
 	ui->helpBox->setVisible(_viewport->Show_sexp_help_mission_events);
+
+	// Shift+F1 toggles the sexp help panes for this session without changing the saved preference.
+	auto* helpToggle = new QShortcut(QKeySequence(QStringLiteral("Shift+F1")), this);
+	connect(helpToggle, &QShortcut::activated, this, [this] {
+		const bool show = !ui->helpBox->isVisible();
+		ui->miniHelpBox->setVisible(show);
+		ui->helpBox->setVisible(show);
+	});
 
 	// connect the sexp tree stuff
 	connect(ui->eventTree, &sexp_tree_view::modified, this, [this]() { _model->setModified(); });

--- a/qtfred/src/ui/dialogs/MissionGoalsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionGoalsDialog.cpp
@@ -1,4 +1,5 @@
 #include <QtWidgets/QMessageBox>
+#include <QShortcut>
 #include "MissionGoalsDialog.h"
 
 #include "ui/util/SignalBlockers.h"
@@ -20,6 +21,12 @@ MissionGoalsDialog::MissionGoalsDialog(QWidget* parent, EditorViewport* viewport
 
 	ui->helpTextBox->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 	ui->helpTextBox->setVisible(viewport->Show_sexp_help_mission_goals);
+
+	// Shift+F1 toggles the sexp help pane for this session without changing the saved preference.
+	auto* helpToggle = new QShortcut(QKeySequence(QStringLiteral("Shift+F1")), this);
+	connect(helpToggle, &QShortcut::activated, this, [this] {
+		ui->helpTextBox->setVisible(!ui->helpTextBox->isVisible());
+	});
 
 	connect(_model.get(), &MissionGoalsDialogModel::modelChanged, this, &MissionGoalsDialog::updateUi);
 	connect(ui->goalEventTree, &sexp_tree_view::modified, this, [this] { _model->setModified(); });

--- a/qtfred/src/ui/dialogs/PropEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/PropEditorDialog.cpp
@@ -11,12 +11,19 @@
 #include <ui/widgets/FlagList.h>
 
 #include <QMetaObject>
+#include <QShortcut>
 
 namespace fso::fred::dialogs {
 
 PropEditorDialog::PropEditorDialog(FredView* parent, EditorViewport* viewport)
 	: QDialog(parent), ui(new ::Ui::PropEditorDialog()), _model(new PropEditorDialogModel(this, viewport)), _viewport(viewport) {
 	ui->setupUi(this);
+
+	// F6 / Shift+F6 cycle to the next / previous prop, mirroring the Next/Prev buttons.
+	auto* nextShortcut = new QShortcut(QKeySequence(Qt::Key_F6), this);
+	connect(nextShortcut, &QShortcut::activated, this, [this] { ui->nextButton->click(); });
+	auto* prevShortcut = new QShortcut(QKeySequence(QStringLiteral("Shift+F6")), this);
+	connect(prevShortcut, &QShortcut::activated, this, [this] { ui->prevButton->click(); });
 
 	ui->propNameLineEdit->setMaxLength(NAME_LENGTH - 1);
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -14,6 +14,7 @@
 
 #include <ui/dialogs/General/CheckBoxListDialog.h>
 #include <QVariant>
+#include <QShortcut>
 
 namespace fso::fred::dialogs {
 
@@ -24,8 +25,25 @@ ShipEditorDialog::ShipEditorDialog(FredView* parent, EditorViewport* viewport)
 {
 	this->setFocus();
 	ui->setupUi(this);
-	ui->HelpTitle->setVisible(viewport->Show_sexp_help_ship_editor);
-	ui->helpText->setVisible(viewport->Show_sexp_help_ship_editor);
+	_show_sexp_help = viewport->Show_sexp_help_ship_editor;
+	ui->HelpTitle->setVisible(_show_sexp_help);
+	ui->helpText->setVisible(_show_sexp_help);
+
+	// Shift+F1 toggles the sexp help pane for this session without changing the saved preference.
+	auto* helpToggle = new QShortcut(QKeySequence(QStringLiteral("Shift+F1")), this);
+	connect(helpToggle, &QShortcut::activated, this, [this] {
+		_show_sexp_help = !_show_sexp_help;
+		ui->HelpTitle->setVisible(!_cues_hidden && _show_sexp_help);
+		ui->helpText->setVisible(!_cues_hidden && _show_sexp_help);
+		QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+		resize(sizeHint());
+	});
+
+	// F6 / Shift+F6 cycle to the next / previous ship, mirroring the Next/Prev buttons.
+	auto* nextShortcut = new QShortcut(QKeySequence(Qt::Key_F6), this);
+	connect(nextShortcut, &QShortcut::activated, this, [this] { ui->nextButton->click(); });
+	auto* prevShortcut = new QShortcut(QKeySequence(QStringLiteral("Shift+F6")), this);
+	connect(prevShortcut, &QShortcut::activated, this, [this] { ui->prevButton->click(); });
 
 	ui->shipNameEdit->setMaxLength(NAME_LENGTH - 1);
 	ui->shipDisplayNameEdit->setMaxLength(NAME_LENGTH - 1);
@@ -666,7 +684,7 @@ void ShipEditorDialog::on_specialStatsButton_clicked()
 }
 void ShipEditorDialog::on_hideCuesButton_clicked()
 {
-	const auto showHelp = _viewport->Show_sexp_help_ship_editor;
+	const auto showHelp = _show_sexp_help;
 
 	_cues_hidden = !_cues_hidden;
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
@@ -98,6 +98,7 @@ class ShipEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	EditorViewport* _viewport;
 
 	bool _cues_hidden = false;
+	bool _show_sexp_help = false; // session-local help visibility, seeded from the saved preference
 
 	void initializeUi();
 	void updateUi();

--- a/qtfred/src/ui/dialogs/WaypointEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WaypointEditorDialog.cpp
@@ -1,4 +1,5 @@
 #include <QtWidgets/QTextEdit>
+#include <QShortcut>
 #include "ui/dialogs/WaypointEditorDialog.h"
 #include "ui/util/SignalBlockers.h"
 #include "ui_WaypointEditorDialog.h"
@@ -19,6 +20,12 @@ WaypointEditorDialog::WaypointEditorDialog(FredView* parent, EditorViewport* vie
 {
 	this->setFocus();
 	ui->setupUi(this);
+
+	// F6 / Shift+F6 cycle to the next / previous waypoint path, mirroring the Next/Prev buttons.
+	auto* nextShortcut = new QShortcut(QKeySequence(Qt::Key_F6), this);
+	connect(nextShortcut, &QShortcut::activated, this, [this] { ui->nextPathButton->click(); });
+	auto* prevShortcut = new QShortcut(QKeySequence(QStringLiteral("Shift+F6")), this);
+	connect(prevShortcut, &QShortcut::activated, this, [this] { ui->prevPathButton->click(); });
 
 	ui->nameEdit->setMaxLength(NAME_LENGTH - 1);
 

--- a/qtfred/src/ui/dialogs/WingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.cpp
@@ -10,6 +10,7 @@
 #include <ship/ship.h>
 #include <ui/util/SignalBlockers.h>
 #include <ui/util/ImageRenderer.h>
+#include <QShortcut>
 #include <ui/util/menu.h>
 #include <QMessageBox>
 
@@ -22,8 +23,25 @@ WingEditorDialog::WingEditorDialog(FredView* parent, EditorViewport* viewport)
 {
 	ui->setupUi(this);
 
-	ui->HelpTitle->setVisible(viewport->Show_sexp_help_wing_editor);
-	ui->helpText->setVisible(viewport->Show_sexp_help_wing_editor);
+	_show_sexp_help = viewport->Show_sexp_help_wing_editor;
+	ui->HelpTitle->setVisible(_show_sexp_help);
+	ui->helpText->setVisible(_show_sexp_help);
+
+	// Shift+F1 toggles the sexp help pane for this session without changing the saved preference.
+	auto* helpToggle = new QShortcut(QKeySequence(QStringLiteral("Shift+F1")), this);
+	connect(helpToggle, &QShortcut::activated, this, [this] {
+		_show_sexp_help = !_show_sexp_help;
+		ui->HelpTitle->setVisible(!_cues_hidden && _show_sexp_help);
+		ui->helpText->setVisible(!_cues_hidden && _show_sexp_help);
+		QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+		resize(sizeHint());
+	});
+
+	// F6 / Shift+F6 cycle to the next / previous wing, mirroring the Next/Prev buttons.
+	auto* nextShortcut = new QShortcut(QKeySequence(Qt::Key_F6), this);
+	connect(nextShortcut, &QShortcut::activated, this, [this] { ui->nextWingButton->click(); });
+	auto* prevShortcut = new QShortcut(QKeySequence(QStringLiteral("Shift+F6")), this);
+	connect(prevShortcut, &QShortcut::activated, this, [this] { ui->prevWingButton->click(); });
 
 	ui->wingNameEdit->setMaxLength(NAME_LENGTH - 1);
 	ui->wingDisplayNameEdit->setMaxLength(NAME_LENGTH - 1);
@@ -366,8 +384,8 @@ void WingEditorDialog::initializeUi()
 
 void WingEditorDialog::on_hideCuesButton_clicked()
 {
-	const auto showHelp = _viewport->Show_sexp_help_wing_editor;
-	
+	const auto showHelp = _show_sexp_help;
+
 	_cues_hidden = !_cues_hidden;
 	
 	ui->arrivalGroupBox->setVisible(!_cues_hidden);

--- a/qtfred/src/ui/dialogs/WingEditorDialog.h
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.h
@@ -78,6 +78,7 @@ class WingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	EditorViewport* _viewport;
 
 	bool _cues_hidden = false;
+	bool _show_sexp_help = false; // session-local help visibility, seeded from the saved preference
 
 	void initializeUi();
 	void updateUi();

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -89,6 +89,8 @@
      </property>
      <addaction name="actionCamera"/>
      <addaction name="actionCurrent_Ship"/>
+     <addaction name="separator"/>
+     <addaction name="actionToggle_Viewpoint"/>
     </widget>
     <addaction name="actionSceneBrowser"/>
     <addaction name="separator"/>
@@ -488,9 +490,6 @@
    <property name="toolTip">
     <string>Prevent selection from changing (Spacebar)</string>
    </property>
-   <property name="shortcut">
-    <string>Space</string>
-   </property>
   </action>
   <action name="actionWingForm">
    <property name="text">
@@ -545,9 +544,6 @@
    </property>
    <property name="toolTip">
     <string>Show Distances (D)</string>
-   </property>
-   <property name="shortcut">
-    <string>D</string>
    </property>
   </action>
   <action name="actionOrbitSelected">
@@ -878,6 +874,17 @@
     <string>Current &amp;Ship</string>
    </property>
   </action>
+  <action name="actionToggle_Viewpoint">
+   <property name="text">
+    <string>&amp;Toggle Viewpoint</string>
+   </property>
+   <property name="toolTip">
+    <string>Toggle between the camera and the current ship's viewpoint (Ctrl+Shift+V)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+V</string>
+   </property>
+  </action>
   <action name="actionx1">
    <property name="checkable">
     <bool>true</bool>
@@ -1049,6 +1056,9 @@
    <property name="text">
     <string>Props</string>
    </property>
+   <property name="shortcut">
+    <string>Shift+P</string>
+   </property>
   </action>
   <action name="actionWaypoint_Paths">
    <property name="text">
@@ -1076,7 +1086,7 @@
     <string>&amp;Team Loadout</string>
    </property>
    <property name="shortcut">
-    <string>Shift+P</string>
+    <string>Shift+L</string>
    </property>
   </action>
   <action name="actionBackground">
@@ -1146,6 +1156,9 @@
   <action name="actionShield_System">
    <property name="text">
     <string>Shie&amp;ld System</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+M</string>
    </property>
   </action>
   <action name="actionSet_Global_Ship_Flags">
@@ -1458,6 +1471,9 @@
   <action name="actionVolumetric_Nebula">
    <property name="text">
     <string>Volumetric Nebula</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+U</string>
    </property>
   </action>
   <action name="actionCalculate_Relative_Coordinates">


### PR DESCRIPTION
Fix reported bug where pressing D did not toggle Show Distances: the menu and toolbar actions both claimed D, producing an ambiguous shortcut overload. Removed the duplicate from the toolbar action. Applied the same fix to Space (Selection Lock), which was owned by both a QAction and the configurable ControlBindings.

Restore/align several FRED2 shortcuts and reshuffle dialog keys slightly so all dialogs have a SHIFT-KEY:
- X = Rotate Locally (routed through the transform local-axes button)
- Shift+P = Props
- Shift+L = Team Loadout (Team Loadout is a change from FRED2, but one worth making, I think. It frees up Shift+P for Props)
- Shift+V = Variables & Containers
- Ctrl+Shift+V = Toggle Viewpoint (new action mirroring FRED2's OnToggleViewpoint)
- Shift+U = Volumetric Nebula
- Shift+M = Shield System

Add Shift+F1 to toggle the sexp help pane for the session (without changing the saved preference) in the Ship, Wing, Mission Events, Goals, and Cutscenes editors.

Add F6 / Shift+F6 to cycle Next / Prev in the Ship, Wing, Waypoint, Jump Node, and Prop editors.