### PR TITLE
Clear stale Prop_info model handles when a model is unloaded

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -35,6 +35,7 @@
 #include "model/modelreplace.h"
 #include "model/modelsinc.h"
 #include "parse/parselo.h"
+#include "prop/prop.h"
 #include "render/3dinternal.h"
 #include "ship/ship.h"
 #include "starfield/starfield.h"
@@ -311,6 +312,16 @@ void model_unload(int modelnum, int force)
 		}
 		if (pm->id == wi.external_model_num) {
 			wi.external_model_num = -1;
+		}
+	}
+
+	// and props, for the same reason: props_level_close() only clears the prop
+	// instances, so without this the class-level handle survives the model being
+	// freed and the next placement of that prop class reads a slot that has since
+	// been reused by an unrelated model.
+	for (auto& pip : Prop_info) {
+		if (pm->id == pip.model_num) {
+			pip.model_num = -1;
 		}
 	}
 


### PR DESCRIPTION
Adds the matching Prop_info pass. Doing it in model_unload rather than props_level_close mirrors how the two closest analogues are handled (Ship_info and Weapon_info are likewise class tables holding a cached handle for placeable objects) and covers any unload path, not just level close. (asteroid_level_close solves the same problem for Asteroid_info from the other direction.)

The Assert I triggered can be reproduced like this: In QtFRED or FRED2 create a prop, File -> New Mission & Discard, then create the same prop again. Asserts in model_get with "Index collision between model <other>.pof and requested model N".