### PR TITLE
clean up static alias lists used for name lookups

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -494,8 +494,8 @@ extern int Mission_all_attack;	//	!0 means all teams attack all teams.
 extern ai_info Ai_info[];
 extern ai_info *Player_ai;
 
-extern ai_class *Ai_classes;
-extern char** Ai_class_names;
+extern SCP_vector<ai_class> Ai_classes;
+extern SCP_vector<const char*> Ai_class_names;
 
 extern int Num_ai_classes;
 extern int Ai_firing_enabled;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -203,10 +203,9 @@ object *En_objp;
 #define	STEALTH_MAX_VIEW_DIST	400		// dist at which 1) stealth no longer visible 2) firing inaccuracy is greatest
 #define	STEALTH_VIEW_CONE_DOT	0.707		// (half angle of 45 degrees)
 
-ai_class *Ai_classes = NULL;
+SCP_vector<ai_class> Ai_classes;
 int	Ai_firing_enabled = 1;
 int	Num_ai_classes;
-int Num_alloced_ai_classes;
 
 int	AI_FrameCount = 0;
 int	AI_watch_object = 0; // Debugging, object to spew debug info for.
@@ -289,7 +288,7 @@ pnode		*Ppfp;			//	Free pointer in path points.
 
 float	AI_frametime;
 
-char** Ai_class_names = NULL;
+SCP_vector<const char*> Ai_class_names;
 
 //used for good-primary-time
 typedef struct {
@@ -612,15 +611,6 @@ int create_object_hash(object *objp)
 	return hashval;
 }
 
-void free_ai_stuff()
-{
-	if(Ai_classes != NULL)
-		vm_free(Ai_classes);
-	
-	if(Ai_class_names != NULL)
-		vm_free(Ai_class_names);
-}
-
 int ai_get_autoscale_index(int absolute_index)
 {
 	int index = 0;
@@ -765,11 +755,11 @@ void parse_ai_class()
 		}
 
 		// Setup a new ai class
-		aicp = &Ai_classes[Num_ai_classes];
+		Ai_classes.emplace_back();
+		aicp = &Ai_classes.back();
 		strcpy(aicp->name, thisName);
 
 		init_ai_class(aicp);
-		Ai_class_names[Num_ai_classes] = aicp->name;
 
 		Num_ai_classes++;
 
@@ -955,18 +945,6 @@ void parse_ai_class()
 	set_aic_flag(aicp, "$AI balances shields instead of directs when attacked:", AI::Profile_Flags::AI_balances_shields_when_attacked);
 }
 
