### PR TITLE
fetch libRocket via FetchContent instead of a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/libRocket"]
-	path = lib/libRocket
-	url = https://github.com/scp-fs2open/libRocket.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,6 @@ endif()
 
 PROJECT(FS2_Open LANGUAGES ${FSO_LANGUAGES})
 
-# Check if the external modules exists
-IF(NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib/libRocket/Build")
-	message(FATAL_ERROR "External submodules could not be found. Please make sure you have updated your submodules.")
-endif()
-
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/finder")
 

--- a/lib/libRocket.cmake
+++ b/lib/libRocket.cmake
@@ -2,7 +2,23 @@
 # Build script for libRocket =======
 #===================================
 
-set(LIBROCKET_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libRocket")
+# Fetch the libRocket sources. We only consume the source tree here (the
+# Rocket* targets below are defined by this script, not by libRocket's own
+# build system), and the repository has no top-level CMakeLists.txt, so
+# FetchContent_MakeAvailable() populates it without calling add_subdirectory().
+#
+# Offline / local development: point FetchContent at an existing checkout to
+# skip the download, e.g.
+#     -DFETCHCONTENT_SOURCE_DIR_LIBROCKET=/path/to/libRocket
+# or set FETCHCONTENT_BASE_DIR to a shared cache so clean rebuilds reuse it.
+include(FetchContent)
+FetchContent_Declare(libRocket
+	GIT_REPOSITORY https://github.com/scp-fs2open/libRocket.git
+	GIT_TAG        b0c18e17d257a46db8395485895185915f483ede
+)
+FetchContent_MakeAvailable(libRocket)
+
+set(LIBROCKET_DIR "${librocket_SOURCE_DIR}")
 
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0015 NEW)


### PR DESCRIPTION
libRocket was the last git submodule. FSO only consumes its source tree (the Rocket* targets are defined by lib/libRocket.cmake, not by libRocket's own build system, and the repo has no top-level CMakeLists.txt), so fetch it with FetchContent_MakeAvailable, which populates the sources without building them. Point LIBROCKET_DIR at the populated source dir.

With no submodules left, drop .gitmodules and the "External submodules could not be found" check in the top-level CMakeLists. Cloning and configuring no longer requires `git submodule update --init`.

Offline/local builds can set FETCHCONTENT_SOURCE_DIR_LIBROCKET (documented in libRocket.cmake).

~~In draft as it depends on #7656.~~