### PR TITLE
Fix scripting copy-paste bug and other minor optimizations

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -7592,7 +7592,7 @@ static void get_behind_ship(ai_info *aip)
 
 	dot = vm_vec_dot(&vec_from_enemy, &En_objp->orient.vec.fvec);
 	
-	if (ai_willing_to_afterburn_hard(aip) && dot > 0.9f && vm_vec_dist(&Pl_objp->pos, &En_objp->pos) > 1000.0f) {
+	if (ai_willing_to_afterburn_hard(aip) && dot > 0.9f && vm_vec_dist_squared(&Pl_objp->pos, &En_objp->pos) > 1000.0f * 1000.0f) {
 		ai_afterburn_hard(Pl_objp, aip);
 	} else if (dot > 0.25f) {
 		accelerate_ship(aip, 1.0f);
@@ -12373,10 +12373,12 @@ void ai_process_subobjects(int objnum)
 
 				// handle ending animations
 				if ( (pss->turret_animation_position == MA_POS_READY) && timestamp_elapsed(pss->turret_animation_done_time) ) {
+					ship_info* turret_sip = &Ship_info[shipp->ship_info_index];
+					polymodel_instance* turret_pmi = model_get_instance(shipp->model_instance_num);
 					//For legacy animations using subtype for turret number
-					bool started = (Ship_info[shipp->ship_info_index].animations.getAll(model_get_instance(shipp->model_instance_num), animation::ModelAnimationTriggerType::TurretFiring, pss->system_info->subobj_num, true)
+					bool started = (turret_sip->animations.getAll(turret_pmi, animation::ModelAnimationTriggerType::TurretFiring, pss->system_info->subobj_num, true)
 						//For modern animations using proper triggered-by-subsys name
-						+ Ship_info[shipp->ship_info_index].animations.get(model_get_instance(shipp->model_instance_num), animation::ModelAnimationTriggerType::TurretFiring, animation::anim_name_from_subsys(pss->system_info)))
+						+ turret_sip->animations.get(turret_pmi, animation::ModelAnimationTriggerType::TurretFiring, animation::anim_name_from_subsys(pss->system_info)))
 						.start(animation::ModelAnimationDirection::RWD);
 					
 					if (started) {

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1101,7 +1101,7 @@ void obj_collide_pair(object *A, object *B)
                 }
 
                 // for nonplayer ships, only create collision pair if close enough
-                if ( (B->parent >= 0) && !((Objects[B->parent].signature == B->parent_sig) && (Objects[B->parent].flags[Object::Object_Flags::Player_ship])) && (vm_vec_dist_squared(&B->pos, &A->pos) < (4.0f*A->radius + 200.0f) * (4.0f*A->radius + 200.0f)) ) {
+                if ( (B->parent >= 0) && ((Objects[B->parent].signature != B->parent_sig) || !(Objects[B->parent].flags[Object::Object_Flags::Player_ship])) && (vm_vec_dist_squared(&B->pos, &A->pos) < (4.0f*A->radius + 200.0f) * (4.0f*A->radius + 200.0f)) ) {
                     collision_info->next_check_time = -1;
                     return;
                 }

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1101,7 +1101,7 @@ void obj_collide_pair(object *A, object *B)
                 }
 
                 // for nonplayer ships, only create collision pair if close enough
-                if ( (B->parent >= 0) && !((Objects[B->parent].signature == B->parent_sig) && (Objects[B->parent].flags[Object::Object_Flags::Player_ship])) && (vm_vec_dist(&B->pos, &A->pos) < (4.0f*A->radius + 200.0f)) ) {
+                if ( (B->parent >= 0) && !((Objects[B->parent].signature == B->parent_sig) && (Objects[B->parent].flags[Object::Object_Flags::Player_ship])) && (vm_vec_dist_squared(&B->pos, &A->pos) < (4.0f*A->radius + 200.0f) * (4.0f*A->radius + 200.0f)) ) {
                     collision_info->next_check_time = -1;
                     return;
                 }

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1417,7 +1417,9 @@ void obj_move_all_post(object *objp, float frametime)
 
 			//Check for changing team colors
 			ship* shipp = &Ships[objp->instance];
-			if (Ship_info[shipp->ship_info_index].uses_team_colors && stricmp(shipp->secondary_team_name.c_str(), "none") != 0) {
+			// team_change_time is nonzero only while a fade is in progress (see sexp_change_team_color),
+			// so use that as the initial short-circuit check before the string match
+			if (shipp->team_change_time != 0 && Ship_info[shipp->ship_info_index].uses_team_colors && stricmp(shipp->secondary_team_name.c_str(), "none") != 0) {
 				if (f2fl(Missiontime) * 1000 > f2fl(shipp->team_change_timestamp) * 1000 + shipp->team_change_time) {
 					shipp->team_name = shipp->secondary_team_name;
 					shipp->team_change_timestamp = 0;
@@ -1711,7 +1713,7 @@ void obj_move_all(float frametime)
 		obj_move_all_post(objp, frametime);
 
 		// Equipment script processing
-		if (objp->type == OBJ_SHIP) {
+		if (objp->type == OBJ_SHIP && scripting::hooks::OnWeaponEquipped->isActive()) {
 			ship* shipp = &Ships[objp->instance];
 			object* target;
 
@@ -1722,13 +1724,11 @@ void obj_move_all(float frametime)
 			if (objp == Player_obj && Player_ai->target_objnum != -1)
 				target = &Objects[Player_ai->target_objnum];
 
-			if (scripting::hooks::OnWeaponEquipped->isActive()) {
-				scripting::hooks::OnWeaponEquipped->run(scripting::hooks::WeaponEquippedConditions{ shipp, target },
-					scripting::hook_param_list(
-						scripting::hook_param("User", 'o', objp),
-						scripting::hook_param("Target", 'o', target)
-					));
-			}
+			scripting::hooks::OnWeaponEquipped->run(scripting::hooks::WeaponEquippedConditions{ shipp, target },
+				scripting::hook_param_list(
+					scripting::hook_param("User", 'o', objp),
+					scripting::hook_param("Target", 'o', target)
+				));
 		}
 	}
 

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -292,10 +292,10 @@ void radar_plot_object( object *objp )
 
 	// Apply range filter (squared-distance cull first so the sqrt only runs for blips that survive)
 	max_radar_dist = Radar_ranges[HUD_config.rp_dist];
-	if (vm_vec_dist_squared(&world_pos, &Player_obj->pos) > max_radar_dist * max_radar_dist) {
+	float dist_sq = vm_vec_mag_squared(&tempv);
+	if (dist_sq > max_radar_dist * max_radar_dist)
 		return;
-	}
-	dist = vm_vec_dist(&world_pos, &Player_obj->pos);
+	dist = sqrtf(dist_sq);
 
 	// Mine range-based visibility: sensors_range is the outer detection envelope. The parser
 	// guarantees sensors_range >= targetable_range, so anything within targetable range is
@@ -651,12 +651,12 @@ RadarVisibility radar_is_visible( object *objp )
 	vm_vec_sub(&tempv, &world_pos, &Player_obj->pos);
 	vm_vec_rotate(&pos, &tempv, &Player_obj->orient);
 
-	// Apply range filter
-	dist = vm_vec_dist(&world_pos, &Player_obj->pos);
+	// Apply range filter (squared-distance cull first so the sqrt only runs for blips that survive)
 	max_radar_dist = Radar_ranges[HUD_config.rp_dist];
-	if (dist > max_radar_dist) {
+	float dist_sq = vm_vec_mag_squared(&tempv);
+	if (dist_sq > max_radar_dist * max_radar_dist)
 		return NOT_VISIBLE;
-	}
+	dist = sqrtf(dist_sq);
 	
 	if (objp->type == OBJ_SHIP)
 	{

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -290,12 +290,12 @@ void radar_plot_object( object *objp )
 	vm_vec_sub(&tempv, &world_pos, &Player_obj->pos);
 	vm_vec_rotate(&pos, &tempv, &eye_orient);
 
-	// Apply range filter
-	dist = vm_vec_dist(&world_pos, &Player_obj->pos);
+	// Apply range filter (squared-distance cull first so the sqrt only runs for blips that survive)
 	max_radar_dist = Radar_ranges[HUD_config.rp_dist];
-	if (dist > max_radar_dist) {
+	if (vm_vec_dist_squared(&world_pos, &Player_obj->pos) > max_radar_dist * max_radar_dist) {
 		return;
 	}
+	dist = vm_vec_dist(&world_pos, &Player_obj->pos);
 
 	// Mine range-based visibility: sensors_range is the outer detection envelope. The parser
 	// guarantees sensors_range >= targetable_range, so anything within targetable range is

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -572,7 +572,7 @@ RadarVisibility radar_is_visible( object *objp )
 		return NOT_VISIBLE;
 
 	vec3d pos, tempv;
-	float awacs_level, dist, max_radar_dist;
+	float awacs_level;
 	vec3d world_pos = objp->pos;
 
 	// get team-wide awacs level for the object if not ship
@@ -652,12 +652,11 @@ RadarVisibility radar_is_visible( object *objp )
 	vm_vec_rotate(&pos, &tempv, &Player_obj->orient);
 
 	// Apply range filter (squared-distance cull first so the sqrt only runs for blips that survive)
-	max_radar_dist = Radar_ranges[HUD_config.rp_dist];
+	float max_radar_dist = Radar_ranges[HUD_config.rp_dist];
 	float dist_sq = vm_vec_mag_squared(&tempv);
 	if (dist_sq > max_radar_dist * max_radar_dist)
 		return NOT_VISIBLE;
-	dist = sqrtf(dist_sq);
-	
+
 	if (objp->type == OBJ_SHIP)
 	{
 		// ships specifically hidden from sensors

--- a/code/scripting/api/objs/parse_object.cpp
+++ b/code/scripting/api/objs/parse_object.cpp
@@ -848,7 +848,7 @@ ADE_VIRTVAR(SecondaryBanks, l_ParseSubsystem, nullptr, "The overridden secondary
 
 	luacpp::LuaTable tbl = luacpp::LuaTable::create(L);
 	auto po              = poh->getSubsys();
-	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; ++i) {
+	for (int i = 0; i < MAX_SHIP_SECONDARY_BANKS; ++i) {
 		if (po->secondary_banks[i] == -1) {
 			break;
 		}
@@ -886,7 +886,7 @@ ADE_VIRTVAR(SecondaryAmmo, l_ParseSubsystem, nullptr, "The overridden secondary 
 
 	luacpp::LuaTable tbl = luacpp::LuaTable::create(L);
 	auto po              = poh->getSubsys();
-	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; ++i) {
+	for (int i = 0; i < MAX_SHIP_SECONDARY_BANKS; ++i) {
 		if (po->secondary_banks[i] == -1) {
 			break;
 		}


### PR DESCRIPTION
The iterators for secondary banks for lua access had a copy-paste bug from primaries, so we should fix that. The early == -1 break masks it whenever a ship uses 3 or fewer secondary banks, which is probably why it went unnoticed.

Also add some additional low-hanging fruit optimizations.