-void reset_ai_class_names()
-{
-	ai_class *aicp;
-
-	for (int i = 0; i < Num_ai_classes; i++) {
-		aicp = &Ai_classes[i];
-
-		Ai_class_names[i] = aicp->name;
-	}
-}
-
-#define AI_CLASS_INCREMENT		10
 void parse_aitbl(const char* filename)
 {
 	try {
@@ -976,20 +954,7 @@ void parse_aitbl(const char* filename)
 		required_string("#AI Classes");
 
 		while (required_string_either("#End", "$Name:")) {
-
 			parse_ai_class();
-
-			if(Num_ai_classes >= Num_alloced_ai_classes)
-			{
-				Num_alloced_ai_classes += AI_CLASS_INCREMENT;
-				Ai_classes = (ai_class*) vm_realloc(Ai_classes, Num_alloced_ai_classes * sizeof(ai_class));
-
-				// Ai_class_names doesn't realloc all that well so we have to do it the hard way.
-				// Luckily, it's contents can be easily replaced so we don't have to save anything.
-				vm_free(Ai_class_names);
-				Ai_class_names = (char **) vm_malloc(Num_alloced_ai_classes * sizeof(char*));
-				reset_ai_class_names();
-			}
 		}
 
 	}
@@ -1010,13 +975,10 @@ LOCAL int ai_inited = 0;
 void ai_init()
 {
 	if ( !ai_inited )	{
-		// Do the first time initialization stuff here		
-		free_ai_stuff();
-
+		// Do the first time initialization stuff here
+		Ai_classes.clear();
+		Ai_class_names.clear();
 		Num_ai_classes = 0;
-		Num_alloced_ai_classes = AI_CLASS_INCREMENT;
-		Ai_classes = (ai_class*)vm_malloc(Num_alloced_ai_classes * sizeof(ai_class));
-		Ai_class_names = (char**)vm_malloc(Num_alloced_ai_classes * sizeof(char*));
 
 		parse_aitbl("ai.tbl");
 
@@ -1042,7 +1004,10 @@ void ai_init()
 			Ai_classes[autoscaled_class_index].ai_class_autoscale = false;
 		}
 
-		atexit(free_ai_stuff);
+		// fill in the name alias list
+		Ai_class_names.clear();
+		for (const auto &aic : Ai_classes)
+			Ai_class_names.push_back(aic.name);
 
 		ai_inited = 1;
 	}

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -63,7 +63,6 @@ extern int Hud_target_w, Hud_target_h;
 
 extern shader Training_msg_glass;
 
-extern char **Ai_class_names;
 extern const char *Submode_text[];
 extern const char *Strafe_submode_text[];
 

--- a/code/iff_defs/iff_defs.cpp
+++ b/code/iff_defs/iff_defs.cpp
@@ -18,6 +18,7 @@
 extern int radar_target_id_flags;
 
 SCP_vector<iff_info> Iff_info;
+SCP_vector<const char *> Iff_info_names;		// to be filled in from Iff_info
 
 int Iff_traitor;
 
@@ -144,9 +145,13 @@ void resolve_iff_data()
 			Iff_info[Iff_traitor].iff_name);
 	}
 
