### PR TITLE
fix keycontrol unsetting dual-fire

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1931,18 +1931,18 @@ int button_function_critical(int n, net_player *p = NULL)
 				break;
 			}
 
-			if (!ship_secondary_bank_can_dual_fire(&Ships[objp->instance], Ships[objp->instance].weapons.current_secondary_bank)) {
-				// leave the dual fire preference alone; it is ignored rather than cleared for banks that can't use it
-				if(at_self) {
-					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "This secondary bank cannot fire dual missiles", 1932));
-					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
-					hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-				}
-			} else if (Ships[objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire]) {
+			if (Ships[objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire]) {
 				Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
 				if(at_self) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Secondary weapon set to normal fire mode", 34));
 					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::SECONDARY_CYCLE)) );
+					hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
+				}
+			} else if (!ship_secondary_bank_can_dual_fire(&Ships[objp->instance], Ships[objp->instance].weapons.current_secondary_bank)) {
+				// leave the dual fire preference alone; it is ignored rather than cleared for banks that can't use it
+				if(at_self) {
+					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "This secondary bank cannot fire dual missiles", 1932));
+					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 					hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
 				}
 			} else {


### PR DESCRIPTION
Quick follow-up to #7635.  Even though you can't set dual-fire when a non-dual-fire bank is active, you should be able to *un*set it.  Reorder the conditions so this is possible.