### PR TITLE
QtFRED fix waypoint initial orders

### DIFF
--- a/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.cpp
@@ -301,6 +301,12 @@ void ShipGoalsDialog::updateUi()
 			default:
 				break;
 			}
+
+			// Commit the shown default target for new orders so they validate instead of erroring out.
+			if (_model->getObject(i) == -1 && objects[i]->count() > 0) {
+				_model->setObject(i, objects[i]->itemData(objects[i]->currentIndex()).value<int>());
+			}
+
 			if (mode == AI_GOAL_DESTROY_SUBSYSTEM) {
 				subsys[i]->setEnabled(true);
 				docks[i]->setEnabled(false);


### PR DESCRIPTION
New initial orders start with no committed target (_object == -1). The target combo visually defaults to its first item, but with signals blocked that selection is never pushed to the model, and re-picking the already-shown item emits no change signal. Ship/player targets auto-commit their first valid entry inline during population; waypoint paths, individual waypoints, ship classes, and wings did not, so a new order of those types stayed uncommitted and failed validation on apply.

Add a uniform fallback after the target combos are populated. If a new order has no committed target, commit the currently-shown default.