+	Iff_info_names.clear();
+
 	// next get the attackees and colors
 	for (int cur_iff = 0; cur_iff < (int)Iff_info.size(); cur_iff++) {
 		iff_info* iff = &Iff_info[cur_iff];
+
+		Iff_info_names.push_back(iff->iff_name);
 
 		// clear the iffs to be attacked
 		iff->attackee_bitmask = 0;

--- a/code/iff_defs/iff_defs.h
+++ b/code/iff_defs/iff_defs.h
@@ -58,6 +58,7 @@ typedef struct iff_info {
 } iff_info;
 
 extern SCP_vector<iff_info> Iff_info;
+extern SCP_vector<const char *> Iff_info_names;
 
 extern int Iff_traitor;
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -270,8 +270,6 @@ const char *Ai_behavior_names[MAX_AI_BEHAVIORS] = {
 char *Cargo_names[MAX_CARGO];
 char Cargo_names_buf[MAX_CARGO][NAME_LENGTH];
 
-const char *Ship_class_names[MAX_SHIP_CLASSES];		// to be filled in from Ship_info array
-
 const char *Icon_names[MIN_BRIEF_ICONS] = {
 	"Fighter", "Fighter Wing", "Cargo", "Cargo Wing", "Largeship",
 	"Largeship Wing", "Capital", "Planet", "Asteroid Field", "Waypoint",
@@ -1934,11 +1932,6 @@ void parse_briefing(mission * /*pm*/, int flags)
 
 			Assert(bs->num_icons <= MAX_STAGE_ICONS );
 
-			// static alias stuff - stupid, but it seems to be necessary
-			auto temp_team_names = std::unique_ptr<const char* []>(new const char*[Iff_info.size()]);
-			for (i = 0; i < (int)Iff_info.size(); i++)
-				temp_team_names[i] = Iff_info[i].iff_name;
-
 			while (required_string_either("$end_stage", "$start_icon"))
 			{
 				required_string("$start_icon");
@@ -1970,9 +1963,9 @@ void parse_briefing(mission * /*pm*/, int flags)
 						bi->type = ICON_TRANSPORT_WING;
 				}
 
-				find_and_stuff("$team:", &bi->team, F_NAME, temp_team_names.get(), Iff_info.size(), "team name");
+				find_and_stuff("$team:", &bi->team, F_NAME, Iff_info_names.data(), Iff_info_names.size(), "team name");
 
-				find_and_stuff("$class:", &bi->ship_class, F_NAME, Ship_class_names, Ship_info.size(), "ship class");
+				find_and_stuff("$class:", &bi->ship_class, F_NAME, Ship_class_names.data(), Ship_class_names.size(), "ship class");
 				bi->modelnum = -1;
 				bi->model_instance_num = -1;
 
@@ -3404,7 +3397,6 @@ extern int parse_warp_params(const WarpParams *inherit_from, WarpDirection direc
  */
 int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 {
-	int	i;
     char name[NAME_LENGTH];
 	ship_info *sip;
 
@@ -3427,7 +3419,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 		p_objp->flags.set(Mission::Parse_Object_Flags::SF_Has_display_name);
 	}
 
-	find_and_stuff("$Class:", &p_objp->ship_class, F_NAME, Ship_class_names, Ship_info.size(), "ship class");
+	find_and_stuff("$Class:", &p_objp->ship_class, F_NAME, Ship_class_names.data(), Ship_class_names.size(), "ship class");
 	if (p_objp->ship_class < 0)
 	{
 		if (Fred_running) {
@@ -3536,11 +3528,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 			mprintf(("Using callsign: %s\n", name));
 	}
 
-	auto temp_team_names = std::unique_ptr<const char*[]>(new const char*[Iff_info.size()]);
-	for (i = 0; i < (int)Iff_info.size(); i++)
-		temp_team_names[i] = Iff_info[i].iff_name;
-
-	find_and_stuff("$Team:", &p_objp->team, F_NAME, temp_team_names.get(), Iff_info.size(), "team name");
+	find_and_stuff("$Team:", &p_objp->team, F_NAME, Iff_info_names.data(), Iff_info_names.size(), "team name");
 
 	// save current team for loadout purposes, so that in multi we always respawn
 	// from the original loadout slot even if the team changes
@@ -3578,7 +3566,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 
 	if (optional_string("+AI Class:")) 
 	{
-		p_objp->ai_class = match_and_stuff(F_NAME, Ai_class_names, Num_ai_classes, "AI class");
+		p_objp->ai_class = match_and_stuff(F_NAME, Ai_class_names.data(), Num_ai_classes, "AI class");
 
 		if (p_objp->ai_class < 0) 
 		{
@@ -4252,7 +4240,7 @@ void parse_common_object_data(p_object *p_objp)
 
 		if (optional_string("+AI Class:"))
 		{
-			Subsys_status[i].ai_class = match_and_stuff(F_NAME, Ai_class_names, Num_ai_classes, "AI class");
+			Subsys_status[i].ai_class = match_and_stuff(F_NAME, Ai_class_names.data(), Num_ai_classes, "AI class");
 
 			if (Subsys_status[i].ai_class < 0)
 			{
@@ -7540,16 +7528,10 @@ void mission_init(mission *pm, bool quick_init)
 // info such as game type, number of players etc. or whether we are importing from a different format.
 bool parse_main(const char *mission_name, int flags)
 {
-	int i;
 	bool rval;
 
 	Assert(Ship_info.size() <= MAX_SHIP_CLASSES);
 
-	// fill in Ship_class_names array with the names from the ship_info struct
-	i = 0;
-	for (auto it = Ship_info.begin(); it != Ship_info.end(); i++, ++it)
-		Ship_class_names[i] = it->name;
-	
 	do {
 		// don't do this for imports
 		if (!(flags & MPF_IMPORT_FSM)) {

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -309,7 +309,6 @@ typedef struct path_restriction_t {
 	char path_names[MAX_SHIP_BAY_PATHS][MAX_NAME_LEN];
 } path_restriction_t;
 
-extern const char *Ship_class_names[MAX_SHIP_CLASSES];
 extern const char *Ai_behavior_names[MAX_AI_BEHAVIORS];
 extern const char *Arrival_location_names[MAX_ARRIVAL_NAMES];
 extern const char *Departure_location_names[MAX_DEPARTURE_NAMES];

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -311,6 +311,8 @@ ship_obj		Ship_objs[MAX_SHIP_OBJS];		// array used to store ship object indexes
 ship_obj		Ship_obj_list;							// head of linked list of ship_obj structs, Standalone ship cannot be in this list or it will cause bugs.
 
 SCP_vector<ship_info>	Ship_info;
+SCP_vector<const char *> Ship_class_names;		// to be filled in from Ship_info
+
 SCP_vector<reinforcements>	Reinforcements;
 SCP_vector<ship_info>	Ship_templates;
 
@@ -318,6 +320,7 @@ SCP_vector<ship_type_info> Ship_types;
 bool Fighter_bomber_valid = false;
 const char *Fighter_bomber_type_name = "fighter/bomber";
 int Ship_type_fighter = -1, Ship_type_bomber = -1, Ship_type_fighter_bomber = -1;
+
 
 SCP_vector<ArmorType> Armor_types;
 SCP_vector<DamageTypeStruct>	Damage_types;
@@ -4169,7 +4172,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		}
 	}
 
-	find_and_stuff_optional("$AI Class:", &sip->ai_class, F_NAME, Ai_class_names, Num_ai_classes, "AI class names");
+	find_and_stuff_optional("$AI Class:", &sip->ai_class, F_NAME, Ai_class_names.data(), Num_ai_classes, "AI class names");
 
 	// Get Afterburner information
 	// Be aware that if $Afterburner is not 1, the other Afterburner fields are not read in
@@ -6158,8 +6161,12 @@ static void ship_parse_post_cleanup()
 	int j;
 	char name_tmp[NAME_LENGTH];
 
+	Ship_class_names.clear();
+
 	for (auto sip = Ship_info.begin(); sip != Ship_info.end(); ++sip)
 	{
+		Ship_class_names.push_back(sip->name);
+
 		// ballistic primary fixage...
 		{
 			bool pbank_capacity_specified = false;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1735,6 +1735,8 @@ extern char TVT_wing_names[MAX_TVT_WINGS][NAME_LENGTH];
 extern int ai_paused;
 
 extern SCP_vector<ship_info> Ship_info;
+extern SCP_vector<const char *> Ship_class_names;
+
 extern SCP_vector<reinforcements> Reinforcements;
 
 // structure definition for ship type counts.  Used to give a count of the number of ships

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -109,8 +109,7 @@ missile_obj Missile_obj_list;						// head of linked list of missile_obj structs
 
 #define DEFAULT_WEAPON_SPAWN_COUNT	10
 
-int	Num_spawn_types = 0;
-char** Spawn_names = nullptr;
+SCP_vector<SCP_string> Spawn_names;
 
 //WEAPON SUBTYPE STUFF
 const char *Weapon_subtype_names[] = {
@@ -142,14 +141,8 @@ special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info
 	{ "spawn",							Weapon::Info_Flags::Spawn,								true, [](const SCP_string& spawn, weapon_info* weaponp, flagset<Weapon::Info_Flags>& flags) {
 		if (weaponp->num_spawn_weapons_defined < MAX_SPAWN_TYPES_PER_WEAPON)
 		{
-			//We need more spawning slots
-			//allocate in slots of 10
-			if ((Num_spawn_types % 10) == 0) {
-				Spawn_names = (char**)vm_realloc(Spawn_names, (Num_spawn_types + 10) * sizeof(*Spawn_names));
-			}
-
 			flags.set(Weapon::Info_Flags::Spawn);
-			weaponp->spawn_info[weaponp->num_spawn_weapons_defined].spawn_wep_index = (short)Num_spawn_types;
+			weaponp->spawn_info[weaponp->num_spawn_weapons_defined].spawn_wep_index = (short)Spawn_names.size();
 			size_t start_num = spawn.find_first_of(',');
 			if (start_num == SCP_string::npos) {
 				weaponp->spawn_info[weaponp->num_spawn_weapons_defined].spawn_count = DEFAULT_WEAPON_SPAWN_COUNT;
@@ -161,8 +154,7 @@ special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info
 
 			weaponp->maximum_children_spawned += weaponp->spawn_info[weaponp->num_spawn_weapons_defined].spawn_count;
 
-			Spawn_names[Num_spawn_types] = vm_strndup(spawn.substr(0, start_num).c_str(), start_num);
-			Num_spawn_types++;
+			Spawn_names.push_back(spawn.substr(0, start_num));
 			weaponp->num_spawn_weapons_defined++;
 		}
 		else {
@@ -4382,16 +4374,13 @@ void translate_spawn_types()
     {
         for (j = 0; j < Weapon_info[i].num_spawn_weapons_defined; j++)
         {
-            if ( (Weapon_info[i].spawn_info[j].spawn_wep_index > -1) && (Weapon_info[i].spawn_info[j].spawn_wep_index < Num_spawn_types) )
+            int spawn_type = Weapon_info[i].spawn_info[j].spawn_wep_index;
+            if ( Spawn_names.in_bounds(spawn_type) )
             {
-                int	spawn_type = Weapon_info[i].spawn_info[j].spawn_wep_index;
-
-                Assert( spawn_type < Num_spawn_types );
-
 				bool found_a_match = false;
                 for (k = 0; k < weapon_info_size(); k++)
                 {
-                    if ( !stricmp(Spawn_names[spawn_type], Weapon_info[k].name) ) 
+                    if ( !stricmp(Spawn_names[spawn_type].c_str(), Weapon_info[k].name) )
                     {
                         Weapon_info[i].spawn_info[j].spawn_wep_index = (short)k;
 
@@ -4404,7 +4393,7 @@ void translate_spawn_types()
                 }
 
 				if (!found_a_match) {
-					Warning(LOCATION, "Couldn't find spawn weapon %s for Weapon %s.\n", Spawn_names[spawn_type], Weapon_info[i].name);
+					Warning(LOCATION, "Couldn't find spawn weapon %s for Weapon %s.\n", Spawn_names[spawn_type].c_str(), Weapon_info[i].name);
 					Weapon_info[i].spawn_info[j].spawn_wep_index = -1;
 				}
             }
@@ -5176,7 +5165,7 @@ void weapon_post_ship_init()
 void weapon_init()
 {
 	if ( !Weapons_inited ) {
-		Num_spawn_types = 0;
+		Spawn_names.clear();
 
 		// parse weapons.tbl
 		Removed_weapons.clear();
@@ -5217,17 +5206,7 @@ void weapon_close()
 		used_weapons = NULL;
 	}
 
-	if (Spawn_names != NULL) {
-		for (i=0; i<Num_spawn_types; i++) {
-			if (Spawn_names[i] != NULL) {
-				vm_free(Spawn_names[i]);
-				Spawn_names[i] = NULL;
-			}
-		}
-
-		vm_free(Spawn_names);
-		Spawn_names = NULL;
-	}
+	Spawn_names.clear();
 }
 
 /**


### PR DESCRIPTION
Refactor `Ship_class_names`, `Iff_info_names`, and `Ai_class_names` to be populated once at parse time, as opposed to ad-hoc and possibly many times.

Also make `Ai_classes` and `Spawn_names` proper SCP_vectors.

This PR is another step toward the lifting of ship class limits.