### PR TITLE
Qtfred briefing map widget fixes

### DIFF
--- a/qtfred/src/ui/Theme.cpp
+++ b/qtfred/src/ui/Theme.cpp
@@ -288,6 +288,11 @@ void applyEditorTheme(ThemeMode mode)
 	applyPalette(resolveDark(mode));
 }
 
+bool currentThemeIsDark()
+{
+	return resolveDark(Current_mode);
+}
+
 ThemeMode readThemeModeSetting()
 {
 	QSettings settings;

--- a/qtfred/src/ui/Theme.h
+++ b/qtfred/src/ui/Theme.h
@@ -22,6 +22,9 @@ void applyEditorTheme(ThemeMode mode);
 ThemeMode readThemeModeSetting();
 void writeThemeModeSetting(ThemeMode mode);
 
+// Whether the currently-applied editor theme is dark (System resolved against the OS scheme).
+bool currentThemeIsDark();
+
 // Draw a palette-aware icon for a standard Qt pixmap using QPainter.
 // Falls back to the style's own icon for unhandled StandardPixmap values.
 QIcon makeThemedIcon(QStyle::StandardPixmap sp, const QColor& color, int size = 16);

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
@@ -150,8 +150,11 @@ void BriefingEditorDialog::setupMapWidget()
 {
 	// Replace the mapView placeholder with the BriefingMapWidget
 	_mapWidget = new fso::fred::BriefingMapWidget(this, _model.get(), _viewport);
-	_mapWidget->setMinimumSize(ui->mapView->minimumSize());
-	_mapWidget->setSizePolicy(ui->mapView->sizePolicy());
+	// The map paints an aspect-correct, letterboxed image and can scale to any size, so it needs no
+	// minimum. A minimum here would set the floor the whole left pane can't shrink below, which is
+	// what stops the dialog narrowing. Keep it at (0,0) and let it expand to fill available space.
+	_mapWidget->setMinimumSize(0, 0);
+	_mapWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
 	// Insert the map widget in place of the placeholder in the left pane layout
 	int idx = ui->leftPaneLayout->indexOf(ui->mapView);
@@ -183,46 +186,6 @@ void BriefingEditorDialog::setupMapWidget()
 	if (_model->getTotalStages() > 0) {
 		_mapWidget->setStage(_model->getCurrentStage());
 		captureResetCameraForCurrentStage();
-	}
-
-	applyMapWidgetAspectRatio();
-}
-
-void BriefingEditorDialog::applyMapWidgetAspectRatio()
-{
-	if (_mapWidget == nullptr) {
-		return;
-	}
-
-	if (Briefing_window_resolution[0] <= 0 || Briefing_window_resolution[1] <= 0) {
-		return;
-	}
-
-	auto mapWidth = _mapWidget->width();
-	if (mapWidth <= 0) {
-		mapWidth = _mapWidget->minimumWidth();
-	}
-	if (mapWidth <= 0) {
-		return;
-	}
-
-	const auto targetHeight = std::max(1,
-		static_cast<int>(std::lround(static_cast<double>(mapWidth) *
-									 static_cast<double>(Briefing_window_resolution[1]) /
-									 static_cast<double>(Briefing_window_resolution[0]))));
-
-	_mapWidget->setMinimumHeight(targetHeight);
-	_mapWidget->setMaximumHeight(targetHeight);
-	_mapWidget->resize(mapWidth, targetHeight);
-
-	const auto oldDialogHeight = height();
-	if (auto* dialogLayout = layout(); dialogLayout != nullptr) {
-		dialogLayout->activate();
-	}
-
-	const auto requiredSize = sizeHint();
-	if (requiredSize.height() > oldDialogHeight) {
-		resize(width(), requiredSize.height());
 	}
 }
 

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.h
@@ -97,7 +97,6 @@ class BriefingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 
 	void initializeUi();
 	void setupMapWidget();
-	void applyMapWidgetAspectRatio();
 	void updateUi();
 	void enableDisableControls();
 	void captureResetCameraForCurrentStage();

--- a/qtfred/src/ui/dialogs/HelpTopicsDialog.cpp
+++ b/qtfred/src/ui/dialogs/HelpTopicsDialog.cpp
@@ -82,7 +82,7 @@ QVariant HelpBrowser::loadResource(int type, const QUrl& name) {
 }
 
 bool HelpBrowser::isDarkMode() const {
-	return palette().color(QPalette::Window).lightness() < 128;
+	return currentThemeIsDark();
 }
 
 QByteArray HelpBrowser::darkModeStyleBlock() {

--- a/qtfred/src/ui/dialogs/VariableDialog.cpp
+++ b/qtfred/src/ui/dialogs/VariableDialog.cpp
@@ -44,10 +44,9 @@ VariableDialog::VariableDialog(QWidget* parent, EditorViewport* viewport, Tab in
 VariableDialog::~VariableDialog() = default;
 
 // Returns a subtle, theme-aware tint: blue for blue_type=true, orange for blue_type=false.
-// Detects dark/light mode via the application window-background lightness.
 QColor VariableDialog::rowTypeColor(bool blue_type)
 {
-	const bool dark_mode = QApplication::palette().color(QPalette::Window).lightness() < 128;
+	const bool dark_mode = currentThemeIsDark();
 	if (blue_type) {
 		return dark_mode ? QColor(50, 60, 80) : QColor(225, 235, 252);
 	} else {

--- a/qtfred/src/ui/widgets/BriefingMapWidget.cpp
+++ b/qtfred/src/ui/widgets/BriefingMapWidget.cpp
@@ -14,6 +14,7 @@
 #include "mission/dialogs/BriefingEditorDialogModel.h"
 #include "mission/EditorViewport.h"
 #include "ui/ControlBindings.h"
+#include "ui/Theme.h"
 
 #include "graphics/2d.h"
 #include "render/3d.h"
@@ -284,9 +285,36 @@ void BriefingMapWidget::updateEditorHighlightPlayback() const {
 	}
 }
 
+QPixmap BriefingMapWidget::checkerboardTile() {
+	// A subtle, theme-appropriate checkerboard so the letterbox/pillarbox bars read as matte rather
+	// than part of the (pure-black) render. Two close grey shades keep it quiet; the real signal is the
+	// contrast between the black map and the grey bars. Rebuilt only when the editor theme flips.
+	const bool dark = currentThemeIsDark();
+	if (!_checkerTile.isNull() && dark == _checkerTileDark) {
+		return _checkerTile;
+	}
+	_checkerTileDark = dark;
+
+	constexpr int square = 8;
+	const QColor light = dark ? QColor(0x36, 0x36, 0x36) : QColor(0xDC, 0xDC, 0xDC);
+	const QColor darkc = dark ? QColor(0x2A, 0x2A, 0x2A) : QColor(0xC8, 0xC8, 0xC8);
+
+	QPixmap tile(square * 2, square * 2);
+	{
+		QPainter p(&tile);
+		p.fillRect(tile.rect(), darkc);
+		p.fillRect(0, 0, square, square, light);
+		p.fillRect(square, square, square, square, light);
+	}
+	_checkerTile = tile;
+	return _checkerTile;
+}
+
 void BriefingMapWidget::paintEvent(QPaintEvent* /*event*/) {
 	QPainter painter(this);
-	painter.fillRect(rect(), Qt::black); // letterbox / pillarbox bars
+	// Matte bars: the briefing image drawn over _blitRect below is opaque, so the checkerboard only
+	// shows through in the letterbox/pillarbox area around it.
+	painter.fillRect(rect(), QBrush(checkerboardTile()));
 
 	if (_frameImage.isNull()) {
 		return;

--- a/qtfred/src/ui/widgets/BriefingMapWidget.cpp
+++ b/qtfred/src/ui/widgets/BriefingMapWidget.cpp
@@ -18,7 +18,6 @@
 #include "graphics/2d.h"
 #include "render/3d.h"
 #include "mission/missionbriefcommon.h"
-#include "mod_table/mod_table.h"
 
 #include <algorithm>
 #include <cmath>
@@ -61,12 +60,13 @@ SDL_Window* BriefingViewport::toSDLWindow() {
 }
 
 std::pair<uint32_t, uint32_t> BriefingViewport::getSize() {
-	// The briefing always renders into an off-screen render target sized to the reference resolution
-	// (bm_set_render_target drives gr_screen), so this is only a nominal size. Report the reference
-	// resolution rather than the offscreen surface's placeholder 1x1.
-	const uint32_t w = (Briefing_window_resolution[0] > 0) ? static_cast<uint32_t>(Briefing_window_resolution[0]) : 888u;
-	const uint32_t h = (Briefing_window_resolution[1] > 0) ? static_cast<uint32_t>(Briefing_window_resolution[1]) : 371u;
-	return std::make_pair(w, h);
+	// The reference resolution the briefing is composed at (also the off-screen render target size).
+	// Pinned to the retail GR_1024 briefing map size, what the game and Lua's ui.drawBriefingMap()
+	// default to, rather than the FRED-only "$FRED Briefing window resolution" table setting: the game
+	// ignores that setting, so honoring it here would only make the editor preview diverge from the
+	// shipped briefing. This is the single source of truth for the render size (see renderFrame()).
+	return std::make_pair(static_cast<uint32_t>(Brief_grid_coords[GR_1024][2]),
+		static_cast<uint32_t>(Brief_grid_coords[GR_1024][3]));
 }
 
 void BriefingViewport::swapBuffers() {
@@ -485,9 +485,10 @@ void BriefingMapWidget::renderFrame() {
 		return;
 	}
 
-	// Reference resolution the briefing is authored/rendered at (mod-configurable, retail default).
-	const int resW = (Briefing_window_resolution[0] > 0) ? Briefing_window_resolution[0] : 888;
-	const int resH = (Briefing_window_resolution[1] > 0) ? Briefing_window_resolution[1] : 371;
+	// Reference resolution the briefing is composed at (see BriefingViewport::getSize).
+	const auto refSize = _briefingViewport->getSize();
+	const int resW = static_cast<int>(refSize.first);
+	const int resH = static_cast<int>(refSize.second);
 
 	// Lazily (re)create the offscreen render target at the reference resolution. Rendering the
 	// briefing at a fixed canonical size and scaling the finished image to fit the widget is what

--- a/qtfred/src/ui/widgets/BriefingMapWidget.cpp
+++ b/qtfred/src/ui/widgets/BriefingMapWidget.cpp
@@ -2,8 +2,11 @@
 
 #include <QKeyEvent>
 #include <QMouseEvent>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QOffscreenSurface>
 #include <QtGui/QOpenGLContext>
-#include <QtWidgets/QHBoxLayout>
+#include <QtGui/QOpenGLFunctions>
 
 #include "FredApplication.h"
 #include "anim/animplay.h"
@@ -48,46 +51,9 @@ void ensure_highlight_anim_loaded(brief_icon& icon) {
 }
 }
 
-// ---- BriefingMapWindow ----
-
-BriefingMapWindow::BriefingMapWindow(QWidget* parentWidget)
-	: QWindow(static_cast<QWindow*>(nullptr)), _parentWidget(parentWidget)
-{
-	setSurfaceType(QWindow::OpenGLSurface);
-}
-
-void BriefingMapWindow::initializeGL(const QSurfaceFormat& fmt) {
-	setFormat(fmt);
-	create();
-}
-
-bool BriefingMapWindow::event(QEvent* evt) {
-	switch (evt->type()) {
-	case QEvent::KeyPress:
-	case QEvent::KeyRelease:
-	case QEvent::MouseButtonPress:
-	case QEvent::MouseButtonRelease:
-	case QEvent::MouseMove:
-		// Forward input events to the parent widget
-		qGuiApp->sendEvent(_parentWidget, evt);
-		return true;
-	default:
-		return QWindow::event(evt);
-	}
-}
-
-void BriefingMapWindow::exposeEvent(QExposeEvent* event) {
-	if (isExposed()) {
-		requestUpdate();
-		event->accept();
-	} else {
-		QWindow::exposeEvent(event);
-	}
-}
-
 // ---- BriefingViewport ----
 
-BriefingViewport::BriefingViewport(BriefingMapWindow* window) : _window(window) {
+BriefingViewport::BriefingViewport(QOffscreenSurface* surface) : _surface(surface) {
 }
 
 SDL_Window* BriefingViewport::toSDLWindow() {
@@ -95,14 +61,16 @@ SDL_Window* BriefingViewport::toSDLWindow() {
 }
 
 std::pair<uint32_t, uint32_t> BriefingViewport::getSize() {
-	return std::make_pair(static_cast<uint32_t>(_window->width()),
-		static_cast<uint32_t>(_window->height()));
+	// The briefing always renders into an off-screen render target sized to the reference resolution
+	// (bm_set_render_target drives gr_screen), so this is only a nominal size. Report the reference
+	// resolution rather than the offscreen surface's placeholder 1x1.
+	const uint32_t w = (Briefing_window_resolution[0] > 0) ? static_cast<uint32_t>(Briefing_window_resolution[0]) : 888u;
+	const uint32_t h = (Briefing_window_resolution[1] > 0) ? static_cast<uint32_t>(Briefing_window_resolution[1]) : 371u;
+	return std::make_pair(w, h);
 }
 
 void BriefingViewport::swapBuffers() {
-	if (_window->isExposed()) {
-		QOpenGLContext::currentContext()->swapBuffers(_window);
-	}
+	// Nothing to present: the briefing is read back from the render target, not swapped to a window.
 }
 
 void BriefingViewport::setState(os::ViewportState /*state*/) {
@@ -115,7 +83,7 @@ void BriefingViewport::restore() {
 }
 
 QSurface* BriefingViewport::getRenderSurface() {
-	return _window;
+	return _surface;
 }
 
 // ---- BriefingMapWidget ----
@@ -127,14 +95,8 @@ BriefingMapWidget::BriefingMapWidget(QWidget* parent,
 {
 	setFocusPolicy(Qt::StrongFocus);
 	setMouseTracking(true);
-
-	_window = new BriefingMapWindow(this);
-
-	auto layout = new QHBoxLayout(this);
-	layout->setSpacing(0);
-	layout->addWidget(QWidget::createWindowContainer(_window, this));
-	layout->setContentsMargins(0, 0, 0, 0);
-	setLayout(layout);
+	// Opaque: we always fill the whole widget (image + black letterbox bars) in paintEvent.
+	setAttribute(Qt::WA_OpaquePaintEvent, true);
 
 	_renderTimer = new QTimer(this);
 	_renderTimer->setInterval(33); // ~30 fps
@@ -152,32 +114,21 @@ BriefingMapWidget::~BriefingMapWidget() {
 }
 
 void BriefingMapWidget::initBriefingMap() {
-	// Get the surface format from the current GL context and initialize our window
+	// The briefing renders through an off-screen surface (no visible window): the engine's GL context
+	// is made current on it so we can render into a render target, which we then read back and paint.
 	auto* currentCtx = QOpenGLContext::currentContext();
+	_surface = new QOffscreenSurface(nullptr, this);
 	if (currentCtx) {
-		_window->initializeGL(currentCtx->format());
+		_surface->setFormat(currentCtx->format());
 	}
+	_surface->create();
 
 	// brief_render_map() calls anim_render_all(), which requires anim_init()
 	// to have initialized the render/free lists.
 	anim_init();
 
-	_diagnosticContext.reset(new QOpenGLContext());
-	if (currentCtx) {
-		_diagnosticContext->setShareContext(currentCtx);
-		_diagnosticContext->setFormat(currentCtx->format());
-	} else {
-		_diagnosticContext->setFormat(_window->requestedFormat());
-	}
-	if (!_diagnosticContext->create()) {
-		mprintf(("BriefingMapWidget: failed to create dedicated diagnostic GL context.\n"));
-		_diagnosticContext.reset();
-	} else {
-		mprintf(("BriefingMapWidget: dedicated diagnostic GL context created.\n"));
-	}
-
-	// Create our os::Viewport wrapper so we can use gr_use_viewport() / gr_flip()
-	_briefingViewport = std::unique_ptr<BriefingViewport>(new BriefingViewport(_window));
+	// Create our os::Viewport wrapper so we can use gr_use_viewport().
+	_briefingViewport = std::unique_ptr<BriefingViewport>(new BriefingViewport(_surface));
 
 	// Initialize the briefing rendering subsystem.
 	// This mirrors what brief_init(true) does in the Lua API path:
@@ -206,7 +157,6 @@ void BriefingMapWidget::initBriefingMap() {
 
 	_initialized = true;
 	_renderTimer->start();
-	mprintf(("BriefingMapWidget: init complete, timer started for render diagnostics.\n"));
 }
 
 void BriefingMapWidget::setStage(int stageNum) {
@@ -334,12 +284,30 @@ void BriefingMapWidget::updateEditorHighlightPlayback() const {
 	}
 }
 
-void BriefingMapWidget::drawSelectedIconOutline() {
+void BriefingMapWidget::paintEvent(QPaintEvent* /*event*/) {
+	QPainter painter(this);
+	painter.fillRect(rect(), Qt::black); // letterbox / pillarbox bars
+
+	if (_frameImage.isNull()) {
+		return;
+	}
+
+	// Aspect-fit the reference-resolution briefing image into the widget, centered (letterboxed).
+	const QSize scaled = _frameImage.size().scaled(size(), Qt::KeepAspectRatio);
+	_blitRect = QRect(QPoint((width() - scaled.width()) / 2, (height() - scaled.height()) / 2), scaled);
+
+	painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+	painter.drawImage(_blitRect, _frameImage);
+
+	drawSelectionBrackets(painter);
+}
+
+void BriefingMapWidget::drawSelectionBrackets(QPainter& painter) {
 	auto* briefPtr = _model->getWipBriefingPtr(_model->getCurrentTeam());
 	if (briefPtr == nullptr || _currentStage < 0 || _currentStage >= briefPtr->num_stages) {
 		return;
 	}
-	if (_blitW <= 0 || _blitH <= 0 || _lastRenderWidth <= 0 || _lastRenderHeight <= 0) {
+	if (_blitRect.width() <= 0 || _blitRect.height() <= 0 || _lastRenderWidth <= 0 || _lastRenderHeight <= 0) {
 		return;
 	}
 
@@ -349,40 +317,37 @@ void BriefingMapWidget::drawSelectedIconOutline() {
 		return;
 	}
 
-	// This is an editor overlay drawn in the widget's device-pixel space (after the briefing image
-	// has been blitted), so the brackets stay crisp. Icon coordinates are in reference-resolution
-	// space, so map them through the letterbox blit rectangle to land on the on-screen icons.
-	const float scale = static_cast<float>(_blitW) / static_cast<float>(_lastRenderWidth);
-	const auto mapX = [&](float refX) { return _blitX + static_cast<int>(std::lround(refX * scale)); };
-	const auto mapY = [&](float refY) { return _blitY + static_cast<int>(std::lround(refY * scale)); };
+	// Icon coordinates are in reference-resolution space; map them through the letterbox rectangle so
+	// the (crisp, overlaid) brackets land on the on-screen icons.
+	const double scale = static_cast<double>(_blitRect.width()) / static_cast<double>(_lastRenderWidth);
+	const auto mapX = [&](double refX) { return _blitRect.x() + static_cast<int>(std::lround(refX * scale)); };
+	const auto mapY = [&](double refY) { return _blitRect.y() + static_cast<int>(std::lround(refY * scale)); };
 
-	gr_set_color(255, 255, 255);
+	painter.setPen(QPen(Qt::white, 1));
 	for (const auto selected : selectedIcons) {
 		if (selected < 0 || selected >= stage.num_icons) {
 			continue;
 		}
 
 		auto& icon = stage.icons[selected];
-		const int left = mapX(static_cast<float>(icon.x - 2));
-		const int top = mapY(static_cast<float>(icon.y - 2));
-		const int right = mapX(static_cast<float>(icon.x + icon.w + 2));
-		const int bottom = mapY(static_cast<float>(icon.y + icon.h + 2));
-		const int width = right - left;
-		const int height = bottom - top;
-		const int cornerLen = std::max(3, std::min(width, height) / 4);
+		const int left = mapX(icon.x - 2);
+		const int top = mapY(icon.y - 2);
+		const int right = mapX(icon.x + icon.w + 2);
+		const int bottom = mapY(icon.y + icon.h + 2);
+		const int cornerLen = std::max(3, std::min(right - left, bottom - top) / 4);
 
 		// Top-left
-		gr_line(left, top, left + cornerLen, top, GR_RESIZE_NONE);
-		gr_line(left, top, left, top + cornerLen, GR_RESIZE_NONE);
+		painter.drawLine(left, top, left + cornerLen, top);
+		painter.drawLine(left, top, left, top + cornerLen);
 		// Top-right
-		gr_line(right - cornerLen, top, right, top, GR_RESIZE_NONE);
-		gr_line(right, top, right, top + cornerLen, GR_RESIZE_NONE);
+		painter.drawLine(right - cornerLen, top, right, top);
+		painter.drawLine(right, top, right, top + cornerLen);
 		// Bottom-left
-		gr_line(left, bottom, left + cornerLen, bottom, GR_RESIZE_NONE);
-		gr_line(left, bottom - cornerLen, left, bottom, GR_RESIZE_NONE);
+		painter.drawLine(left, bottom, left + cornerLen, bottom);
+		painter.drawLine(left, bottom - cornerLen, left, bottom);
 		// Bottom-right
-		gr_line(right - cornerLen, bottom, right, bottom, GR_RESIZE_NONE);
-		gr_line(right, bottom - cornerLen, right, bottom, GR_RESIZE_NONE);
+		painter.drawLine(right - cornerLen, bottom, right, bottom);
+		painter.drawLine(right, bottom - cornerLen, right, bottom);
 	}
 }
 
@@ -485,37 +450,12 @@ void BriefingMapWidget::applyCameraPoseLikeKeyboardControls(const vec3d& camPos,
 	cameraChanged(camPos, camOrient);
 }
 
-QWindow* BriefingMapWidget::getRenderWindow() const {
-	return _window;
-}
-
 void BriefingMapWidget::renderFrame() {
-	if (!_initialized) {
-		if (!_loggedNotInitialized) {
-			mprintf(("BriefingMapWidget: render skipped because widget is not initialized.\n"));
-			_loggedNotInitialized = true;
-		}
+	if (!_initialized || !_briefingViewport || _surface == nullptr) {
 		return;
 	}
 
-	if (!_window->isExposed()) {
-		if (!_loggedNotExposed) {
-			mprintf(("BriefingMapWidget: render skipped because window is not exposed.\n"));
-			_loggedNotExposed = true;
-		}
-		return;
-	}
-
-	if (!_briefingViewport) {
-		if (!_loggedNoViewport) {
-			mprintf(("BriefingMapWidget: render skipped because briefing viewport is null.\n"));
-			_loggedNoViewport = true;
-		}
-		return;
-	}
-
-	// Guard against re-entrancy: swapBuffers() can pump the Qt event loop on Windows,
-	// which may fire our timer again while we're still mid-render.
+	// Guard against re-entrancy.
 	if (_rendering)
 		return;
 
@@ -531,8 +471,7 @@ void BriefingMapWidget::renderFrame() {
 
 	_rendering = true;
 
-	// Render briefing content through the normal graphics pipeline so gr_flip()
-	// performs any required FBO resolve/blit before presenting.
+	// Make the engine's GL context current on our off-screen surface so we can render the briefing.
 	gr_use_viewport(_briefingViewport.get());
 	auto* context = QOpenGLContext::currentContext();
 
@@ -541,34 +480,10 @@ void BriefingMapWidget::renderFrame() {
 			mprintf(("BriefingMapWidget: no current OpenGL context after gr_use_viewport().\n"));
 			_loggedNoContext = true;
 		}
-		// Restore main viewport frame before bailing out
-		if (mainFrameWasActive) {
-			auto* mainView = _viewport->renderer->getTargetViewport();
-			auto mainSize = mainView->getSize();
-			gr_use_viewport(mainView);
-			gr_screen_resize(static_cast<int>(mainSize.first) * devicePixelRatio(),
-				static_cast<int>(mainSize.second) * devicePixelRatio());
-			g3_start_frame(0);
-			g3_set_view_matrix(&_viewport->camera.eye_pos, &_viewport->camera.eye_orient, 0.5f);
-		}
+		restoreMainViewportFrame(mainFrameWasActive);
 		_rendering = false;
 		return;
 	}
-
-	if (context->surface() != _window) {
-		if (!_loggedSurfaceMismatch) {
-			mprintf(("BriefingMapWidget: surface mismatch before clear (current=%p target=%p).\n",
-				static_cast<void*>(context->surface()),
-				static_cast<void*>(_window)));
-			_loggedSurfaceMismatch = true;
-		}
-	}
-
-	auto viewSize = _briefingViewport->getSize();
-	const int w = static_cast<int>(viewSize.first);
-	const int h = static_cast<int>(viewSize.second);
-	const int deviceW = static_cast<int>(w * devicePixelRatio());
-	const int deviceH = static_cast<int>(h * devicePixelRatio());
 
 	// Reference resolution the briefing is authored/rendered at (mod-configurable, retail default).
 	const int resW = (Briefing_window_resolution[0] > 0) ? Briefing_window_resolution[0] : 888;
@@ -592,15 +507,7 @@ void BriefingMapWidget::renderFrame() {
 			mprintf(("BriefingMapWidget: failed to create %dx%d render target.\n", resW, resH));
 			_loggedNoRenderTarget = true;
 		}
-		if (mainFrameWasActive) {
-			auto* mainView = _viewport->renderer->getTargetViewport();
-			auto mainSize = mainView->getSize();
-			gr_use_viewport(mainView);
-			gr_screen_resize(static_cast<int>(mainSize.first) * devicePixelRatio(),
-				static_cast<int>(mainSize.second) * devicePixelRatio());
-			g3_start_frame(0);
-			g3_set_view_matrix(&_viewport->camera.eye_pos, &_viewport->camera.eye_orient, 0.5f);
-		}
+		restoreMainViewportFrame(mainFrameWasActive);
 		_rendering = false;
 		return;
 	}
@@ -609,10 +516,7 @@ void BriefingMapWidget::renderFrame() {
 	_lastRenderWidth = resW;
 	_lastRenderHeight = resH;
 
-	// Establish the window-surface dimensions; bm_set_render_target(-1) restores back to these.
-	gr_screen_resize(deviceW, deviceH);
-
-	// ---- Render the briefing into the offscreen target at the reference resolution ----
+	// ---- Render the briefing into the off-screen target and read it back into a QImage ----
 	// bm_set_render_target() switches gr_screen to the target's own dimensions for us.
 	if (bm_set_render_target(_renderTarget)) {
 		brief_screen savedBscreen = bscreen;
@@ -647,56 +551,39 @@ void BriefingMapWidget::renderFrame() {
 			}
 		}
 
+		// Read the finished frame back while the render target is still bound. The briefing is an
+		// opaque scene, so use RGBX (ignore the alpha byte) to avoid the background reading as
+		// transparent. FSO already renders the target top-down, so no vertical flip is needed.
+		QImage frame(resW, resH, QImage::Format_RGBX8888);
+		context->functions()->glReadPixels(0, 0, resW, resH, GL_RGBA, GL_UNSIGNED_BYTE, frame.bits());
+		_frameImage = frame.copy();
+
 		Briefing = savedBriefing;
 		bscreen = savedBscreen;
 
-		bm_set_render_target(-1); // back to the window's back buffer (restores gr_screen dims)
+		bm_set_render_target(-1);
 	}
 
-	// ---- Letterbox the reference-resolution image into the widget (device pixels) ----
-	{
-		const double targetAspect = static_cast<double>(resW) / static_cast<double>(resH);
-		if (deviceW > 0 && deviceH > 0 && static_cast<double>(deviceW) / deviceH > targetAspect) {
-			// Wider than the briefing: pillarbox (bars left/right).
-			_blitH = deviceH;
-			_blitW = std::max(1, static_cast<int>(std::lround(deviceH * targetAspect)));
-			_blitX = (deviceW - _blitW) / 2;
-			_blitY = 0;
-		} else {
-			// Taller than the briefing: letterbox (bars top/bottom).
-			_blitW = deviceW;
-			_blitH = std::max(1, static_cast<int>(std::lround(deviceW / targetAspect)));
-			_blitX = 0;
-			_blitY = (deviceH - _blitH) / 2;
-		}
-	}
-
-	gr_reset_clip();
-	gr_clear(); // black letterbox bars
-	if (_blitW > 0 && _blitH > 0) {
-		gr_set_bitmap(_renderTarget);
-		gr_bitmap(_blitX, _blitY, GR_RESIZE_NONE, false, static_cast<float>(_blitW) / static_cast<float>(resW));
-	}
-
-	// Selection brackets are an editor overlay: draw them in window space on top of the blitted image.
-	drawSelectedIconOutline();
-
-	gr_flip();
-	_debugFrameCounter++;
-
-	// Restore the main viewport's persistent frame so that mouse-interaction
-	// helpers (select_object → g3_point_to_vec) continue to work between the
-	// main viewport's own render calls.
-	if (mainFrameWasActive) {
-		auto* mainView = _viewport->renderer->getTargetViewport();
-		auto mainSize = mainView->getSize();
-		gr_use_viewport(mainView);
-		gr_screen_resize(static_cast<int>(mainSize.first) * devicePixelRatio(), static_cast<int>(mainSize.second) * devicePixelRatio());
-		g3_start_frame(0);
-		g3_set_view_matrix(&_viewport->camera.eye_pos, &_viewport->camera.eye_orient, 0.5f);
-	}
+	// Restore the main viewport's persistent frame so its mouse-interaction helpers keep working.
+	restoreMainViewportFrame(mainFrameWasActive);
 
 	_rendering = false;
+
+	// Repaint the widget with the freshly read-back frame (selection brackets are drawn there).
+	update();
+}
+
+void BriefingMapWidget::restoreMainViewportFrame(bool wasActive) {
+	if (!wasActive) {
+		return;
+	}
+	auto* mainView = _viewport->renderer->getTargetViewport();
+	auto mainSize = mainView->getSize();
+	gr_use_viewport(mainView);
+	gr_screen_resize(static_cast<int>(mainSize.first) * devicePixelRatio(),
+		static_cast<int>(mainSize.second) * devicePixelRatio());
+	g3_start_frame(0);
+	g3_set_view_matrix(&_viewport->camera.eye_pos, &_viewport->camera.eye_orient, 0.5f);
 }
 
 bool BriefingMapWidget::event(QEvent* evt) {
@@ -760,24 +647,23 @@ void BriefingMapWidget::mousePressEvent(QMouseEvent* event) {
 	if (!_initialized || event->button() != Qt::LeftButton)
 		return;
 
-	_lastMousePos = event->pos();
 	_dragStartMousePos = event->position();
 
 	auto* briefPtr = _model->getWipBriefingPtr(_model->getCurrentTeam());
 	if (!briefPtr || _currentStage < 0 || _currentStage >= briefPtr->num_stages || _lastRenderWidth <= 0 || _lastRenderHeight <= 0 ||
-		_blitW <= 0 || _blitH <= 0) {
+		_blitRect.width() <= 0 || _blitRect.height() <= 0) {
 		_draggingIcon = false;
 		_dragIconIndex = -1;
 		return;
 	}
 
-	// Map the logical mouse position into reference-resolution space: convert to device pixels,
-	// shift by the letterbox origin, then scale from the blit rectangle to the render-target size.
-	const auto dpr = static_cast<float>(devicePixelRatio());
-	const auto mouseX = (static_cast<float>(event->position().x()) * dpr - static_cast<float>(_blitX)) *
-						(static_cast<float>(_lastRenderWidth) / static_cast<float>(_blitW));
-	const auto mouseY = (static_cast<float>(event->position().y()) * dpr - static_cast<float>(_blitY)) *
-						(static_cast<float>(_lastRenderHeight) / static_cast<float>(_blitH));
+	// Map the logical mouse position into reference-resolution space: shift by the letterbox origin,
+	// then scale from the (logical) blit rectangle to the render-target size. QWidget coordinates and
+	// _blitRect are both logical, so no device-pixel-ratio factor is needed here.
+	const auto mouseX = (static_cast<float>(event->position().x()) - static_cast<float>(_blitRect.x())) *
+						(static_cast<float>(_lastRenderWidth) / static_cast<float>(_blitRect.width()));
+	const auto mouseY = (static_cast<float>(event->position().y()) - static_cast<float>(_blitRect.y())) *
+						(static_cast<float>(_lastRenderHeight) / static_cast<float>(_blitRect.height()));
 
 	auto& stage = briefPtr->stages[_currentStage];
 	int hitIndex = -1;
@@ -818,17 +704,16 @@ void BriefingMapWidget::mouseMoveEvent(QMouseEvent* event) {
 
 	auto* briefPtr = _model->getWipBriefingPtr(_model->getCurrentTeam());
 	if (!briefPtr || _currentStage < 0 || _currentStage >= briefPtr->num_stages || _dragIconIndex >= briefPtr->stages[_currentStage].num_icons ||
-		_lastRenderWidth <= 0 || _lastRenderHeight <= 0 || _blitW <= 0 || _blitH <= 0) {
+		_lastRenderWidth <= 0 || _lastRenderHeight <= 0 || _blitRect.width() <= 0 || _blitRect.height() <= 0) {
 		return;
 	}
 
-	// Convert the logical mouse delta into reference-resolution pixels (device pixels scaled from the
-	// letterbox blit rectangle to the render-target size). The letterbox offset cancels in a delta.
-	const auto dpr = static_cast<float>(devicePixelRatio());
-	const auto scaleX = static_cast<float>(_lastRenderWidth) / static_cast<float>(_blitW);
-	const auto scaleY = static_cast<float>(_lastRenderHeight) / static_cast<float>(_blitH);
-	const auto deltaX = static_cast<float>(event->position().x() - _dragStartMousePos.x()) * dpr * scaleX;
-	const auto deltaY = static_cast<float>(event->position().y() - _dragStartMousePos.y()) * dpr * scaleY;
+	// Convert the logical mouse delta into reference-resolution pixels (scaled from the logical
+	// letterbox rectangle to the render-target size). The letterbox offset cancels in a delta.
+	const auto scaleX = static_cast<float>(_lastRenderWidth) / static_cast<float>(_blitRect.width());
+	const auto scaleY = static_cast<float>(_lastRenderHeight) / static_cast<float>(_blitRect.height());
+	const auto deltaX = static_cast<float>(event->position().x() - _dragStartMousePos.x()) * scaleX;
+	const auto deltaY = static_cast<float>(event->position().y() - _dragStartMousePos.y()) * scaleY;
 
 	const auto camPos = brief_get_current_cam_pos();
 	const auto camOrient = brief_get_current_cam_orient();
@@ -850,8 +735,6 @@ void BriefingMapWidget::mouseMoveEvent(QMouseEvent* event) {
 	vm_vec_scale_add2(&newPos, &camOrient.vec.rvec, deltaX * worldPerPixelX * DragResponseScale);
 	vm_vec_scale_add2(&newPos, &camOrient.vec.uvec, -deltaY * worldPerPixelY * DragResponseScale);
 	_model->setIconPosition(newPos);
-
-	_lastMousePos = event->pos();
 }
 
 void BriefingMapWidget::mouseReleaseEvent(QMouseEvent* event) {

--- a/qtfred/src/ui/widgets/BriefingMapWidget.cpp
+++ b/qtfred/src/ui/widgets/BriefingMapWidget.cpp
@@ -15,6 +15,10 @@
 #include "graphics/2d.h"
 #include "render/3d.h"
 #include "mission/missionbriefcommon.h"
+#include "mod_table/mod_table.h"
+
+#include <algorithm>
+#include <cmath>
 
 namespace fso::fred {
 
@@ -141,6 +145,10 @@ BriefingMapWidget::BriefingMapWidget(QWidget* parent,
 
 BriefingMapWidget::~BriefingMapWidget() {
 	_renderTimer->stop();
+	if (_renderTarget >= 0) {
+		bm_release(_renderTarget);
+		_renderTarget = -1;
+	}
 }
 
 void BriefingMapWidget::initBriefingMap() {
@@ -327,15 +335,26 @@ void BriefingMapWidget::updateEditorHighlightPlayback() const {
 }
 
 void BriefingMapWidget::drawSelectedIconOutline() {
-	if (Briefing == nullptr || _currentStage < 0 || _currentStage >= Briefing->num_stages) {
+	auto* briefPtr = _model->getWipBriefingPtr(_model->getCurrentTeam());
+	if (briefPtr == nullptr || _currentStage < 0 || _currentStage >= briefPtr->num_stages) {
+		return;
+	}
+	if (_blitW <= 0 || _blitH <= 0 || _lastRenderWidth <= 0 || _lastRenderHeight <= 0) {
 		return;
 	}
 
 	const auto selectedIcons = _model->getLineSelection();
-	auto& stage = Briefing->stages[_currentStage];
+	auto& stage = briefPtr->stages[_currentStage];
 	if (selectedIcons.empty()) {
 		return;
 	}
+
+	// This is an editor overlay drawn in the widget's device-pixel space (after the briefing image
+	// has been blitted), so the brackets stay crisp. Icon coordinates are in reference-resolution
+	// space, so map them through the letterbox blit rectangle to land on the on-screen icons.
+	const float scale = static_cast<float>(_blitW) / static_cast<float>(_lastRenderWidth);
+	const auto mapX = [&](float refX) { return _blitX + static_cast<int>(std::lround(refX * scale)); };
+	const auto mapY = [&](float refY) { return _blitY + static_cast<int>(std::lround(refY * scale)); };
 
 	gr_set_color(255, 255, 255);
 	for (const auto selected : selectedIcons) {
@@ -344,26 +363,26 @@ void BriefingMapWidget::drawSelectedIconOutline() {
 		}
 
 		auto& icon = stage.icons[selected];
-		const auto left = (icon.x - 2);
-		const auto top = icon.y - 2;
-		const auto right = left + icon.w + 4;
-		const auto bottom = top + icon.h + 4;
-		const auto width = right - left;
-		const auto height = bottom - top;
-		const auto cornerLen = std::max(3, std::min(width, height) / 4);
+		const int left = mapX(static_cast<float>(icon.x - 2));
+		const int top = mapY(static_cast<float>(icon.y - 2));
+		const int right = mapX(static_cast<float>(icon.x + icon.w + 2));
+		const int bottom = mapY(static_cast<float>(icon.y + icon.h + 2));
+		const int width = right - left;
+		const int height = bottom - top;
+		const int cornerLen = std::max(3, std::min(width, height) / 4);
 
 		// Top-left
-		gr_line(left, top, left + cornerLen, top);
-		gr_line(left, top, left, top + cornerLen);
+		gr_line(left, top, left + cornerLen, top, GR_RESIZE_NONE);
+		gr_line(left, top, left, top + cornerLen, GR_RESIZE_NONE);
 		// Top-right
-		gr_line(right - cornerLen, top, right, top);
-		gr_line(right, top, right, top + cornerLen);
+		gr_line(right - cornerLen, top, right, top, GR_RESIZE_NONE);
+		gr_line(right, top, right, top + cornerLen, GR_RESIZE_NONE);
 		// Bottom-left
-		gr_line(left, bottom, left + cornerLen, bottom);
-		gr_line(left, bottom - cornerLen, left, bottom);
+		gr_line(left, bottom, left + cornerLen, bottom, GR_RESIZE_NONE);
+		gr_line(left, bottom - cornerLen, left, bottom, GR_RESIZE_NONE);
 		// Bottom-right
-		gr_line(right - cornerLen, bottom, right, bottom);
-		gr_line(right, bottom - cornerLen, right, bottom);
+		gr_line(right - cornerLen, bottom, right, bottom, GR_RESIZE_NONE);
+		gr_line(right, bottom - cornerLen, right, bottom, GR_RESIZE_NONE);
 	}
 }
 
@@ -548,68 +567,122 @@ void BriefingMapWidget::renderFrame() {
 	auto viewSize = _briefingViewport->getSize();
 	const int w = static_cast<int>(viewSize.first);
 	const int h = static_cast<int>(viewSize.second);
-	_lastRenderWidth = w;
-	_lastRenderHeight = h;
+	const int deviceW = static_cast<int>(w * devicePixelRatio());
+	const int deviceH = static_cast<int>(h * devicePixelRatio());
 
-	gr_screen_resize(w * devicePixelRatio(), h * devicePixelRatio());
+	// Reference resolution the briefing is authored/rendered at (mod-configurable, retail default).
+	const int resW = (Briefing_window_resolution[0] > 0) ? Briefing_window_resolution[0] : 888;
+	const int resH = (Briefing_window_resolution[1] > 0) ? Briefing_window_resolution[1] : 371;
 
-	brief_screen savedBscreen = bscreen;
-	bscreen.map_x1 = 0;
-	bscreen.map_y1 = 0;
-	bscreen.map_x2 = w;
-	bscreen.map_y2 = h;
-	bscreen.resize = GR_RESIZE_NONE;
+	// Lazily (re)create the offscreen render target at the reference resolution. Rendering the
+	// briefing at a fixed canonical size and scaling the finished image to fit the widget is what
+	// makes this a faithful WYSIWYG view: icon sizes, grid, line thickness and text all scale together.
+	if (_renderTarget < 0 || _renderTargetW != resW || _renderTargetH != resH) {
+		if (_renderTarget >= 0) {
+			bm_release(_renderTarget);
+		}
+		_renderTarget = bm_make_render_target(resW, resH,
+			BMP_FLAG_RENDER_TARGET_DYNAMIC | BMP_FLAG_RENDER_TARGET_DEPTH_ATTACHMENT);
+		_renderTargetW = resW;
+		_renderTargetH = resH;
+	}
 
-	briefing* savedBriefing = Briefing;
-	Briefing = _model->getWipBriefingPtr(_model->getCurrentTeam());
+	if (_renderTarget < 0) {
+		if (!_loggedNoRenderTarget) {
+			mprintf(("BriefingMapWidget: failed to create %dx%d render target.\n", resW, resH));
+			_loggedNoRenderTarget = true;
+		}
+		if (mainFrameWasActive) {
+			auto* mainView = _viewport->renderer->getTargetViewport();
+			auto mainSize = mainView->getSize();
+			gr_use_viewport(mainView);
+			gr_screen_resize(static_cast<int>(mainSize.first) * devicePixelRatio(),
+				static_cast<int>(mainSize.second) * devicePixelRatio());
+			g3_start_frame(0);
+			g3_set_view_matrix(&_viewport->camera.eye_pos, &_viewport->camera.eye_orient, 0.5f);
+		}
+		_rendering = false;
+		return;
+	}
 
-	gr_reset_clip();
-	gr_clear();
+	// Icon coordinates come out of brief_render_map() in reference-resolution space.
+	_lastRenderWidth = resW;
+	_lastRenderHeight = resH;
 
-	if (Briefing != nullptr) {
-		const bool stage_valid = (_currentStage >= 0 && _currentStage < Briefing->num_stages);
-		if (!stage_valid) {
-			mprintf(("BriefingMapWidget: invalid stage index %d (num_stages=%d)\n", _currentStage, Briefing->num_stages));
+	// Establish the window-surface dimensions; bm_set_render_target(-1) restores back to these.
+	gr_screen_resize(deviceW, deviceH);
+
+	// ---- Render the briefing into the offscreen target at the reference resolution ----
+	// bm_set_render_target() switches gr_screen to the target's own dimensions for us.
+	if (bm_set_render_target(_renderTarget)) {
+		brief_screen savedBscreen = bscreen;
+		bscreen.map_x1 = 0;
+		bscreen.map_y1 = 0;
+		bscreen.map_x2 = resW;
+		bscreen.map_y2 = resH;
+		bscreen.resize = GR_RESIZE_NONE;
+
+		briefing* savedBriefing = Briefing;
+		Briefing = _model->getWipBriefingPtr(_model->getCurrentTeam());
+
+		gr_reset_clip();
+		gr_clear();
+
+		if (Briefing != nullptr) {
+			const bool stage_valid = (_currentStage >= 0 && _currentStage < Briefing->num_stages);
+			if (!stage_valid) {
+				mprintf(("BriefingMapWidget: invalid stage index %d (num_stages=%d)\n", _currentStage, Briefing->num_stages));
+			}
+
+			if (stage_valid) {
+				const float frametime = 0.033f;
+				applyBoundCameraControls(frametime);
+				Brief_text_wipe_time_elapsed += frametime;
+				brief_camera_move(frametime, _currentStage);
+				updateEditorHighlightPlayback();
+				brief_render_map(_currentStage, frametime);
+				updateEditorHighlightPlayback();
+				maybeRenderCutTransition(frametime, resW, resH);
+				cameraChanged(brief_get_current_cam_pos(), brief_get_current_cam_orient());
+			}
 		}
 
-		if ((_debugFrameCounter % 120) == 0 && stage_valid) {
-			const auto& stage = Briefing->stages[_currentStage];
-			mprintf(("BriefingMapWidget: stage=%d/%d draw_grid=%d num_icons=%d num_lines=%d cam_time=%d\n",
-				_currentStage,
-				Briefing->num_stages,
-				stage.draw_grid ? 1 : 0,
-				stage.num_icons,
-				stage.num_lines,
-				stage.camera_time));
-		}
+		Briefing = savedBriefing;
+		bscreen = savedBscreen;
 
-		if (stage_valid) {
-			const float frametime = 0.033f;
-			applyBoundCameraControls(frametime);
-			Brief_text_wipe_time_elapsed += frametime;
-			brief_camera_move(frametime, _currentStage);
-			updateEditorHighlightPlayback();
-			brief_render_map(_currentStage, frametime);
-			updateEditorHighlightPlayback();
-			drawSelectedIconOutline();
-			maybeRenderCutTransition(frametime, w, h);
-			cameraChanged(brief_get_current_cam_pos(), brief_get_current_cam_orient());
+		bm_set_render_target(-1); // back to the window's back buffer (restores gr_screen dims)
+	}
+
+	// ---- Letterbox the reference-resolution image into the widget (device pixels) ----
+	{
+		const double targetAspect = static_cast<double>(resW) / static_cast<double>(resH);
+		if (deviceW > 0 && deviceH > 0 && static_cast<double>(deviceW) / deviceH > targetAspect) {
+			// Wider than the briefing: pillarbox (bars left/right).
+			_blitH = deviceH;
+			_blitW = std::max(1, static_cast<int>(std::lround(deviceH * targetAspect)));
+			_blitX = (deviceW - _blitW) / 2;
+			_blitY = 0;
+		} else {
+			// Taller than the briefing: letterbox (bars top/bottom).
+			_blitW = deviceW;
+			_blitH = std::max(1, static_cast<int>(std::lround(deviceW / targetAspect)));
+			_blitX = 0;
+			_blitY = (deviceH - _blitH) / 2;
 		}
 	}
 
-	Briefing = savedBriefing;
-	bscreen = savedBscreen;
+	gr_reset_clip();
+	gr_clear(); // black letterbox bars
+	if (_blitW > 0 && _blitH > 0) {
+		gr_set_bitmap(_renderTarget);
+		gr_bitmap(_blitX, _blitY, GR_RESIZE_NONE, false, static_cast<float>(_blitW) / static_cast<float>(resW));
+	}
+
+	// Selection brackets are an editor overlay: draw them in window space on top of the blitted image.
+	drawSelectedIconOutline();
 
 	gr_flip();
 	_debugFrameCounter++;
-
-	if ((_debugFrameCounter % 120) == 0) {
-		mprintf(("BriefingMapWidget: rendered briefing frame=%u size=%dx%d current_surface=%p\n",
-			_debugFrameCounter,
-			w,
-			h,
-			static_cast<void*>(context->surface())));
-	}
 
 	// Restore the main viewport's persistent frame so that mouse-interaction
 	// helpers (select_object → g3_point_to_vec) continue to work between the
@@ -692,15 +765,19 @@ void BriefingMapWidget::mousePressEvent(QMouseEvent* event) {
 
 	auto* briefPtr = _model->getWipBriefingPtr(_model->getCurrentTeam());
 	if (!briefPtr || _currentStage < 0 || _currentStage >= briefPtr->num_stages || _lastRenderWidth <= 0 || _lastRenderHeight <= 0 ||
-		width() <= 0 || height() <= 0) {
+		_blitW <= 0 || _blitH <= 0) {
 		_draggingIcon = false;
 		_dragIconIndex = -1;
 		return;
 	}
 
-	const auto mouseX = static_cast<float>(event->position().x() * devicePixelRatio()) * (static_cast<float>(_lastRenderWidth) / static_cast<float>(width()));
-	const auto mouseY = static_cast<float>(event->position().y() * devicePixelRatio()) *
-						(static_cast<float>(_lastRenderHeight) / static_cast<float>(height()));
+	// Map the logical mouse position into reference-resolution space: convert to device pixels,
+	// shift by the letterbox origin, then scale from the blit rectangle to the render-target size.
+	const auto dpr = static_cast<float>(devicePixelRatio());
+	const auto mouseX = (static_cast<float>(event->position().x()) * dpr - static_cast<float>(_blitX)) *
+						(static_cast<float>(_lastRenderWidth) / static_cast<float>(_blitW));
+	const auto mouseY = (static_cast<float>(event->position().y()) * dpr - static_cast<float>(_blitY)) *
+						(static_cast<float>(_lastRenderHeight) / static_cast<float>(_blitH));
 
 	auto& stage = briefPtr->stages[_currentStage];
 	int hitIndex = -1;
@@ -741,17 +818,17 @@ void BriefingMapWidget::mouseMoveEvent(QMouseEvent* event) {
 
 	auto* briefPtr = _model->getWipBriefingPtr(_model->getCurrentTeam());
 	if (!briefPtr || _currentStage < 0 || _currentStage >= briefPtr->num_stages || _dragIconIndex >= briefPtr->stages[_currentStage].num_icons ||
-		_lastRenderWidth <= 0 || _lastRenderHeight <= 0 || width() <= 0 || height() <= 0) {
+		_lastRenderWidth <= 0 || _lastRenderHeight <= 0 || _blitW <= 0 || _blitH <= 0) {
 		return;
 	}
 
-	const auto scaleX = static_cast<float>(_lastRenderWidth) / static_cast<float>(width());
-	const auto scaleY = static_cast<float>(_lastRenderHeight) / static_cast<float>(height());
-	const auto deltaX =
-		static_cast<float>((event->position().x() * devicePixelRatio()) - (_dragStartMousePos.x() * devicePixelRatio())) * scaleX;
-	const auto deltaY = static_cast<float>((event->position().y() * devicePixelRatio()) -
-										   (_dragStartMousePos.y() * devicePixelRatio())) *
-		scaleY;
+	// Convert the logical mouse delta into reference-resolution pixels (device pixels scaled from the
+	// letterbox blit rectangle to the render-target size). The letterbox offset cancels in a delta.
+	const auto dpr = static_cast<float>(devicePixelRatio());
+	const auto scaleX = static_cast<float>(_lastRenderWidth) / static_cast<float>(_blitW);
+	const auto scaleY = static_cast<float>(_lastRenderHeight) / static_cast<float>(_blitH);
+	const auto deltaX = static_cast<float>(event->position().x() - _dragStartMousePos.x()) * dpr * scaleX;
+	const auto deltaY = static_cast<float>(event->position().y() - _dragStartMousePos.y()) * dpr * scaleY;
 
 	const auto camPos = brief_get_current_cam_pos();
 	const auto camOrient = brief_get_current_cam_orient();

--- a/qtfred/src/ui/widgets/BriefingMapWidget.cpp
+++ b/qtfred/src/ui/widgets/BriefingMapWidget.cpp
@@ -667,7 +667,9 @@ void BriefingMapWidget::mousePressEvent(QMouseEvent* event) {
 						(static_cast<float>(_lastRenderHeight) / static_cast<float>(_blitRect.height()));
 
 	auto& stage = briefPtr->stages[_currentStage];
-	int hitIndex = -1;
+
+	// Collect every icon under the cursor, top-most first (higher index = drawn later = on top).
+	SCP_vector<int> hits;
 	for (int i = stage.num_icons - 1; i >= 0; --i) {
 		auto& icon = stage.icons[i];
 
@@ -679,24 +681,39 @@ void BriefingMapWidget::mousePressEvent(QMouseEvent* event) {
 		const auto top = static_cast<float>(icon.y);
 
 		if (mouseX >= left && mouseX <= left + scaledW && mouseY >= top && mouseY <= top + scaledH) {
-			hitIndex = i;
-			break;
+			hits.push_back(i);
 		}
 	}
 
-	if (hitIndex >= 0) {
-		_draggingIcon = true;
-		_dragIconIndex = hitIndex;
-		_dragStartIconPos = stage.icons[hitIndex].pos;
-		brief_move_icon_reset();
-		Q_EMIT iconSelected(hitIndex, (event->modifiers() & Qt::ShiftModifier) != 0);
-	} else {
+	const bool shiftHeld = (event->modifiers() & Qt::ShiftModifier) != 0;
+
+	if (hits.empty()) {
 		_draggingIcon = false;
 		_dragIconIndex = -1;
-		if ((event->modifiers() & Qt::ShiftModifier) == 0) {
+		if (!shiftHeld) {
 			Q_EMIT iconSelected(-1, false);
 		}
+		return;
 	}
+
+	int pickedIndex = hits.front(); // default: the top-most icon under the cursor
+	if (!shiftHeld) {
+		// Rolling select: if the currently-selected icon is one of the stacked hits, advance to the
+		// next one underneath (wrapping bottom -> top) so repeated clicks cycle the whole stack.
+		const int current = _model->getCurrentIconIndex();
+		for (size_t k = 0; k < hits.size(); ++k) {
+			if (hits[k] == current) {
+				pickedIndex = hits[(k + 1) % hits.size()];
+				break;
+			}
+		}
+	}
+
+	_draggingIcon = true;
+	_dragIconIndex = pickedIndex;
+	_dragStartIconPos = stage.icons[pickedIndex].pos;
+	brief_move_icon_reset();
+	Q_EMIT iconSelected(pickedIndex, shiftHeld);
 }
 
 void BriefingMapWidget::mouseMoveEvent(QMouseEvent* event) {

--- a/qtfred/src/ui/widgets/BriefingMapWidget.h
+++ b/qtfred/src/ui/widgets/BriefingMapWidget.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <QWidget>
-#include <QWindow>
+#include <QImage>
+#include <QRect>
 #include <QTimer>
 
 #include "globalincs/pstypes.h"
@@ -9,6 +10,9 @@
 #include "osapi/osapi.h"
 #include "ui/QtGraphicsOperations.h"
 
+class QOffscreenSurface;
+class QPainter;
+class QPaintEvent;
 class briefing;
 
 namespace fso::fred::dialogs {
@@ -19,26 +23,13 @@ namespace fso::fred {
 
 class EditorViewport;
 
-class BriefingMapWindow : public QWindow {
-	Q_OBJECT
-public:
-	explicit BriefingMapWindow(QWidget* parentWidget);
-
-	void initializeGL(const QSurfaceFormat& fmt);
-
-protected:
-	bool event(QEvent* evt) override;
-	void exposeEvent(QExposeEvent* event) override;
-
-private:
-	QWidget* _parentWidget = nullptr;
-};
-
-// Lightweight os::Viewport that wraps BriefingMapWindow so we can use
-// gr_use_viewport() / gr_flip() through FSO's normal rendering pipeline.
+// Lightweight os::Viewport backed by an offscreen surface so we can make the engine's GL context
+// current and render the briefing into an off-screen render target. The briefing map is then read
+// back into a QImage and painted into a normal QWidget, which (unlike an embedded native QWindow)
+// participates in the layout and resizes/clips cleanly.
 class BriefingViewport : public QtSurfaceViewport {
 public:
-	explicit BriefingViewport(BriefingMapWindow* window);
+	explicit BriefingViewport(QOffscreenSurface* surface);
 
 	SDL_Window* toSDLWindow() override;
 	std::pair<uint32_t, uint32_t> getSize() override;
@@ -49,7 +40,7 @@ public:
 	QSurface* getRenderSurface() override;
 
 private:
-	BriefingMapWindow* _window = nullptr;
+	QOffscreenSurface* _surface = nullptr;
 };
 
 class BriefingMapWidget : public QWidget {
@@ -68,8 +59,6 @@ public:
 	void setMovementSpeedScale(float scale);
 	void setRotationSpeedScale(float scale);
 
-	QWindow* getRenderWindow() const;
-
 signals:
 	void iconSelected(int index, bool toggleSelection);
 	void cameraChanged(vec3d pos, matrix orient);
@@ -81,24 +70,27 @@ protected:
 	void mousePressEvent(QMouseEvent* event) override;
 	void mouseMoveEvent(QMouseEvent* event) override;
 	void mouseReleaseEvent(QMouseEvent* event) override;
+	void paintEvent(QPaintEvent* event) override;
 
 private:
 	void renderFrame();
+	void restoreMainViewportFrame(bool wasActive);
 	void initBriefingMap();
 	void applyStageTransition(int stageNum, int transitionTime);
 	void maybeRenderCutTransition(float frametime, int width, int height);
 	static bool shouldUseCutTransition(int fromStage, int toStage, const briefing* briefPtr);
 	void updateEditorHighlightPlayback() const;
-	void drawSelectedIconOutline();
+	void drawSelectionBrackets(QPainter& painter);
 	void applyCameraPoseLikeKeyboardControls(const vec3d& camPos, const matrix& camOrient, bool updateModel);
 	void applyBoundCameraControls(float frametime);
 
 	CameraController _cameraController;
 
-	BriefingMapWindow* _window = nullptr;
+	QOffscreenSurface* _surface = nullptr; // offscreen GL surface the briefing renders through
+	QImage _frameImage;                    // last rendered briefing frame (reference resolution)
+	QRect _blitRect;                       // where _frameImage is drawn in the widget (logical px)
 	QTimer* _renderTimer = nullptr;
 	std::unique_ptr<BriefingViewport> _briefingViewport; // our os::Viewport for gr_use_viewport
-	std::unique_ptr<QOpenGLContext> _diagnosticContext;
 
 	dialogs::BriefingEditorDialogModel* _model = nullptr;
 	EditorViewport* _viewport = nullptr;
@@ -106,31 +98,19 @@ private:
 	int _currentStage = 0;
 	bool _initialized = false;
 	bool _rendering = false; // re-entrancy guard
-	bool _loggedNotInitialized = false;
-	bool _loggedNotExposed = false;
-	bool _loggedNoViewport = false;
-	bool _loggedInFrameSkip = false;
 	bool _loggedNoContext = false;
-	bool _loggedSurfaceMismatch = false;
-	bool _loggedMakeCurrentFailure = false;
 	bool _loggedNoRenderTarget = false;
-	uint32_t _debugFrameCounter = 0;
 
-	// Offscreen render target: the briefing is rendered at the reference resolution and then blitted
-	// (scaled + letterboxed) into the widget, so the view is a faithful copy of the canonical briefing.
+	// Offscreen render target: the briefing is rendered at the reference resolution, read back into
+	// _frameImage, and painted (scaled + letterboxed) into the widget, so the view is a faithful copy
+	// of the canonical briefing that resizes cleanly.
 	int _renderTarget = -1;
 	int _renderTargetW = 0;
 	int _renderTargetH = 0;
-	// Destination rectangle of that blit, in device pixels (also used to map mouse input back).
-	int _blitX = 0;
-	int _blitY = 0;
-	int _blitW = 0;
-	int _blitH = 0;
 
 	// Mouse drag state
 	bool _draggingIcon = false;
 	int _dragIconIndex = -1;
-	QPoint _lastMousePos;
 	QPointF _dragStartMousePos;
 	vec3d _dragStartIconPos = ZERO_VECTOR;
 	// Render size icon coordinates are expressed in (the reference/render-target resolution).

--- a/qtfred/src/ui/widgets/BriefingMapWidget.h
+++ b/qtfred/src/ui/widgets/BriefingMapWidget.h
@@ -113,7 +113,19 @@ private:
 	bool _loggedNoContext = false;
 	bool _loggedSurfaceMismatch = false;
 	bool _loggedMakeCurrentFailure = false;
+	bool _loggedNoRenderTarget = false;
 	uint32_t _debugFrameCounter = 0;
+
+	// Offscreen render target: the briefing is rendered at the reference resolution and then blitted
+	// (scaled + letterboxed) into the widget, so the view is a faithful copy of the canonical briefing.
+	int _renderTarget = -1;
+	int _renderTargetW = 0;
+	int _renderTargetH = 0;
+	// Destination rectangle of that blit, in device pixels (also used to map mouse input back).
+	int _blitX = 0;
+	int _blitY = 0;
+	int _blitW = 0;
+	int _blitH = 0;
 
 	// Mouse drag state
 	bool _draggingIcon = false;
@@ -121,6 +133,7 @@ private:
 	QPoint _lastMousePos;
 	QPointF _dragStartMousePos;
 	vec3d _dragStartIconPos = ZERO_VECTOR;
+	// Render size icon coordinates are expressed in (the reference/render-target resolution).
 	int _lastRenderWidth = 0;
 	int _lastRenderHeight = 0;
 

--- a/qtfred/src/ui/widgets/BriefingMapWidget.h
+++ b/qtfred/src/ui/widgets/BriefingMapWidget.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <QImage>
+#include <QPixmap>
 #include <QRect>
 #include <QTimer>
 
@@ -81,6 +82,7 @@ private:
 	static bool shouldUseCutTransition(int fromStage, int toStage, const briefing* briefPtr);
 	void updateEditorHighlightPlayback() const;
 	void drawSelectionBrackets(QPainter& painter);
+	QPixmap checkerboardTile(); // subtle, theme-appropriate matte for the letterbox bars
 	void applyCameraPoseLikeKeyboardControls(const vec3d& camPos, const matrix& camOrient, bool updateModel);
 	void applyBoundCameraControls(float frametime);
 
@@ -89,6 +91,8 @@ private:
 	QOffscreenSurface* _surface = nullptr; // offscreen GL surface the briefing renders through
 	QImage _frameImage;                    // last rendered briefing frame (reference resolution)
 	QRect _blitRect;                       // where _frameImage is drawn in the widget (logical px)
+	QPixmap _checkerTile;                  // cached matte tile
+	bool _checkerTileDark = false;         // theme the cached tile was built for
 	QTimer* _renderTimer = nullptr;
 	std::unique_ptr<BriefingViewport> _briefingViewport; // our os::Viewport for gr_use_viewport
 


### PR DESCRIPTION
This reworks the QtFRED Briefing Editor's map viewport, which previously embedded its render as a native QWindow that painted over the surrounding controls and refused to shrink inside the dialog's layout. The briefing is now rendered into an off-screen render target, read back into a QImage, and painted in an ordinary QWidget, so it participates in the layout and resizes/letterboxes cleanly in every direction while staying DPI-correct. It composes at the retail GR_1024 briefing map size (Brief_grid_coords[GR_1024], 888×371), what the game and Lua's ui.drawBriefingMap() default to, rather than the FRED-only $FRED Briefing window resolution setting that the game ignores, making the editor an unconditional WYSIWYG preview of the actual shipped briefing. 

Clicking overlapping icons now cycles top-to-bottom through the stack on repeated clicks, so icons layered underneath others are finally selectable. 

The letterbox/pillarbox bars get a subtle, theme-appropriate grey checkerboard matte so the map's true edges are clearly distinguishable from the empty space around them.

Finally, a small shared Theme::currentThemeIsDark() accessor was added for that and adopted by VariableDialog and the help browser in place of three separate ad-hoc dark-mode checks.