### PR TITLE
Fix space mouse detection with SDL_hidapi

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -411,6 +411,14 @@ void os_init(const char * wclass, const char * title, const char * app_name)
 		SDL_SetLogOutputFunction(&logHandler, nullptr);
 	}
 
+	// Initialize SDL's HIDAPI up front. SDL_hid_enumerate() nominally auto-inits, but FRED's space
+	// mouse support only reliably finds an already-connected device when HIDAPI is initialized here
+	// rather than lazily on first enumeration. Paired with SDL_hid_exit() in os_deinit().
+	if ( SDL_hid_init() != 0 )
+	{
+		mprintf(("Couldn't init SDL HIDAPI (space mouse may be unavailable): %s\n", SDL_GetError()));
+	}
+
 	if ( !SDL_Init(SDL_INIT_EVENTS) )
 	{
 		fprintf(stderr, "Couldn't init SDL: %s", SDL_GetError());
@@ -622,10 +630,13 @@ bool os_is_legacy_mode()
 // called at shutdown. Makes sure all thread processing terminates.
 void os_deinit()
 {
-	// Free the view ports 
+	// Free the view ports
 	os::closeAllViewports();
 
 	SDL_Quit();
+
+	// Balance the SDL_hid_init() from os_init().
+	SDL_hid_exit();
 }
 
 void debug_int3(const char *file, int line)


### PR DESCRIPTION
Since #7646 switched from the bundled hidapi to SDL_hidapi, no space mouse is ever found: the standalone hidapi's hid_enumerate() implicitly initialized the library, but SDL's SDL_hid_enumerate() does not reliably do so, so it returns an empty device list and getSharedSpaceMouse() caches nullptr for the session.

Call SDL_hid_init() before enumerating, matching SDL's documented usage.