### PR TITLE
Fix shadow rendering for cockpits when raytracing is active

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -66,16 +66,10 @@ uniform shadowCascadeParams {
 
 	mat4 shadow_mv_matrix;
 
-	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
-	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
 	int shadow_ray_cull_mask;
-
-	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
-	int rt_shadow_debug_visualize;
-
-	// World-space correction for RT shadow ray reconstruction; see
-	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
-	// (shadows.cpp) for the derivation.
 	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -320,30 +314,15 @@ void main()
 		float lightDist;
 		GetLightInfo(position, alpha, reflectDir, lightDir, attenuation, area_normalisation, lightDist);
 
-		// Debug: occlusion from this pixel's raytraced shadow query, and whether a
-		// query actually ran at all -- rt_shadow_debug_visualize needs both, not
-		// just occlusion, since "no query ran" and "query ran, fully lit" would
-		// otherwise look identical (no tint either way). Both stay at their
-		// zero/false default whenever the CSM fallback runs instead (#else below)
-		// or enable_shadows is 0.
-		float rtShadowDebugOcclusion = 0.0;
-		bool rtShadowDebugQueried = false;
-
 		if (enable_shadows != 0) {
 #ifdef RT_SHADOWS
-			// shadow_ray_world_offset corrects for the cockpit pass's view matrix
-			// being anchored at leaning_position rather than the ship's actual world
-			// position -- see shadow_cascade_static_data (uniform_structs.h). Zero
-			// everywhere else, so this is a no-op outside the cockpit.
+			// Zero outside the cockpit pass; see shadow_cascade_static_data (uniform_structs.h).
 			vec3 worldPos = (inv_view_matrix * vec4(position, 1.0)).xyz + shadow_ray_world_offset;
 			vec3 worldNormal = normalize((inv_view_matrix * vec4(normal, 0.0)).xyz);
 			vec3 worldLightDir = normalize((inv_view_matrix * vec4(lightDir, 0.0)).xyz);
 
 			float rtShadowBias = computeRtShadowBias(length(position), rtShadowBiasMin, rtShadowBiasMax);
-			float rtShadowTerm = traceShadowRay(shadow_tlas, worldPos, worldNormal, worldLightDir, lightDist, rtShadowBias, uint(shadow_ray_cull_mask));
-			rtShadowDebugOcclusion = 1.0 - rtShadowTerm;
-			rtShadowDebugQueried = true;
-			attenuation *= rtShadowTerm;
+			attenuation *= traceShadowRay(shadow_tlas, worldPos, worldNormal, worldLightDir, lightDist, rtShadowBias, uint(shadow_ray_cull_mask));
 #else
 			vec4 fragShadowPos = shadow_mv_matrix * inv_view_matrix * vec4(position, 1.0);
 			vec4 fragShadowUV[NUM_SHADOW_CASCADES];
@@ -358,16 +337,6 @@ void main()
 		vec3 halfVec = normalize(lightDir + eyeDir);
 		float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
 		fragmentColor.rgb = computeLighting(specColor.rgb, diffColor, lightDir, normal.xyz, halfVec, eyeDir, roughness, fresnel, NdotL).rgb * diffuseLightColor * attenuation * area_normalisation;
-
-#ifdef RT_SHADOWS
-		// Three readable states: untouched = no RT shadow query ran for this pixel
-		// (permutation/enable_shadows/m_shadow-init problem); solid green = query
-		// ran, found no occluder (TLAS/transform problem, or genuinely unoccluded);
-		// solid red = query ran, fully occluded.
-		if (rt_shadow_debug_visualize != 0 && rtShadowDebugQueried) {
-			fragmentColor.rgb = mix(vec3(0.0, 1.0, 0.0), vec3(1.0, 0.0, 0.0), rtShadowDebugOcclusion);
-		}
-#endif
 	}
 
 	fragOut0 = max(fragmentColor, vec4(0.0));

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -72,6 +72,11 @@ uniform shadowCascadeParams {
 
 	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
 	int rt_shadow_debug_visualize;
+
+	// World-space correction for RT shadow ray reconstruction; see
+	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
+	// (shadows.cpp) for the derivation.
+	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -326,7 +331,11 @@ void main()
 
 		if (enable_shadows != 0) {
 #ifdef RT_SHADOWS
-			vec3 worldPos = (inv_view_matrix * vec4(position, 1.0)).xyz;
+			// shadow_ray_world_offset corrects for the cockpit pass's view matrix
+			// being anchored at leaning_position rather than the ship's actual world
+			// position -- see shadow_cascade_static_data (uniform_structs.h). Zero
+			// everywhere else, so this is a no-op outside the cockpit.
+			vec3 worldPos = (inv_view_matrix * vec4(position, 1.0)).xyz + shadow_ray_world_offset;
 			vec3 worldNormal = normalize((inv_view_matrix * vec4(normal, 0.0)).xyz);
 			vec3 worldLightDir = normalize((inv_view_matrix * vec4(lightDir, 0.0)).xyz);
 

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -65,6 +65,12 @@ uniform shadowCascadeParams {
 	float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
+	vec3 shadow_ray_world_offset;
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -310,12 +316,13 @@ void main()
 
 		if (enable_shadows != 0) {
 #ifdef RT_SHADOWS
-			vec3 worldPos = (inv_view_matrix * vec4(position, 1.0)).xyz;
+			// Zero outside the cockpit pass; see shadow_cascade_static_data (uniform_structs.h).
+			vec3 worldPos = (inv_view_matrix * vec4(position, 1.0)).xyz + shadow_ray_world_offset;
 			vec3 worldNormal = normalize((inv_view_matrix * vec4(normal, 0.0)).xyz);
 			vec3 worldLightDir = normalize((inv_view_matrix * vec4(lightDir, 0.0)).xyz);
 
 			float rtShadowBias = computeRtShadowBias(length(position), rtShadowBiasMin, rtShadowBiasMax);
-			attenuation *= traceShadowRay(shadow_tlas, worldPos, worldNormal, worldLightDir, lightDist, rtShadowBias);
+			attenuation *= traceShadowRay(shadow_tlas, worldPos, worldNormal, worldLightDir, lightDist, rtShadowBias, uint(shadow_ray_cull_mask));
 #else
 			vec4 fragShadowPos = shadow_mv_matrix * inv_view_matrix * vec4(position, 1.0);
 			vec4 fragShadowUV[NUM_SHADOW_CASCADES];

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -65,6 +65,10 @@ uniform shadowCascadeParams {
 	float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
+	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -315,7 +319,7 @@ void main()
 			vec3 worldLightDir = normalize((inv_view_matrix * vec4(lightDir, 0.0)).xyz);
 
 			float rtShadowBias = computeRtShadowBias(length(position), rtShadowBiasMin, rtShadowBiasMax);
-			attenuation *= traceShadowRay(shadow_tlas, worldPos, worldNormal, worldLightDir, lightDist, rtShadowBias);
+			attenuation *= traceShadowRay(shadow_tlas, worldPos, worldNormal, worldLightDir, lightDist, rtShadowBias, uint(shadow_ray_cull_mask));
 #else
 			vec4 fragShadowPos = shadow_mv_matrix * inv_view_matrix * vec4(position, 1.0);
 			vec4 fragShadowUV[NUM_SHADOW_CASCADES];

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -69,6 +69,9 @@ uniform shadowCascadeParams {
 	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
 	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
 	int shadow_ray_cull_mask;
+
+	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
+	int rt_shadow_debug_visualize;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -312,6 +315,15 @@ void main()
 		float lightDist;
 		GetLightInfo(position, alpha, reflectDir, lightDir, attenuation, area_normalisation, lightDist);
 
+		// Debug: occlusion from this pixel's raytraced shadow query, and whether a
+		// query actually ran at all -- rt_shadow_debug_visualize needs both, not
+		// just occlusion, since "no query ran" and "query ran, fully lit" would
+		// otherwise look identical (no tint either way). Both stay at their
+		// zero/false default whenever the CSM fallback runs instead (#else below)
+		// or enable_shadows is 0.
+		float rtShadowDebugOcclusion = 0.0;
+		bool rtShadowDebugQueried = false;
+
 		if (enable_shadows != 0) {
 #ifdef RT_SHADOWS
 			vec3 worldPos = (inv_view_matrix * vec4(position, 1.0)).xyz;
@@ -319,7 +331,10 @@ void main()
 			vec3 worldLightDir = normalize((inv_view_matrix * vec4(lightDir, 0.0)).xyz);
 
 			float rtShadowBias = computeRtShadowBias(length(position), rtShadowBiasMin, rtShadowBiasMax);
-			attenuation *= traceShadowRay(shadow_tlas, worldPos, worldNormal, worldLightDir, lightDist, rtShadowBias, uint(shadow_ray_cull_mask));
+			float rtShadowTerm = traceShadowRay(shadow_tlas, worldPos, worldNormal, worldLightDir, lightDist, rtShadowBias, uint(shadow_ray_cull_mask));
+			rtShadowDebugOcclusion = 1.0 - rtShadowTerm;
+			rtShadowDebugQueried = true;
+			attenuation *= rtShadowTerm;
 #else
 			vec4 fragShadowPos = shadow_mv_matrix * inv_view_matrix * vec4(position, 1.0);
 			vec4 fragShadowUV[NUM_SHADOW_CASCADES];
@@ -334,6 +349,16 @@ void main()
 		vec3 halfVec = normalize(lightDir + eyeDir);
 		float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
 		fragmentColor.rgb = computeLighting(specColor.rgb, diffColor, lightDir, normal.xyz, halfVec, eyeDir, roughness, fresnel, NdotL).rgb * diffuseLightColor * attenuation * area_normalisation;
+
+#ifdef RT_SHADOWS
+		// Three readable states: untouched = no RT shadow query ran for this pixel
+		// (permutation/enable_shadows/m_shadow-init problem); solid green = query
+		// ran, found no occluder (TLAS/transform problem, or genuinely unoccluded);
+		// solid red = query ran, fully occluded.
+		if (rt_shadow_debug_visualize != 0 && rtShadowDebugQueried) {
+			fragmentColor.rgb = mix(vec3(0.0, 1.0, 0.0), vec3(1.0, 0.0, 0.0), rtShadowDebugOcclusion);
+		}
+#endif
 	}
 
 	fragOut0 = max(fragmentColor, vec4(0.0));

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -103,6 +103,12 @@ uniform shadowCascadeParams {
 	float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
+	vec3 shadow_ray_world_offset;
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -237,7 +243,8 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		rtShadowsActive = true;
 	#prereplace ENDIF_FLAG //MODEL_SDR_FLAG_SHADOWS
 	mat4 invView = inverse(viewMatrix);
-	vec3 worldPos = (invView * vertIn.position).xyz;
+	// Zero outside the cockpit pass; see shadow_cascade_static_data (uniform_structs.h).
+	vec3 worldPos = (invView * vertIn.position).xyz + shadow_ray_world_offset;
 	vec3 worldNormal = normalize((invView * vec4(normal, 0.0)).xyz);
 	int shadowedDirectionalCount = 0;
 #endif
@@ -248,7 +255,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		if (rtShadowsActive && lights[i].light_type == LT_DIRECTIONAL && shadowedDirectionalCount < MAX_RT_SHADOW_LIGHTS) {
 			vec3 worldSunDir = normalize((invView * vec4(lights[i].position.xyz, 0.0)).xyz);
 			float rtShadowBias = computeRtShadowBias(length(vertIn.position.xyz), rtShadowBiasMin, rtShadowBiasMax);
-			shadow = traceShadowRay(shadow_tlas, worldPos, worldNormal, worldSunDir, RT_SHADOW_MAX_DISTANCE, rtShadowBias);
+			shadow = traceShadowRay(shadow_tlas, worldPos, worldNormal, worldSunDir, RT_SHADOW_MAX_DISTANCE, rtShadowBias, uint(shadow_ray_cull_mask));
 			++shadowedDirectionalCount;
 		} else {
 			shadow = 1.0;
@@ -270,6 +277,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		lightDiffuse += (lights[i].diffuse_color.rgb * diffuseFactor * NdotL * attenuation) * shadow;
 		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, roughness, fresnel, NdotL) * attenuation * shadow;
 	}
+
 	return diffuseMaterial * lightAmbient + lightSpecular;
 }
 

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -104,16 +104,10 @@ uniform shadowCascadeParams {
 
 	mat4 shadow_mv_matrix;
 
-	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
-	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
 	int shadow_ray_cull_mask;
-
-	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
-	int rt_shadow_debug_visualize;
-
-	// World-space correction for RT shadow ray reconstruction; see
-	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
-	// (shadows.cpp) for the derivation.
 	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -249,21 +243,10 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		rtShadowsActive = true;
 	#prereplace ENDIF_FLAG //MODEL_SDR_FLAG_SHADOWS
 	mat4 invView = inverse(viewMatrix);
-	// shadow_ray_world_offset corrects for the cockpit pass's view matrix/model
-	// positions being anchored at leaning_position rather than the ship's actual
-	// world position -- see shadow_cascade_static_data (uniform_structs.h). Zero
-	// everywhere else, so this is a no-op outside the cockpit.
+	// Zero outside the cockpit pass; see shadow_cascade_static_data (uniform_structs.h).
 	vec3 worldPos = (invView * vertIn.position).xyz + shadow_ray_world_offset;
 	vec3 worldNormal = normalize((invView * vec4(normal, 0.0)).xyz);
 	int shadowedDirectionalCount = 0;
-	// Debug: highest occlusion seen from any raytraced shadow query this fragment,
-	// and whether a query actually ran at all -- rt_shadow_debug_visualize needs
-	// both, not just occlusion, since "no query ran" and "query ran, fully lit"
-	// would otherwise look identical (no tint either way). Both stay at their
-	// zero/false default whenever RT shadows aren't actually being evaluated for
-	// this fragment (permutation not compiled in, or shadow-receiving is off).
-	float rtShadowDebugOcclusion = 0.0;
-	bool rtShadowDebugQueried = false;
 #endif
 
 	#pragma optionNV unroll all
@@ -273,8 +256,6 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 			vec3 worldSunDir = normalize((invView * vec4(lights[i].position.xyz, 0.0)).xyz);
 			float rtShadowBias = computeRtShadowBias(length(vertIn.position.xyz), rtShadowBiasMin, rtShadowBiasMax);
 			shadow = traceShadowRay(shadow_tlas, worldPos, worldNormal, worldSunDir, RT_SHADOW_MAX_DISTANCE, rtShadowBias, uint(shadow_ray_cull_mask));
-			rtShadowDebugOcclusion = max(rtShadowDebugOcclusion, 1.0 - shadow);
-			rtShadowDebugQueried = true;
 			++shadowedDirectionalCount;
 		} else {
 			shadow = 1.0;
@@ -297,19 +278,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, roughness, fresnel, NdotL) * attenuation * shadow;
 	}
 
-	vec3 litColor = diffuseMaterial * lightAmbient + lightSpecular;
-#ifdef MODEL_SDR_FLAG_RT_SHADOWS
-	// Three readable states: untouched = no RT shadow query ran for this fragment
-	// (permutation/shadow-receiving problem); solid green = query ran, found no
-	// occluder (nothing between fragment and light, or a TLAS/transform problem);
-	// solid red = query ran, fully occluded. Partial occlusion (soft/PCSS-less RT
-	// shadows are hard-edged per light, but multiple lights can blend) interpolates
-	// green->red.
-	if (rt_shadow_debug_visualize != 0 && rtShadowDebugQueried) {
-		litColor = mix(vec3(0.0, 1.0, 0.0), vec3(1.0, 0.0, 0.0), rtShadowDebugOcclusion);
-	}
-#endif
-	return litColor;
+	return diffuseMaterial * lightAmbient + lightSpecular;
 }
 
 void main()

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -103,6 +103,10 @@ uniform shadowCascadeParams {
 	float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
+	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -248,7 +252,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		if (rtShadowsActive && lights[i].light_type == LT_DIRECTIONAL && shadowedDirectionalCount < MAX_RT_SHADOW_LIGHTS) {
 			vec3 worldSunDir = normalize((invView * vec4(lights[i].position.xyz, 0.0)).xyz);
 			float rtShadowBias = computeRtShadowBias(length(vertIn.position.xyz), rtShadowBiasMin, rtShadowBiasMax);
-			shadow = traceShadowRay(shadow_tlas, worldPos, worldNormal, worldSunDir, RT_SHADOW_MAX_DISTANCE, rtShadowBias);
+			shadow = traceShadowRay(shadow_tlas, worldPos, worldNormal, worldSunDir, RT_SHADOW_MAX_DISTANCE, rtShadowBias, uint(shadow_ray_cull_mask));
 			++shadowedDirectionalCount;
 		} else {
 			shadow = 1.0;

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -107,6 +107,9 @@ uniform shadowCascadeParams {
 	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
 	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
 	int shadow_ray_cull_mask;
+
+	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
+	int rt_shadow_debug_visualize;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -244,6 +247,14 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 	vec3 worldPos = (invView * vertIn.position).xyz;
 	vec3 worldNormal = normalize((invView * vec4(normal, 0.0)).xyz);
 	int shadowedDirectionalCount = 0;
+	// Debug: highest occlusion seen from any raytraced shadow query this fragment,
+	// and whether a query actually ran at all -- rt_shadow_debug_visualize needs
+	// both, not just occlusion, since "no query ran" and "query ran, fully lit"
+	// would otherwise look identical (no tint either way). Both stay at their
+	// zero/false default whenever RT shadows aren't actually being evaluated for
+	// this fragment (permutation not compiled in, or shadow-receiving is off).
+	float rtShadowDebugOcclusion = 0.0;
+	bool rtShadowDebugQueried = false;
 #endif
 
 	#pragma optionNV unroll all
@@ -253,6 +264,8 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 			vec3 worldSunDir = normalize((invView * vec4(lights[i].position.xyz, 0.0)).xyz);
 			float rtShadowBias = computeRtShadowBias(length(vertIn.position.xyz), rtShadowBiasMin, rtShadowBiasMax);
 			shadow = traceShadowRay(shadow_tlas, worldPos, worldNormal, worldSunDir, RT_SHADOW_MAX_DISTANCE, rtShadowBias, uint(shadow_ray_cull_mask));
+			rtShadowDebugOcclusion = max(rtShadowDebugOcclusion, 1.0 - shadow);
+			rtShadowDebugQueried = true;
 			++shadowedDirectionalCount;
 		} else {
 			shadow = 1.0;
@@ -274,7 +287,20 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		lightDiffuse += (lights[i].diffuse_color.rgb * diffuseFactor * NdotL * attenuation) * shadow;
 		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, roughness, fresnel, NdotL) * attenuation * shadow;
 	}
-	return diffuseMaterial * lightAmbient + lightSpecular;
+
+	vec3 litColor = diffuseMaterial * lightAmbient + lightSpecular;
+#ifdef MODEL_SDR_FLAG_RT_SHADOWS
+	// Three readable states: untouched = no RT shadow query ran for this fragment
+	// (permutation/shadow-receiving problem); solid green = query ran, found no
+	// occluder (nothing between fragment and light, or a TLAS/transform problem);
+	// solid red = query ran, fully occluded. Partial occlusion (soft/PCSS-less RT
+	// shadows are hard-edged per light, but multiple lights can blend) interpolates
+	// green->red.
+	if (rt_shadow_debug_visualize != 0 && rtShadowDebugQueried) {
+		litColor = mix(vec3(0.0, 1.0, 0.0), vec3(1.0, 0.0, 0.0), rtShadowDebugOcclusion);
+	}
+#endif
+	return litColor;
 }
 
 void main()

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -110,6 +110,11 @@ uniform shadowCascadeParams {
 
 	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
 	int rt_shadow_debug_visualize;
+
+	// World-space correction for RT shadow ray reconstruction; see
+	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
+	// (shadows.cpp) for the derivation.
+	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
@@ -244,7 +249,11 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		rtShadowsActive = true;
 	#prereplace ENDIF_FLAG //MODEL_SDR_FLAG_SHADOWS
 	mat4 invView = inverse(viewMatrix);
-	vec3 worldPos = (invView * vertIn.position).xyz;
+	// shadow_ray_world_offset corrects for the cockpit pass's view matrix/model
+	// positions being anchored at leaning_position rather than the ship's actual
+	// world position -- see shadow_cascade_static_data (uniform_structs.h). Zero
+	// everywhere else, so this is a no-op outside the cockpit.
+	vec3 worldPos = (invView * vertIn.position).xyz + shadow_ray_world_offset;
 	vec3 worldNormal = normalize((invView * vec4(normal, 0.0)).xyz);
 	int shadowedDirectionalCount = 0;
 	// Debug: highest occlusion seen from any raytraced shadow query this fragment,

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -117,6 +117,12 @@ uniform shadowCascadeParams {
 	float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
+	vec3 shadow_ray_world_offset;
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -121,6 +121,9 @@ uniform shadowCascadeParams {
 	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
 	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
 	int shadow_ray_cull_mask;
+
+	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
+	int rt_shadow_debug_visualize;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -118,16 +118,10 @@ uniform shadowCascadeParams {
 
 	mat4 shadow_mv_matrix;
 
-	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
-	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
 	int shadow_ray_cull_mask;
-
-	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
-	int rt_shadow_debug_visualize;
-
-	// World-space correction for RT shadow ray reconstruction; see
-	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
-	// (shadows.cpp) for the derivation.
 	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -124,6 +124,11 @@ uniform shadowCascadeParams {
 
 	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
 	int rt_shadow_debug_visualize;
+
+	// World-space correction for RT shadow ray reconstruction; see
+	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
+	// (shadows.cpp) for the derivation.
+	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -117,6 +117,10 @@ uniform shadowCascadeParams {
 	float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
+	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-g.sdr
+++ b/code/def_files/data/effects/shadow_map-g.sdr
@@ -18,6 +18,9 @@ layout (std140) uniform shadowCascadeParams {
 	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
 	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
 	int shadow_ray_cull_mask;
+
+	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
+	int rt_shadow_debug_visualize;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-g.sdr
+++ b/code/def_files/data/effects/shadow_map-g.sdr
@@ -14,6 +14,12 @@ layout (std140) uniform shadowCascadeParams {
     float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
+	vec3 shadow_ray_world_offset;
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-g.sdr
+++ b/code/def_files/data/effects/shadow_map-g.sdr
@@ -14,6 +14,10 @@ layout (std140) uniform shadowCascadeParams {
     float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
+	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-g.sdr
+++ b/code/def_files/data/effects/shadow_map-g.sdr
@@ -15,16 +15,10 @@ layout (std140) uniform shadowCascadeParams {
 
 	mat4 shadow_mv_matrix;
 
-	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
-	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
 	int shadow_ray_cull_mask;
-
-	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
-	int rt_shadow_debug_visualize;
-
-	// World-space correction for RT shadow ray reconstruction; see
-	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
-	// (shadows.cpp) for the derivation.
 	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-g.sdr
+++ b/code/def_files/data/effects/shadow_map-g.sdr
@@ -21,6 +21,11 @@ layout (std140) uniform shadowCascadeParams {
 
 	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
 	int rt_shadow_debug_visualize;
+
+	// World-space correction for RT shadow ray reconstruction; see
+	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
+	// (shadows.cpp) for the derivation.
+	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-v.sdr
+++ b/code/def_files/data/effects/shadow_map-v.sdr
@@ -44,6 +44,10 @@ uniform shadowCascadeParams {
     float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
+	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-v.sdr
+++ b/code/def_files/data/effects/shadow_map-v.sdr
@@ -48,6 +48,9 @@ uniform shadowCascadeParams {
 	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
 	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
 	int shadow_ray_cull_mask;
+
+	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
+	int rt_shadow_debug_visualize;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-v.sdr
+++ b/code/def_files/data/effects/shadow_map-v.sdr
@@ -44,6 +44,12 @@ uniform shadowCascadeParams {
     float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
+
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
+	vec3 shadow_ray_world_offset;
+	int shadow_ray_cull_mask;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-v.sdr
+++ b/code/def_files/data/effects/shadow_map-v.sdr
@@ -45,16 +45,10 @@ uniform shadowCascadeParams {
 
 	mat4 shadow_mv_matrix;
 
-	// Ray cull mask for raytraced shadow queries; see shadow_cascade_static_data (uniform_structs.h)
-	// and shadow_cascade_params_bind() (shadows.cpp) for how this gets set.
+	// shadow_ray_cull_mask/shadow_ray_world_offset: see shadow_cascade_static_data
+	// (uniform_structs.h) for what these mean and shadow_cascade_params_bind()
+	// (shadows.cpp) for how they're set.
 	int shadow_ray_cull_mask;
-
-	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
-	int rt_shadow_debug_visualize;
-
-	// World-space correction for RT shadow ray reconstruction; see
-	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
-	// (shadows.cpp) for the derivation.
 	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadow_map-v.sdr
+++ b/code/def_files/data/effects/shadow_map-v.sdr
@@ -51,6 +51,11 @@ uniform shadowCascadeParams {
 
 	// Debug visualization toggle; see shadow_cascade_static_data (uniform_structs.h).
 	int rt_shadow_debug_visualize;
+
+	// World-space correction for RT shadow ray reconstruction; see
+	// shadow_cascade_static_data (uniform_structs.h) and shadow_cascade_params_bind()
+	// (shadows.cpp) for the derivation.
+	vec3 shadow_ray_world_offset;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];
 	vec4 cascade_distances[(NUM_SHADOW_CASCADES + 4 - 1) / 4];
 	vec4 smoothness_factors[(NUM_SHADOW_CASCADES + 4 - 1) / 4];

--- a/code/def_files/data/effects/shadows.sdr
+++ b/code/def_files/data/effects/shadows.sdr
@@ -114,14 +114,20 @@ float computeRtShadowBias(float cameraDist, float biasMin, float biasMax)
 //
 // bias is a world-unit offset applied along worldNormal before tracing, to clear
 // the source triangle -- see computeRtShadowBias() above for how callers derive it.
-float traceShadowRay(accelerationStructureEXT tlas, vec3 worldPos, vec3 worldNormal, vec3 worldLightDir, float tMax, float bias)
+//
+// cullMask selects which TLAS instances this ray can hit (Vulkan spec: an instance
+// is a candidate iff (cullMask & instance.mask) != 0). Callers should pass
+// shadow_ray_cull_mask (shadowCascadeParams uniform block) rather than a literal --
+// see SHADOW_RAY_CULL_MASK_EXCLUDE_VIEWER_HULL/TLAS_MASK_VIEWER_HULL (shadows.h)
+// for how it excludes the viewer ship's own hull outside the cockpit pass.
+float traceShadowRay(accelerationStructureEXT tlas, vec3 worldPos, vec3 worldNormal, vec3 worldLightDir, float tMax, float bias, uint cullMask)
 {
 	vec3 origin = worldPos + worldNormal * bias;
 	vec3 direction = normalize(worldLightDir);
 
 	rayQueryEXT rq;
 	rayQueryInitializeEXT(rq, tlas, gl_RayFlagsOpaqueEXT | gl_RayFlagsTerminateOnFirstHitEXT,
-		0xFF, origin, 0.001, direction, tMax);
+		cullMask, origin, 0.001, direction, tMax);
 	while (rayQueryProceedEXT(rq)) {}
 
 	return (rayQueryGetIntersectionTypeEXT(rq, true) == gl_RayQueryCommittedIntersectionNoneEXT) ? 1.0 : 0.0;

--- a/code/def_files/data/effects/shadows.sdr
+++ b/code/def_files/data/effects/shadows.sdr
@@ -118,10 +118,8 @@ float computeRtShadowBias(float cameraDist, float biasMin, float biasMax)
 // cullMask selects which TLAS instances this ray can hit (Vulkan spec: an instance
 // is a candidate iff (cullMask & instance.mask) != 0). Callers should pass
 // shadow_ray_cull_mask (shadowCascadeParams uniform block) rather than a literal --
-// it's 0x7F outside the cockpit pass, excluding the viewer ship's own hull instance
-// (tagged 0x80 in VulkanRaytracingManager::gatherShadowCasterInstances()) to match
-// the rasterized path's exclusion of Viewer_obj from the main shadow cascades, and
-// 0xFF inside the cockpit pass when the ship is allowed to cast onto its own cockpit.
+// see SHADOW_RAY_CULL_MASK_EXCLUDE_VIEWER_HULL/TLAS_MASK_VIEWER_HULL (shadows.h)
+// for how it excludes the viewer ship's own hull outside the cockpit pass.
 float traceShadowRay(accelerationStructureEXT tlas, vec3 worldPos, vec3 worldNormal, vec3 worldLightDir, float tMax, float bias, uint cullMask)
 {
 	vec3 origin = worldPos + worldNormal * bias;

--- a/code/def_files/data/effects/shadows.sdr
+++ b/code/def_files/data/effects/shadows.sdr
@@ -114,14 +114,22 @@ float computeRtShadowBias(float cameraDist, float biasMin, float biasMax)
 //
 // bias is a world-unit offset applied along worldNormal before tracing, to clear
 // the source triangle -- see computeRtShadowBias() above for how callers derive it.
-float traceShadowRay(accelerationStructureEXT tlas, vec3 worldPos, vec3 worldNormal, vec3 worldLightDir, float tMax, float bias)
+//
+// cullMask selects which TLAS instances this ray can hit (Vulkan spec: an instance
+// is a candidate iff (cullMask & instance.mask) != 0). Callers should pass
+// shadow_ray_cull_mask (shadowCascadeParams uniform block) rather than a literal --
+// it's 0x7F outside the cockpit pass, excluding the viewer ship's own hull instance
+// (tagged 0x80 in VulkanRaytracingManager::gatherShadowCasterInstances()) to match
+// the rasterized path's exclusion of Viewer_obj from the main shadow cascades, and
+// 0xFF inside the cockpit pass when the ship is allowed to cast onto its own cockpit.
+float traceShadowRay(accelerationStructureEXT tlas, vec3 worldPos, vec3 worldNormal, vec3 worldLightDir, float tMax, float bias, uint cullMask)
 {
 	vec3 origin = worldPos + worldNormal * bias;
 	vec3 direction = normalize(worldLightDir);
 
 	rayQueryEXT rq;
 	rayQueryInitializeEXT(rq, tlas, gl_RayFlagsOpaqueEXT | gl_RayFlagsTerminateOnFirstHitEXT,
-		0xFF, origin, 0.001, direction, tMax);
+		cullMask, origin, 0.001, direction, tMax);
 	while (rayQueryProceedEXT(rq)) {}
 
 	return (rayQueryGetIntersectionTypeEXT(rq, true) == gl_RayQueryCommittedIntersectionNoneEXT) ? 1.0 : 0.0;

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -22,7 +22,9 @@
 #include "nebula/neb.h"
 #include "nebula/volumetrics.h"
 #include "mod_table/mod_table.h"
+#include "object/object.h"
 #include "render/3d.h"
+#include "ship/ship.h"
 #include "tracing/tracing.h"
 #ifdef USE_OPENGL_ES
 #include "es_compatibility.h"
@@ -318,7 +320,17 @@ void gr_opengl_deferred_lighting_finish()
 			vm_inverse_matrix4(&header->inv_view_matrix, &Shadow_view_matrix_render);
 			int offset = (Lighting_mode == lighting_mode::COCKPIT) ? 0 : Num_cockpit_shadow_cascades;
 			int count  = (Lighting_mode == lighting_mode::COCKPIT) ? Num_cockpit_shadow_cascades : Num_shadow_cascades;
-			shadow_cascade_params_bind(offset, count);
+			// See shadow_cascade_params_bind()'s declaration (shadows.h): this deferred
+			// lighting pass shades every G-buffer texel written during the cockpit block
+			// (ship.cpp) in one full-screen draw, so it can only carry one correction.
+			// That's exact for the common case (a ship with a cockpit model prerenders its
+			// hull separately, outside Lighting_mode::COCKPIT, so only cockpit fragments
+			// land in this G-buffer); it's a known gap for Cockpit_shares_coordinate_space
+			// ships or cockpit-less ships, where hull fragments also land here and would
+			// need a different correction than the cockpit's.
+			vec3d world_offset = (Lighting_mode == lighting_mode::COCKPIT && Viewer_obj != nullptr) ? Viewer_obj->pos : vmd_zero_vector;
+			bool allow_viewer_self_shadow = Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit();
+			shadow_cascade_params_bind(offset, count, world_offset, allow_viewer_self_shadow);
 		}
 
 		header->invScreenWidth = 1.0f / gr_screen.max_w;

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -316,9 +316,7 @@ void gr_opengl_deferred_lighting_finish()
 		auto header = light_uniform_aligner.getHeader<deferred_global_data>();
 		if (Shadow_quality != ShadowQuality::Disabled) {
 			vm_inverse_matrix4(&header->inv_view_matrix, &Shadow_view_matrix_render);
-			int offset = (Lighting_mode == lighting_mode::COCKPIT) ? 0 : Num_cockpit_shadow_cascades;
-			int count  = (Lighting_mode == lighting_mode::COCKPIT) ? Num_cockpit_shadow_cascades : Num_shadow_cascades;
-			shadow_cascade_params_bind(offset, count);
+			shadow_cascade_params_bind_deferred();
 		}
 
 		header->invScreenWidth = 1.0f / gr_screen.max_w;

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -22,9 +22,7 @@
 #include "nebula/neb.h"
 #include "nebula/volumetrics.h"
 #include "mod_table/mod_table.h"
-#include "object/object.h"
 #include "render/3d.h"
-#include "ship/ship.h"
 #include "tracing/tracing.h"
 #ifdef USE_OPENGL_ES
 #include "es_compatibility.h"
@@ -318,19 +316,7 @@ void gr_opengl_deferred_lighting_finish()
 		auto header = light_uniform_aligner.getHeader<deferred_global_data>();
 		if (Shadow_quality != ShadowQuality::Disabled) {
 			vm_inverse_matrix4(&header->inv_view_matrix, &Shadow_view_matrix_render);
-			int offset = (Lighting_mode == lighting_mode::COCKPIT) ? 0 : Num_cockpit_shadow_cascades;
-			int count  = (Lighting_mode == lighting_mode::COCKPIT) ? Num_cockpit_shadow_cascades : Num_shadow_cascades;
-			// See shadow_cascade_params_bind()'s declaration (shadows.h): this deferred
-			// lighting pass shades every G-buffer texel written during the cockpit block
-			// (ship.cpp) in one full-screen draw, so it can only carry one correction.
-			// That's exact for the common case (a ship with a cockpit model prerenders its
-			// hull separately, outside Lighting_mode::COCKPIT, so only cockpit fragments
-			// land in this G-buffer); it's a known gap for Cockpit_shares_coordinate_space
-			// ships or cockpit-less ships, where hull fragments also land here and would
-			// need a different correction than the cockpit's.
-			vec3d world_offset = (Lighting_mode == lighting_mode::COCKPIT && Viewer_obj != nullptr) ? Viewer_obj->pos : vmd_zero_vector;
-			bool allow_viewer_self_shadow = Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit();
-			shadow_cascade_params_bind(offset, count, world_offset, allow_viewer_self_shadow);
+			shadow_cascade_params_bind_deferred();
 		}
 
 		header->invScreenWidth = 1.0f / gr_screen.max_w;

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -665,11 +665,11 @@ matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, fov_t fov, fov_t
 
 	gr_shadow_map_start(&Shadow_view_matrix_light, &light_matrix, eye_pos, true);
 	if (cascade_distances_override)
-		shadow_cascade_params_bind(max_skip_override, num_cascades - max_skip_override);
+		shadow_cascade_params_bind(max_skip_override, num_cascades - max_skip_override, vmd_zero_vector);
 	else if (render_cockpit_cascades)
-		shadow_cascade_params_bind(0, num_cascades);
+		shadow_cascade_params_bind(0, num_cascades, vmd_zero_vector);
 	else
-		shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades);
+		shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades, vmd_zero_vector);
 
 	return light_matrix;
 }
@@ -764,9 +764,9 @@ static void render_viewer_shadow(object* objp, const matrix* light_matrix,
 
 		gr_shadow_map_start(&dummy_view, light_matrix, &vmd_zero_vector, false);
 		if (casts_shadow_on_cockpit)
-			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades + Num_shadow_cascades);
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades + Num_shadow_cascades, vmd_zero_vector);
 		else
-			shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades);
+			shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades, vmd_zero_vector);
 
 		model_clear_instance(sip->model_num);
 		polymodel_instance* pmi = nullptr;
@@ -782,17 +782,14 @@ static void render_viewer_shadow(object* objp, const matrix* light_matrix,
 		viewer_list.render_all();
 	}
 
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && sip->cockpit_model_num >= 0 && !Disable_cockpits;
+	const bool renderCockpitModel = ship_player_cockpit_model_would_render(sip);
 
 	if (renderCockpitModel && !Shadow_disable_overrides.disable_cockpit) {
 		matrix4 dummy_view;
 		gr_shadow_map_start(&dummy_view, light_matrix, &vmd_zero_vector, false);
-		shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades);
+		shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, vmd_zero_vector);
 
-		vec3d cockpit_offset = sip->cockpit_offset;
-		vm_vec_unrotate(&cockpit_offset, &cockpit_offset, &objp->orient);
-		if (!Disable_cockpit_sway)
-			cockpit_offset += sip->cockpit_sway_val * objp->phys_info.acceleration;
+		vec3d cockpit_offset = ship_cockpit_render_offset(sip, objp);
 
 		model_clear_instance(sip->cockpit_model_num);
 		polymodel_instance* cockpit_pmi = nullptr;
@@ -1035,7 +1032,8 @@ void shadow_cascade_params_shutdown() {
 }
 
 int Shadow_cascade_count = 0;
-void shadow_cascade_params_bind(int cascade_offset, int cascade_count) {
+void shadow_cascade_params_bind(int cascade_offset, int cascade_count, const vec3d& world_offset,
+	bool allow_viewer_self_shadow) {
 	if (!Shadow_cascade_params_buffer.isValid()) {
 		return;
 	}
@@ -1057,6 +1055,10 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count) {
 	static_data.rtShadowBiasMin = Rt_shadow_bias_min;
 	static_data.rtShadowBiasMax = Rt_shadow_bias_max;
 	static_data.shadow_mv_matrix = Shadow_view_matrix_light;
+
+	// See shadow_cascade_params_bind()'s declaration (shadows.h) for what these mean.
+	static_data.shadow_ray_cull_mask = allow_viewer_self_shadow ? 0xFF : SHADOW_RAY_CULL_MASK_EXCLUDE_VIEWER_HULL;
+	static_data.shadow_ray_world_offset = world_offset;
 
 	Shadow_cascade_count = cascade_count;
 
@@ -1082,8 +1084,23 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count) {
 	}
 	offset += sizeof(float) * padding;
 
-	gr_update_buffer_data_offset(Shadow_cascade_params_buffer, 0, required_size, buffer.data());
+	// Must be the full-replacement update, not _offset: this is called several times per
+	// frame with different content, and on Vulkan's streaming buffer _offset only bump-
+	// allocates fresh GPU memory on the first call, silently overwriting the same region
+	// on later calls -- so every draw this frame (command buffers are pre-recorded) would
+	// read whichever bind ran last, not the one current when it was recorded. This always
+	// bump-allocates fresh on Vulkan (matching deferred_global_data/deferred_light_data)
+	// and is a plain buffer-orphaning glBufferData() on OpenGL.
+	gr_update_buffer_data(Shadow_cascade_params_buffer, required_size, buffer.data());
 	gr_bind_uniform_buffer(uniform_block_type::ShadowCascadeParams, 0, required_size, Shadow_cascade_params_buffer);
+}
+
+void shadow_cascade_params_bind_deferred() {
+	int offset = (Lighting_mode == lighting_mode::COCKPIT) ? 0 : Num_cockpit_shadow_cascades;
+	int count  = (Lighting_mode == lighting_mode::COCKPIT) ? Num_cockpit_shadow_cascades : Num_shadow_cascades;
+	vec3d world_offset = (Lighting_mode == lighting_mode::COCKPIT && Viewer_obj != nullptr) ? Viewer_obj->pos : vmd_zero_vector;
+	bool allow_viewer_self_shadow = Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit();
+	shadow_cascade_params_bind(offset, count, world_offset, allow_viewer_self_shadow);
 }
 
 shadow_render_list::shadow_render_list() {

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -1058,6 +1058,14 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count) {
 	static_data.rtShadowBiasMax = Rt_shadow_bias_max;
 	static_data.shadow_mv_matrix = Shadow_view_matrix_light;
 
+	// Default excludes the viewer ship's own hull from raytraced shadow rays
+	// (mirrors the rasterized path's unconditional exclusion of Viewer_obj from
+	// the main shadow cascades, shadows_render_all() below); only the cockpit's
+	// own shading pass allows it through, and only when the ship is actually
+	// supposed to cast onto its cockpit this frame.
+	static_data.shadow_ray_cull_mask =
+		(Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit()) ? 0xFF : 0x7F;
+
 	Shadow_cascade_count = cascade_count;
 
 	offset += sizeof(graphics::shadow_cascade_static_data);

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -27,7 +27,6 @@
 #include "ship/ship.h"
 #include "ship/shipfx.h"
 #include "render/3d.h"
-#include "debugconsole/console.h"
 #include "tracing/tracing.h"
 #include "util/uniform_structs.h"
 
@@ -37,21 +36,6 @@ matrix4 Shadow_view_matrix_light;
 matrix4 Shadow_view_matrix_render;
 SCP_vector<matrix4> Shadow_proj_matrix;
 SCP_vector<float> Shadow_cascade_distances;
-
-bool Rt_shadow_debug_visualize = false;
-
-DCF(rt_shadow_debug, "Toggles red visualization of raytraced shadow occlusion")
-{
-	if (dc_optional_string_either("status", "--status") || dc_optional_string_either("?", "--?")) {
-		dc_printf("Raytraced shadow debug visualization is %s", Rt_shadow_debug_visualize ? "ON" : "OFF");
-		return;
-	}
-
-	Rt_shadow_debug_visualize = !Rt_shadow_debug_visualize;
-	dc_printf("Raytraced shadow debug visualization %s. Occluded fragments will be tinted red wherever "
-		"a raytraced shadow query is actually evaluated (Vulkan, RT shadows enabled, a shadow-receiving "
-		"material).\n", Rt_shadow_debug_visualize ? "enabled" : "disabled");
-}
 
 static SCP_vector<light_frustum_info> Shadow_frustums;
 
@@ -798,7 +782,7 @@ static void render_viewer_shadow(object* objp, const matrix* light_matrix,
 		viewer_list.render_all();
 	}
 
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && sip->cockpit_model_num >= 0 && !Disable_cockpits;
+	const bool renderCockpitModel = ship_player_cockpit_model_would_render(sip);
 
 	if (renderCockpitModel && !Shadow_disable_overrides.disable_cockpit) {
 		matrix4 dummy_view;
@@ -1075,23 +1059,8 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count, const vec
 	static_data.rtShadowBiasMax = Rt_shadow_bias_max;
 	static_data.shadow_mv_matrix = Shadow_view_matrix_light;
 
-	// Default excludes the viewer ship's own hull from raytraced shadow rays
-	// (mirrors the rasterized path's unconditional exclusion of Viewer_obj from
-	// the main shadow cascades, shadows_render_all() below); callers opt in via
-	// allow_viewer_self_shadow only for the specific draw where it's wanted
-	// (the cockpit's own shading, so the hull can cast onto the cockpit -- NOT
-	// the hull's own shading in the same pass, which would just be self-shadow
-	// acne). See shadow_cascade_params_bind()'s declaration (shadows.h).
-	static_data.shadow_ray_cull_mask = allow_viewer_self_shadow ? 0xFF : 0x7F;
-
-	static_data.rt_shadow_debug_visualize = Rt_shadow_debug_visualize ? 1 : 0;
-
-	// See shadow_cascade_params_bind()'s declaration (shadows.h) and
-	// shadow_ray_world_offset's declaration (uniform_structs.h) for the
-	// derivation -- this is caller-supplied because a single pass can contain
-	// draws in different internal frames (e.g. ship_render_player_ship()'s
-	// eye-relative hull draw vs. its cockpit-offset-relative cockpit draw) that
-	// need different corrections; Lighting_mode alone can't distinguish them.
+	// See shadow_cascade_params_bind()'s declaration (shadows.h) for what these mean.
+	static_data.shadow_ray_cull_mask = allow_viewer_self_shadow ? 0xFF : SHADOW_RAY_CULL_MASK_EXCLUDE_VIEWER_HULL;
 	static_data.shadow_ray_world_offset = world_offset;
 
 	Shadow_cascade_count = cascade_count;
@@ -1118,24 +1087,23 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count, const vec
 	}
 	offset += sizeof(float) * padding;
 
-	// Must be the full-replacement update (not _offset): this function is called
-	// multiple times per frame with different content (main scene, viewer-ship-
-	// onto-cockpit, cockpit-self, forward cockpit, deferred cockpit -- up to 5
-	// times when the player's cockpit is rendered). On Vulkan's streaming buffer
-	// path, gr_update_buffer_data_offset() only bump-allocates a fresh GPU region
-	// on the first call of the frame; every later call this frame would silently
-	// overwrite that same region in place instead of getting its own. Since
-	// command buffers are recorded before the GPU executes any of them, every
-	// draw this frame would then read whichever bind happened to run last,
-	// regardless of which one was "current" when that draw was recorded -- e.g.
-	// the main scene's shadow-casting draws picking up the cockpit's cascade
-	// range, or the cockpit's shadow_ray_cull_mask read stale/wrong.
-	// gr_update_buffer_data() always bump-allocates fresh on Vulkan (matching the
-	// per-pass isolation deferred_global_data/deferred_light_data already use for
-	// the same reason), and is a safe, standard buffer-orphaning glBufferData()
-	// call on OpenGL.
+	// Must be the full-replacement update, not _offset: this is called several times per
+	// frame with different content, and on Vulkan's streaming buffer _offset only bump-
+	// allocates fresh GPU memory on the first call, silently overwriting the same region
+	// on later calls -- so every draw this frame (command buffers are pre-recorded) would
+	// read whichever bind ran last, not the one current when it was recorded. This always
+	// bump-allocates fresh on Vulkan (matching deferred_global_data/deferred_light_data)
+	// and is a plain buffer-orphaning glBufferData() on OpenGL.
 	gr_update_buffer_data(Shadow_cascade_params_buffer, required_size, buffer.data());
 	gr_bind_uniform_buffer(uniform_block_type::ShadowCascadeParams, 0, required_size, Shadow_cascade_params_buffer);
+}
+
+void shadow_cascade_params_bind_deferred() {
+	int offset = (Lighting_mode == lighting_mode::COCKPIT) ? 0 : Num_cockpit_shadow_cascades;
+	int count  = (Lighting_mode == lighting_mode::COCKPIT) ? Num_cockpit_shadow_cascades : Num_shadow_cascades;
+	vec3d world_offset = (Lighting_mode == lighting_mode::COCKPIT && Viewer_obj != nullptr) ? Viewer_obj->pos : vmd_zero_vector;
+	bool allow_viewer_self_shadow = Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit();
+	shadow_cascade_params_bind(offset, count, world_offset, allow_viewer_self_shadow);
 }
 
 shadow_render_list::shadow_render_list() {

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -681,11 +681,11 @@ matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, fov_t fov, fov_t
 
 	gr_shadow_map_start(&Shadow_view_matrix_light, &light_matrix, eye_pos, true);
 	if (cascade_distances_override)
-		shadow_cascade_params_bind(max_skip_override, num_cascades - max_skip_override);
+		shadow_cascade_params_bind(max_skip_override, num_cascades - max_skip_override, vmd_zero_vector);
 	else if (render_cockpit_cascades)
-		shadow_cascade_params_bind(0, num_cascades);
+		shadow_cascade_params_bind(0, num_cascades, vmd_zero_vector);
 	else
-		shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades);
+		shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades, vmd_zero_vector);
 
 	return light_matrix;
 }
@@ -780,9 +780,9 @@ static void render_viewer_shadow(object* objp, const matrix* light_matrix,
 
 		gr_shadow_map_start(&dummy_view, light_matrix, &vmd_zero_vector, false);
 		if (casts_shadow_on_cockpit)
-			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades + Num_shadow_cascades);
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades + Num_shadow_cascades, vmd_zero_vector);
 		else
-			shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades);
+			shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades, vmd_zero_vector);
 
 		model_clear_instance(sip->model_num);
 		polymodel_instance* pmi = nullptr;
@@ -803,7 +803,7 @@ static void render_viewer_shadow(object* objp, const matrix* light_matrix,
 	if (renderCockpitModel && !Shadow_disable_overrides.disable_cockpit) {
 		matrix4 dummy_view;
 		gr_shadow_map_start(&dummy_view, light_matrix, &vmd_zero_vector, false);
-		shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades);
+		shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, vmd_zero_vector);
 
 		vec3d cockpit_offset = sip->cockpit_offset;
 		vm_vec_unrotate(&cockpit_offset, &cockpit_offset, &objp->orient);
@@ -1051,7 +1051,8 @@ void shadow_cascade_params_shutdown() {
 }
 
 int Shadow_cascade_count = 0;
-void shadow_cascade_params_bind(int cascade_offset, int cascade_count) {
+void shadow_cascade_params_bind(int cascade_offset, int cascade_count, const vec3d& world_offset,
+	bool allow_viewer_self_shadow) {
 	if (!Shadow_cascade_params_buffer.isValid()) {
 		return;
 	}
@@ -1076,13 +1077,40 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count) {
 
 	// Default excludes the viewer ship's own hull from raytraced shadow rays
 	// (mirrors the rasterized path's unconditional exclusion of Viewer_obj from
-	// the main shadow cascades, shadows_render_all() below); only the cockpit's
-	// own shading pass allows it through, and only when the ship is actually
-	// supposed to cast onto its cockpit this frame.
-	static_data.shadow_ray_cull_mask =
-		(Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit()) ? 0xFF : 0x7F;
+	// the main shadow cascades, shadows_render_all() below); callers opt in via
+	// allow_viewer_self_shadow only for the specific draw where it's wanted
+	// (the cockpit's own shading, so the hull can cast onto the cockpit -- NOT
+	// the hull's own shading in the same pass, which would just be self-shadow
+	// acne). See shadow_cascade_params_bind()'s declaration (shadows.h).
+	static_data.shadow_ray_cull_mask = allow_viewer_self_shadow ? 0xFF : 0x7F;
 
 	static_data.rt_shadow_debug_visualize = Rt_shadow_debug_visualize ? 1 : 0;
+
+	// See shadow_cascade_params_bind()'s declaration (shadows.h) and
+	// shadow_ray_world_offset's declaration (uniform_structs.h) for the
+	// derivation -- this is caller-supplied because a single pass can contain
+	// draws in different internal frames (e.g. ship_render_player_ship()'s
+	// eye-relative hull draw vs. its cockpit-offset-relative cockpit draw) that
+	// need different corrections; Lighting_mode alone can't distinguish them.
+	static_data.shadow_ray_world_offset = world_offset;
+
+	// TEMPORARY: one-shot diagnostic for the cockpit coordinate-space fix. Every
+	// current cockpit-range bind (ship.cpp, gropengldeferred.cpp,
+	// VulkanPostProcessingLighting.cpp) passes exactly this (offset, count)
+	// pair, so this identifies "a cockpit-pass bind happened" regardless of
+	// whether world_offset came out zero or nonzero -- unlike gating on
+	// |world_offset|, this can't be silently skipped just because the ship
+	// happens to be near the origin this test run. Remove once confirmed
+	// against a live rt_shadow_debug test.
+	if (cascade_offset == 0 && cascade_count == Num_cockpit_shadow_cascades) {
+		static bool logged_once = false;
+		if (!logged_once) {
+			logged_once = true;
+			mprintf(("RT shadow space-offset check: |world_offset|=%.3f  (%.2f, %.2f, %.2f)  self_shadow=%d\n",
+				vm_vec_mag(&world_offset), world_offset.xyz.x, world_offset.xyz.y, world_offset.xyz.z,
+				allow_viewer_self_shadow ? 1 : 0));
+		}
+	}
 
 	Shadow_cascade_count = cascade_count;
 
@@ -1108,7 +1136,23 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count) {
 	}
 	offset += sizeof(float) * padding;
 
-	gr_update_buffer_data_offset(Shadow_cascade_params_buffer, 0, required_size, buffer.data());
+	// Must be the full-replacement update (not _offset): this function is called
+	// multiple times per frame with different content (main scene, viewer-ship-
+	// onto-cockpit, cockpit-self, forward cockpit, deferred cockpit -- up to 5
+	// times when the player's cockpit is rendered). On Vulkan's streaming buffer
+	// path, gr_update_buffer_data_offset() only bump-allocates a fresh GPU region
+	// on the first call of the frame; every later call this frame would silently
+	// overwrite that same region in place instead of getting its own. Since
+	// command buffers are recorded before the GPU executes any of them, every
+	// draw this frame would then read whichever bind happened to run last,
+	// regardless of which one was "current" when that draw was recorded -- e.g.
+	// the main scene's shadow-casting draws picking up the cockpit's cascade
+	// range, or the cockpit's shadow_ray_cull_mask read stale/wrong.
+	// gr_update_buffer_data() always bump-allocates fresh on Vulkan (matching the
+	// per-pass isolation deferred_global_data/deferred_light_data already use for
+	// the same reason), and is a safe, standard buffer-orphaning glBufferData()
+	// call on OpenGL.
+	gr_update_buffer_data(Shadow_cascade_params_buffer, required_size, buffer.data());
 	gr_bind_uniform_buffer(uniform_block_type::ShadowCascadeParams, 0, required_size, Shadow_cascade_params_buffer);
 }
 

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -1094,24 +1094,6 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count, const vec
 	// need different corrections; Lighting_mode alone can't distinguish them.
 	static_data.shadow_ray_world_offset = world_offset;
 
-	// TEMPORARY: one-shot diagnostic for the cockpit coordinate-space fix. Every
-	// current cockpit-range bind (ship.cpp, gropengldeferred.cpp,
-	// VulkanPostProcessingLighting.cpp) passes exactly this (offset, count)
-	// pair, so this identifies "a cockpit-pass bind happened" regardless of
-	// whether world_offset came out zero or nonzero -- unlike gating on
-	// |world_offset|, this can't be silently skipped just because the ship
-	// happens to be near the origin this test run. Remove once confirmed
-	// against a live rt_shadow_debug test.
-	if (cascade_offset == 0 && cascade_count == Num_cockpit_shadow_cascades) {
-		static bool logged_once = false;
-		if (!logged_once) {
-			logged_once = true;
-			mprintf(("RT shadow space-offset check: |world_offset|=%.3f  (%.2f, %.2f, %.2f)  self_shadow=%d\n",
-				vm_vec_mag(&world_offset), world_offset.xyz.x, world_offset.xyz.y, world_offset.xyz.z,
-				allow_viewer_self_shadow ? 1 : 0));
-		}
-	}
-
 	Shadow_cascade_count = cascade_count;
 
 	offset += sizeof(graphics::shadow_cascade_static_data);

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -27,6 +27,7 @@
 #include "ship/ship.h"
 #include "ship/shipfx.h"
 #include "render/3d.h"
+#include "debugconsole/console.h"
 #include "tracing/tracing.h"
 #include "util/uniform_structs.h"
 
@@ -36,6 +37,21 @@ matrix4 Shadow_view_matrix_light;
 matrix4 Shadow_view_matrix_render;
 SCP_vector<matrix4> Shadow_proj_matrix;
 SCP_vector<float> Shadow_cascade_distances;
+
+bool Rt_shadow_debug_visualize = false;
+
+DCF(rt_shadow_debug, "Toggles red visualization of raytraced shadow occlusion")
+{
+	if (dc_optional_string_either("status", "--status") || dc_optional_string_either("?", "--?")) {
+		dc_printf("Raytraced shadow debug visualization is %s", Rt_shadow_debug_visualize ? "ON" : "OFF");
+		return;
+	}
+
+	Rt_shadow_debug_visualize = !Rt_shadow_debug_visualize;
+	dc_printf("Raytraced shadow debug visualization %s. Occluded fragments will be tinted red wherever "
+		"a raytraced shadow query is actually evaluated (Vulkan, RT shadows enabled, a shadow-receiving "
+		"material).\n", Rt_shadow_debug_visualize ? "enabled" : "disabled");
+}
 
 static SCP_vector<light_frustum_info> Shadow_frustums;
 
@@ -1065,6 +1081,8 @@ void shadow_cascade_params_bind(int cascade_offset, int cascade_count) {
 	// supposed to cast onto its cockpit this frame.
 	static_data.shadow_ray_cull_mask =
 		(Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit()) ? 0xFF : 0x7F;
+
+	static_data.rt_shadow_debug_visualize = Rt_shadow_debug_visualize ? 1 : 0;
 
 	Shadow_cascade_count = cascade_count;
 

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -95,6 +95,13 @@ extern SCP_vector<matrix4> Shadow_proj_matrix;
 extern SCP_vector<float> Shadow_cascade_distances;
 extern int Shadow_cascade_count;
 
+// Debug visualization: when true, fragments occluded by a raytraced shadow
+// query (traceShadowRay()/shadows.sdr) are tinted red instead of shaded
+// normally. Toggled via the `rt_shadow_debug` debug-console command. Packed
+// into the shared shadowCascadeParams uniform (shadow_cascade_static_data)
+// alongside shadow_ray_cull_mask -- see shadow_cascade_params_bind().
+extern bool Rt_shadow_debug_visualize;
+
 void shadows_construct_light_frustum(vec3d *min_out, vec3d *max_out, vec3d light_vec, matrix *orient, vec3d *pos, fov_t fov, float aspect, float z_near, float z_far);
 bool shadows_obj_in_frustum(object *objp, vec3d *min, vec3d *max, matrix *light_orient);
 void shadows_render_all(fov_t fov, matrix *eye_orient, vec3d *eye_pos,

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -109,7 +109,24 @@ void shadows_render_all(fov_t fov, matrix *eye_orient, vec3d *eye_pos,
 
 void shadow_cascade_params_init();
 void shadow_cascade_params_shutdown();
-void shadow_cascade_params_bind(int cascade_offset, int cascade_count);
+
+// world_offset: added to traceShadowRay()'s reconstructed (inv_view_matrix *
+// viewSpacePos) position before tracing. Zero for every pass that already
+// renders in true world space (objp->pos-anchored view + model matrices).
+// The cockpit pass is the only exception -- see ship_render_player_ship()
+// (ship.cpp) and shadow_cascade_static_data's shadow_ray_world_offset comment
+// (uniform_structs.h) for the derivation. Callers whose draws share this pass
+// but use a *different* internal frame (e.g. the eye-relative hull draw vs.
+// the cockpit-offset-relative cockpit draw) must rebind with the offset
+// appropriate to whichever draw is about to happen -- one bind cannot serve
+// both.
+// allow_viewer_self_shadow: lets the viewer ship's own hull TLAS instance
+// (tagged with a dedicated mask bit, see
+// VulkanRaytracingManager::gatherShadowCasterInstances()) participate in this
+// pass's shadow rays. False everywhere except the cockpit's own shading,
+// where the hull is meant to be able to cast onto the cockpit.
+void shadow_cascade_params_bind(int cascade_offset, int cascade_count, const vec3d& world_offset,
+	bool allow_viewer_self_shadow = false);
 
 matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, fov_t fov, fov_t cockpit_fov, float aspect, const std::optional<SCP_vector<float>>& cascade_distances_override = std::nullopt);
 void shadows_end_render();

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -95,12 +95,14 @@ extern SCP_vector<matrix4> Shadow_proj_matrix;
 extern SCP_vector<float> Shadow_cascade_distances;
 extern int Shadow_cascade_count;
 
-// Debug visualization: when true, fragments occluded by a raytraced shadow
-// query (traceShadowRay()/shadows.sdr) are tinted red instead of shaded
-// normally. Toggled via the `rt_shadow_debug` debug-console command. Packed
-// into the shared shadowCascadeParams uniform (shadow_cascade_static_data)
-// alongside shadow_ray_cull_mask -- see shadow_cascade_params_bind().
-extern bool Rt_shadow_debug_visualize;
+// TLAS ray-cull mask bit reserved for the viewer ship's own hull instance
+// (VulkanRaytracingManager::gatherShadowCasterInstances()'s OBJ_SHIP case), so shadow
+// rays can selectively exclude it -- see shadow_cascade_params_bind()'s
+// shadow_ray_cull_mask and traceShadowRay() (shadows.sdr).
+constexpr uint8_t TLAS_MASK_VIEWER_HULL = 0x80;
+// Default TLAS instance mask (visible to every ray) minus TLAS_MASK_VIEWER_HULL --
+// the shadow_ray_cull_mask used everywhere the viewer's own hull must not self-shadow.
+constexpr uint8_t SHADOW_RAY_CULL_MASK_EXCLUDE_VIEWER_HULL = static_cast<uint8_t>(~TLAS_MASK_VIEWER_HULL);
 
 void shadows_construct_light_frustum(vec3d *min_out, vec3d *max_out, vec3d light_vec, matrix *orient, vec3d *pos, fov_t fov, float aspect, float z_near, float z_far);
 bool shadows_obj_in_frustum(object *objp, vec3d *min, vec3d *max, matrix *light_orient);
@@ -110,23 +112,22 @@ void shadows_render_all(fov_t fov, matrix *eye_orient, vec3d *eye_pos,
 void shadow_cascade_params_init();
 void shadow_cascade_params_shutdown();
 
-// world_offset: added to traceShadowRay()'s reconstructed (inv_view_matrix *
-// viewSpacePos) position before tracing. Zero for every pass that already
-// renders in true world space (objp->pos-anchored view + model matrices).
-// The cockpit pass is the only exception -- see ship_render_player_ship()
-// (ship.cpp) and shadow_cascade_static_data's shadow_ray_world_offset comment
-// (uniform_structs.h) for the derivation. Callers whose draws share this pass
-// but use a *different* internal frame (e.g. the eye-relative hull draw vs.
-// the cockpit-offset-relative cockpit draw) must rebind with the offset
-// appropriate to whichever draw is about to happen -- one bind cannot serve
-// both.
-// allow_viewer_self_shadow: lets the viewer ship's own hull TLAS instance
-// (tagged with a dedicated mask bit, see
-// VulkanRaytracingManager::gatherShadowCasterInstances()) participate in this
-// pass's shadow rays. False everywhere except the cockpit's own shading,
-// where the hull is meant to be able to cast onto the cockpit.
+// world_offset: added to traceShadowRay()'s reconstructed world position before tracing.
+// Zero for every pass rendering in true world space; nonzero only for the cockpit pass
+// (see shadow_cascade_static_data::shadow_ray_world_offset, uniform_structs.h, for the
+// derivation). A pass with draws in more than one internal frame -- e.g.
+// ship_render_player_ship()'s hull vs. cockpit draws -- must rebind before each one.
+// allow_viewer_self_shadow: lets the viewer ship's own hull (TLAS_MASK_VIEWER_HULL,
+// shadows.h) cast shadows in this pass. True only for the cockpit's own shading.
 void shadow_cascade_params_bind(int cascade_offset, int cascade_count, const vec3d& world_offset,
 	bool allow_viewer_self_shadow = false);
+
+// Binds the cascade range/world_offset/self-shadow-mask appropriate for the current
+// Lighting_mode, for callers that (unlike ship_render_player_ship()) only ever shade
+// one frame per pass -- currently the deferred-lighting full-screen passes
+// (gropengldeferred.cpp, VulkanPostProcessingLighting.cpp). See shadow_cascade_params_bind()
+// above for what world_offset/allow_viewer_self_shadow mean and their known limitation here.
+void shadow_cascade_params_bind_deferred();
 
 matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, fov_t fov, fov_t cockpit_fov, float aspect, const std::optional<SCP_vector<float>>& cascade_distances_override = std::nullopt);
 void shadows_end_render();

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -95,6 +95,15 @@ extern SCP_vector<matrix4> Shadow_proj_matrix;
 extern SCP_vector<float> Shadow_cascade_distances;
 extern int Shadow_cascade_count;
 
+// TLAS ray-cull mask bit reserved for the viewer ship's own hull instance
+// (VulkanRaytracingManager::gatherShadowCasterInstances()'s OBJ_SHIP case), so shadow
+// rays can selectively exclude it -- see shadow_cascade_params_bind()'s
+// shadow_ray_cull_mask and traceShadowRay() (shadows.sdr).
+constexpr uint8_t TLAS_MASK_VIEWER_HULL = 0x80;
+// Default TLAS instance mask (visible to every ray) minus TLAS_MASK_VIEWER_HULL --
+// the shadow_ray_cull_mask used everywhere the viewer's own hull must not self-shadow.
+constexpr uint8_t SHADOW_RAY_CULL_MASK_EXCLUDE_VIEWER_HULL = static_cast<uint8_t>(~TLAS_MASK_VIEWER_HULL);
+
 void shadows_construct_light_frustum(vec3d *min_out, vec3d *max_out, vec3d light_vec, matrix *orient, vec3d *pos, fov_t fov, float aspect, float z_near, float z_far);
 bool shadows_obj_in_frustum(object *objp, vec3d *min, vec3d *max, matrix *light_orient);
 void shadows_render_all(fov_t fov, matrix *eye_orient, vec3d *eye_pos,
@@ -102,7 +111,23 @@ void shadows_render_all(fov_t fov, matrix *eye_orient, vec3d *eye_pos,
 
 void shadow_cascade_params_init();
 void shadow_cascade_params_shutdown();
-void shadow_cascade_params_bind(int cascade_offset, int cascade_count);
+
+// world_offset: added to traceShadowRay()'s reconstructed world position before tracing.
+// Zero for every pass rendering in true world space; nonzero only for the cockpit pass
+// (see shadow_cascade_static_data::shadow_ray_world_offset, uniform_structs.h, for the
+// derivation). A pass with draws in more than one internal frame -- e.g.
+// ship_render_player_ship()'s hull vs. cockpit draws -- must rebind before each one.
+// allow_viewer_self_shadow: lets the viewer ship's own hull (TLAS_MASK_VIEWER_HULL,
+// shadows.h) cast shadows in this pass. True only for the cockpit's own shading.
+void shadow_cascade_params_bind(int cascade_offset, int cascade_count, const vec3d& world_offset,
+	bool allow_viewer_self_shadow = false);
+
+// Binds the cascade range/world_offset/self-shadow-mask appropriate for the current
+// Lighting_mode, for callers that (unlike ship_render_player_ship()) only ever shade
+// one frame per pass -- currently the deferred-lighting full-screen passes
+// (gropengldeferred.cpp, VulkanPostProcessingLighting.cpp). See shadow_cascade_params_bind()
+// above for what world_offset/allow_viewer_self_shadow mean and their known limitation here.
+void shadow_cascade_params_bind_deferred();
 
 matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, fov_t fov, fov_t cockpit_fov, float aspect, const std::optional<SCP_vector<float>>& cascade_distances_override = std::nullopt);
 void shadows_end_render();

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -155,13 +155,19 @@ struct shadow_cascade_static_data {
 	// matching the rasterized path's exclusion of Viewer_obj from the main
 	// shadow cascades. Set in shadow_cascade_params_bind() (shadows.cpp).
 	int shadow_ray_cull_mask;
-	float pad[3]; // keep shadow_proj_matrix[]'s offset 16-byte aligned (std140)
+
+	// Debug visualization toggle (see Rt_shadow_debug_visualize, shadows.h):
+	// nonzero paints raytraced-shadow-occluded fragments red. Read by
+	// traceShadowRay()'s callers in main-f.sdr/deferred-f.sdr, not by
+	// traceShadowRay() itself.
+	int rt_shadow_debug_visualize;
+	float pad[2]; // keep shadow_proj_matrix[]'s offset 16-byte aligned (std140)
 };
 // Must match the GLSL shadowCascadeParams block's implicit std140 padding
 // exactly (16 [4 leading scalars] + 64 [matrix4] + 4 [shadow_ray_cull_mask]
-// + 12 [pad[3]] = 96) -- shadow_cascade_params_bind() packs shadow_proj_matrix[]
-// immediately after this struct via sizeof(), so a mismatch here silently
-// shifts every cascade matrix in the buffer, in both backends.
+// + 4 [rt_shadow_debug_visualize] + 8 [pad[2]] = 96) -- shadow_cascade_params_bind()
+// packs shadow_proj_matrix[] immediately after this struct via sizeof(), so a
+// mismatch here silently shifts every cascade matrix in the buffer, in both backends.
 static_assert(sizeof(shadow_cascade_static_data) == 96, "shadow_cascade_static_data must match the GLSL shadowCascadeParams layout (see comment above)");
 
 enum class NanoVGShaderType: int32_t {

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -161,14 +161,31 @@ struct shadow_cascade_static_data {
 	// traceShadowRay()'s callers in main-f.sdr/deferred-f.sdr, not by
 	// traceShadowRay() itself.
 	int rt_shadow_debug_visualize;
-	float pad[2]; // keep shadow_proj_matrix[]'s offset 16-byte aligned (std140)
+	float pad[2]; // pre-pad shadow_ray_world_offset's offset to 16-byte alignment (std140 vec3 rule)
+
+	// World-space correction added to the RT shadow ray's reconstructed position
+	// (inv_view_matrix * viewSpacePos) before tracing. Zero everywhere except the
+	// cockpit pass: ship_render_player_ship() renders the cockpit using a view
+	// matrix anchored at `leaning_position` (a small head-lean vector, never
+	// combined with the ship's actual world position -- see playercontrol.cpp)
+	// and passes model positions as offsets in that same un-translated frame
+	// (ship.cpp's `cockpit_offset`/`eye_offset`, likewise never combined with
+	// objp->pos). So inv_view_matrix reconstructs positions in that frame, not
+	// true world space, while the shadow TLAS is built in true world space
+	// (VulkanRaytracingManager::gatherShadowCasterInstances()/
+	// gatherCockpitShadowCasterInstance() both anchor at objp->pos). Adding the
+	// viewer ship's world position back here closes that gap -- see
+	// shadow_cascade_params_bind() for the derivation and where this is set.
+	vec3d shadow_ray_world_offset;
+	float pad2; // keep shadow_proj_matrix[]'s offset 16-byte aligned (std140)
 };
 // Must match the GLSL shadowCascadeParams block's implicit std140 padding
 // exactly (16 [4 leading scalars] + 64 [matrix4] + 4 [shadow_ray_cull_mask]
-// + 4 [rt_shadow_debug_visualize] + 8 [pad[2]] = 96) -- shadow_cascade_params_bind()
-// packs shadow_proj_matrix[] immediately after this struct via sizeof(), so a
-// mismatch here silently shifts every cascade matrix in the buffer, in both backends.
-static_assert(sizeof(shadow_cascade_static_data) == 96, "shadow_cascade_static_data must match the GLSL shadowCascadeParams layout (see comment above)");
+// + 4 [rt_shadow_debug_visualize] + 8 [pad[2]] + 12 [shadow_ray_world_offset]
+// + 4 [pad2] = 112) -- shadow_cascade_params_bind() packs shadow_proj_matrix[]
+// immediately after this struct via sizeof(), so a mismatch here silently
+// shifts every cascade matrix in the buffer, in both backends.
+static_assert(sizeof(shadow_cascade_static_data) == 112, "shadow_cascade_static_data must match the GLSL shadowCascadeParams layout (see comment above)");
 
 enum class NanoVGShaderType: int32_t {
 	FillGradient = 0, FillImage = 1, Simple = 2, Image = 3

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -147,7 +147,33 @@ struct shadow_cascade_static_data {
 	float rtShadowBiasMin;
 	float rtShadowBiasMax;
 	matrix4 shadow_mv_matrix;
+
+	// World-space correction added to the RT shadow ray's reconstructed position before
+	// tracing. Zero everywhere except the cockpit pass: ship_render_player_ship() renders
+	// the cockpit using a view matrix anchored at `leaning_position` and model positions
+	// offset in that same un-translated frame (never combined with objp->pos), so the
+	// reconstructed position isn't true world space like the shadow TLAS is. Adding the
+	// viewer ship's world position back here closes that gap -- see
+	// shadow_cascade_params_bind() (shadows.cpp) for where this is set.
+	//
+	// Declared before shadow_ray_cull_mask so the trailing int packs into this vec3's
+	// std140 alignment padding instead of needing a manual pad field (std140 gives a vec3
+	// 16-byte alignment but only 12-byte size, so a following scalar fills the gap for free).
+	vec3d shadow_ray_world_offset;
+
+	// Ray cull mask for raytraced shadow queries (traceShadowRay()/shadows.sdr). Excludes
+	// the viewer ship's own hull TLAS instance (TLAS_MASK_VIEWER_HULL, shadows.h) outside
+	// the cockpit pass, matching the rasterized path's exclusion of Viewer_obj from the
+	// main shadow cascades. Set in shadow_cascade_params_bind() (shadows.cpp).
+	int shadow_ray_cull_mask;
 };
+// Must match the GLSL shadowCascadeParams block's implicit std140 padding
+// exactly (16 [4 leading scalars] + 64 [matrix4] + 12 [shadow_ray_world_offset]
+// + 4 [shadow_ray_cull_mask, packed into the vec3's alignment padding] = 96) --
+// shadow_cascade_params_bind() packs shadow_proj_matrix[] immediately after
+// this struct via sizeof(), so a mismatch here silently shifts every cascade
+// matrix in the buffer, in both backends.
+static_assert(sizeof(shadow_cascade_static_data) == 96, "shadow_cascade_static_data must match the GLSL shadowCascadeParams layout (see comment above)");
 
 enum class NanoVGShaderType: int32_t {
 	FillGradient = 0, FillImage = 1, Simple = 2, Image = 3

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -148,43 +148,29 @@ struct shadow_cascade_static_data {
 	float rtShadowBiasMax;
 	matrix4 shadow_mv_matrix;
 
-	// Ray cull mask for raytraced shadow queries (traceShadowRay()/shadows.sdr).
-	// Lets the viewer ship's own hull -- tagged with a dedicated TLAS instance
-	// mask bit, see VulkanRaytracingManager::gatherShadowCasterInstances() --
-	// be selectively excluded from shadow rays outside the cockpit pass,
-	// matching the rasterized path's exclusion of Viewer_obj from the main
-	// shadow cascades. Set in shadow_cascade_params_bind() (shadows.cpp).
+	// Ray cull mask for raytraced shadow queries (traceShadowRay()/shadows.sdr). Excludes
+	// the viewer ship's own hull TLAS instance (TLAS_MASK_VIEWER_HULL, shadows.h) outside
+	// the cockpit pass, matching the rasterized path's exclusion of Viewer_obj from the
+	// main shadow cascades. Set in shadow_cascade_params_bind() (shadows.cpp).
 	int shadow_ray_cull_mask;
+	float pad[3]; // pad shadow_ray_world_offset's offset to 16-byte alignment (std140 vec3 rule)
 
-	// Debug visualization toggle (see Rt_shadow_debug_visualize, shadows.h):
-	// nonzero paints raytraced-shadow-occluded fragments red. Read by
-	// traceShadowRay()'s callers in main-f.sdr/deferred-f.sdr, not by
-	// traceShadowRay() itself.
-	int rt_shadow_debug_visualize;
-	float pad[2]; // pre-pad shadow_ray_world_offset's offset to 16-byte alignment (std140 vec3 rule)
-
-	// World-space correction added to the RT shadow ray's reconstructed position
-	// (inv_view_matrix * viewSpacePos) before tracing. Zero everywhere except the
-	// cockpit pass: ship_render_player_ship() renders the cockpit using a view
-	// matrix anchored at `leaning_position` (a small head-lean vector, never
-	// combined with the ship's actual world position -- see playercontrol.cpp)
-	// and passes model positions as offsets in that same un-translated frame
-	// (ship.cpp's `cockpit_offset`/`eye_offset`, likewise never combined with
-	// objp->pos). So inv_view_matrix reconstructs positions in that frame, not
-	// true world space, while the shadow TLAS is built in true world space
-	// (VulkanRaytracingManager::gatherShadowCasterInstances()/
-	// gatherCockpitShadowCasterInstance() both anchor at objp->pos). Adding the
+	// World-space correction added to the RT shadow ray's reconstructed position before
+	// tracing. Zero everywhere except the cockpit pass: ship_render_player_ship() renders
+	// the cockpit using a view matrix anchored at `leaning_position` and model positions
+	// offset in that same un-translated frame (never combined with objp->pos), so the
+	// reconstructed position isn't true world space like the shadow TLAS is. Adding the
 	// viewer ship's world position back here closes that gap -- see
-	// shadow_cascade_params_bind() for the derivation and where this is set.
+	// shadow_cascade_params_bind() (shadows.cpp) for where this is set.
 	vec3d shadow_ray_world_offset;
 	float pad2; // keep shadow_proj_matrix[]'s offset 16-byte aligned (std140)
 };
 // Must match the GLSL shadowCascadeParams block's implicit std140 padding
 // exactly (16 [4 leading scalars] + 64 [matrix4] + 4 [shadow_ray_cull_mask]
-// + 4 [rt_shadow_debug_visualize] + 8 [pad[2]] + 12 [shadow_ray_world_offset]
-// + 4 [pad2] = 112) -- shadow_cascade_params_bind() packs shadow_proj_matrix[]
-// immediately after this struct via sizeof(), so a mismatch here silently
-// shifts every cascade matrix in the buffer, in both backends.
+// + 12 [pad[3]] + 12 [shadow_ray_world_offset] + 4 [pad2] = 112) --
+// shadow_cascade_params_bind() packs shadow_proj_matrix[] immediately after
+// this struct via sizeof(), so a mismatch here silently shifts every cascade
+// matrix in the buffer, in both backends.
 static_assert(sizeof(shadow_cascade_static_data) == 112, "shadow_cascade_static_data must match the GLSL shadowCascadeParams layout (see comment above)");
 
 enum class NanoVGShaderType: int32_t {

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -147,7 +147,22 @@ struct shadow_cascade_static_data {
 	float rtShadowBiasMin;
 	float rtShadowBiasMax;
 	matrix4 shadow_mv_matrix;
+
+	// Ray cull mask for raytraced shadow queries (traceShadowRay()/shadows.sdr).
+	// Lets the viewer ship's own hull -- tagged with a dedicated TLAS instance
+	// mask bit, see VulkanRaytracingManager::gatherShadowCasterInstances() --
+	// be selectively excluded from shadow rays outside the cockpit pass,
+	// matching the rasterized path's exclusion of Viewer_obj from the main
+	// shadow cascades. Set in shadow_cascade_params_bind() (shadows.cpp).
+	int shadow_ray_cull_mask;
+	float pad[3]; // keep shadow_proj_matrix[]'s offset 16-byte aligned (std140)
 };
+// Must match the GLSL shadowCascadeParams block's implicit std140 padding
+// exactly (16 [4 leading scalars] + 64 [matrix4] + 4 [shadow_ray_cull_mask]
+// + 12 [pad[3]] = 96) -- shadow_cascade_params_bind() packs shadow_proj_matrix[]
+// immediately after this struct via sizeof(), so a mismatch here silently
+// shifts every cascade matrix in the buffer, in both backends.
+static_assert(sizeof(shadow_cascade_static_data) == 96, "shadow_cascade_static_data must match the GLSL shadowCascadeParams layout (see comment above)");
 
 enum class NanoVGShaderType: int32_t {
 	FillGradient = 0, FillImage = 1, Simple = 2, Image = 3

--- a/code/graphics/vulkan/VulkanPostProcessing.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessing.cpp
@@ -425,10 +425,12 @@ bool VulkanPostProcessor::createSceneTargets(vk::Extent2D extent)
 	m_sceneColor.height = extent.height;
 
 	// Scene depth target
+	// eTransferDst needed for restoreSceneDepth (backup→depth copy after the cockpit render)
 	if (!createImage(extent.width, extent.height, m_ctx.depthFormat,
 	                 vk::ImageUsageFlagBits::eDepthStencilAttachment
 	                 | vk::ImageUsageFlagBits::eSampled
-	                 | vk::ImageUsageFlagBits::eTransferSrc,
+	                 | vk::ImageUsageFlagBits::eTransferSrc
+	                 | vk::ImageUsageFlagBits::eTransferDst,
 	                 vk::ImageAspectFlagBits::eDepth,  // View uses depth-only aspect
 	                 m_sceneDepth.image, m_sceneDepth.view, m_sceneDepth.allocation)) {
 		nprintf(("vulkan", "VulkanPostProcessor: Failed to create scene depth image!\n"));
@@ -463,6 +465,22 @@ bool VulkanPostProcessor::createSceneTargets(vk::Extent2D extent)
 	m_sceneDepthCopy.width = extent.width;
 	m_sceneDepthCopy.height = extent.height;
 
+	// Scene depth backup (holds the scene's depth while the cockpit renders)
+	// Copy target on the way out, copy source on the way back in. No shader ever reads it,
+	// but eSampled stays: createImage() always builds a view, and a view needs at least one
+	// non-transfer usage bit (VUID-VkImageViewCreateInfo-image-04441).
+	if (!createImage(extent.width, extent.height, m_ctx.depthFormat,
+	                 vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eTransferSrc
+	                 | vk::ImageUsageFlagBits::eSampled,
+	                 vk::ImageAspectFlagBits::eDepth,
+	                 m_sceneDepthBackup.image, m_sceneDepthBackup.view, m_sceneDepthBackup.allocation)) {
+		nprintf(("vulkan", "VulkanPostProcessor: Failed to create scene depth backup image!\n"));
+		return false;
+	}
+	m_sceneDepthBackup.format = m_ctx.depthFormat;
+	m_sceneDepthBackup.width = extent.width;
+	m_sceneDepthBackup.height = extent.height;
+
 	return true;
 }
 
@@ -476,6 +494,7 @@ void VulkanPostProcessor::destroySceneTargets()
 	m_ctx.destroyTarget(m_sceneColor);
 	m_ctx.destroyTarget(m_sceneDepth);
 	m_ctx.destroyTarget(m_sceneDepthCopy);
+	m_ctx.destroyTarget(m_sceneDepthBackup);
 }
 
 bool VulkanPostProcessor::createSceneFramebuffer()
@@ -577,6 +596,29 @@ void VulkanPostProcessor::copySceneDepth(vk::CommandBuffer cmd) const
 	copyImageToImage(cmd,
 		m_sceneDepth.image, vk::ImageLayout::eDepthStencilAttachmentOptimal, vk::ImageLayout::eDepthStencilAttachmentOptimal,
 		m_sceneDepthCopy.image, vk::ImageLayout::eUndefined, vk::ImageLayout::eShaderReadOnlyOptimal,
+		m_ctx.sceneExtent,
+		imageAspectFromFormat(m_ctx.depthFormat));
+}
+
+void VulkanPostProcessor::saveSceneDepth(vk::CommandBuffer cmd) const
+{
+	// Called outside a render pass, so scene depth is in eDepthStencilAttachmentOptimal
+	// (the scene/G-buffer render pass finalLayout). The backup keeps no content between
+	// frames, hence eUndefined: the copy overwrites every texel.
+	copyImageToImage(cmd,
+		m_sceneDepth.image, vk::ImageLayout::eDepthStencilAttachmentOptimal, vk::ImageLayout::eDepthStencilAttachmentOptimal,
+		m_sceneDepthBackup.image, vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferSrcOptimal,
+		m_ctx.sceneExtent,
+		imageAspectFromFormat(m_ctx.depthFormat));
+}
+
+void VulkanPostProcessor::restoreSceneDepth(vk::CommandBuffer cmd) const
+{
+	// The backup was left in eTransferSrcOptimal by saveSceneDepth() and stays there --
+	// the next save transitions it from eUndefined anyway.
+	copyImageToImage(cmd,
+		m_sceneDepthBackup.image, vk::ImageLayout::eTransferSrcOptimal, vk::ImageLayout::eTransferSrcOptimal,
+		m_sceneDepth.image, vk::ImageLayout::eDepthStencilAttachmentOptimal, vk::ImageLayout::eDepthStencilAttachmentOptimal,
 		m_ctx.sceneExtent,
 		imageAspectFromFormat(m_ctx.depthFormat));
 }
@@ -822,15 +864,34 @@ void VulkanPostProcessor::encodeOutputSdr(vk::CommandBuffer cmd, vk::RenderPass 
 void vulkan_post_process_begin() {}
 void vulkan_post_process_end() {}
 
-// No-op: In OpenGL, save/restore swap the depth attachment between
-// Scene_depth_texture and Cockpit_depth_texture to isolate cockpit
-// depth from the main scene. In Vulkan, the render pass loadOp=eClear
-// clears depth at the start of each scene pass, and separate cockpit
-// depth isolation is not yet implemented. Called from ship.cpp during
-// cockpit rendering but degrades gracefully as a no-op (cockpit just
-// shares the scene depth buffer).
-void vulkan_post_process_save_zbuffer() {}
-void vulkan_post_process_restore_zbuffer() {}
+// Isolate the cockpit's depth from the scene's, the way OpenGL does by swapping the
+// depth attachment between Scene_depth_texture and Cockpit_depth_texture. A Vulkan
+// framebuffer owns its attachments, so the scene depth is parked in a backup image and
+// the live depth buffer is cleared for the cockpit; the restore puts the scene back.
+//
+// Both halves are needed. Without the clear the ship hull the scene already drew wins
+// the depth test against the cockpit around the camera. Without the restore the
+// post-processing passes that sample scene depth (lightshafts) see cockpit depth.
+void vulkan_post_process_save_zbuffer()
+{
+	auto* renderer = getRendererInstance();
+	if (renderer != nullptr) {
+		renderer->saveSceneDepth();
+	}
+
+	// Unconditional, exactly as in OpenGL: when there is nothing to park (post-processing
+	// off, or no scene render pass), clearing is still what gives the cockpit a depth
+	// buffer of its own.
+	gr_zbuffer_clear(TRUE);
+}
+
+void vulkan_post_process_restore_zbuffer()
+{
+	auto* renderer = getRendererInstance();
+	if (renderer != nullptr) {
+		renderer->restoreSceneDepth();
+	}
+}
 
 void vulkan_post_process_set_effect(const char* name, int value, const vec3d* rgb)
 {

--- a/code/graphics/vulkan/VulkanPostProcessing.h
+++ b/code/graphics/vulkan/VulkanPostProcessing.h
@@ -991,6 +991,31 @@ public:
 	void copySceneDepth(vk::CommandBuffer cmd) const;
 
 	/**
+	 * @brief Copy scene depth aside so the cockpit can render on a cleared depth buffer
+	 *
+	 * The cockpit model shares the world with the ship hull around it, so it needs a
+	 * depth buffer of its own -- OpenGL gets one by swapping the depth attachment to
+	 * Cockpit_depth_texture. Here the scene depth stays the attachment and its content
+	 * is parked in a backup image instead, which restoreSceneDepth() puts back.
+	 *
+	 * Must be called outside a render pass. Leaves scene depth in
+	 * eDepthStencilAttachmentOptimal and the backup in eTransferSrcOptimal.
+	 *
+	 * @param cmd Active command buffer (must be outside a render pass)
+	 */
+	void saveSceneDepth(vk::CommandBuffer cmd) const;
+
+	/**
+	 * @brief Put the depth that saveSceneDepth() parked back into the scene depth buffer
+	 *
+	 * Discards whatever the cockpit wrote, which is the point: the post-processing
+	 * passes that sample scene depth (lightshafts) must see the scene, not the cockpit.
+	 *
+	 * @param cmd Active command buffer (must be outside a render pass)
+	 */
+	void restoreSceneDepth(vk::CommandBuffer cmd) const;
+
+	/**
 	 * @brief Check if LDR targets are available (tonemapping + FXAA ready)
 	 */
 	bool hasLDRTargets() const { return m_ldr.isInitialized(); }
@@ -1164,6 +1189,7 @@ private:
 	RenderTarget m_sceneColor;      // RGBA16F HDR scene color
 	RenderTarget m_sceneDepth;      // Depth buffer for scene
 	RenderTarget m_sceneDepthCopy;  // Samplable copy of scene depth (for soft particles)
+	RenderTarget m_sceneDepthBackup; // Scene depth parked across the cockpit render (transfer only)
 	RenderTarget m_sceneEffect;     // RGBA16F effect/composite (snapshot of scene color)
 
 	// Scene render pass and framebuffer

--- a/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
@@ -507,10 +507,7 @@ void VulkanDeferredLighting::render(vk::CommandBuffer cmd)
 
 		if (m_shadow->isInitialized() && Shadow_quality != ShadowQuality::Disabled) {
 			vm_inverse_matrix4(&header->inv_view_matrix, &Shadow_view_matrix_render);
-
-			int offset = (Lighting_mode == lighting_mode::COCKPIT) ? 0 : Num_cockpit_shadow_cascades;
-			int count  = (Lighting_mode == lighting_mode::COCKPIT) ? Num_cockpit_shadow_cascades : Num_shadow_cascades;
-			shadow_cascade_params_bind(offset, count);
+			shadow_cascade_params_bind_deferred();
 		}
 	}
 

--- a/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
@@ -24,8 +24,6 @@
 #include "tracing/tracing.h"
 #include "nebula/neb.h"
 #include "mission/missionparse.h"
-#include "object/object.h"
-#include "ship/ship.h"
 
 extern float Sun_spot;
 extern int Game_subspace_effect;
@@ -509,17 +507,7 @@ void VulkanDeferredLighting::render(vk::CommandBuffer cmd)
 
 		if (m_shadow->isInitialized() && Shadow_quality != ShadowQuality::Disabled) {
 			vm_inverse_matrix4(&header->inv_view_matrix, &Shadow_view_matrix_render);
-
-			int offset = (Lighting_mode == lighting_mode::COCKPIT) ? 0 : Num_cockpit_shadow_cascades;
-			int count  = (Lighting_mode == lighting_mode::COCKPIT) ? Num_cockpit_shadow_cascades : Num_shadow_cascades;
-			// See shadow_cascade_params_bind()'s declaration (shadows.h) and the mirrored
-			// comment in gropengldeferred.cpp: this full-screen pass can only carry one
-			// world_offset for every G-buffer texel it shades, which is exact for the
-			// common case (cockpit-model ships prerender their hull outside
-			// Lighting_mode::COCKPIT) and a known gap otherwise.
-			vec3d world_offset = (Lighting_mode == lighting_mode::COCKPIT && Viewer_obj != nullptr) ? Viewer_obj->pos : vmd_zero_vector;
-			bool allow_viewer_self_shadow = Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit();
-			shadow_cascade_params_bind(offset, count, world_offset, allow_viewer_self_shadow);
+			shadow_cascade_params_bind_deferred();
 		}
 	}
 

--- a/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
+++ b/code/graphics/vulkan/VulkanPostProcessingLighting.cpp
@@ -24,6 +24,8 @@
 #include "tracing/tracing.h"
 #include "nebula/neb.h"
 #include "mission/missionparse.h"
+#include "object/object.h"
+#include "ship/ship.h"
 
 extern float Sun_spot;
 extern int Game_subspace_effect;
@@ -510,7 +512,14 @@ void VulkanDeferredLighting::render(vk::CommandBuffer cmd)
 
 			int offset = (Lighting_mode == lighting_mode::COCKPIT) ? 0 : Num_cockpit_shadow_cascades;
 			int count  = (Lighting_mode == lighting_mode::COCKPIT) ? Num_cockpit_shadow_cascades : Num_shadow_cascades;
-			shadow_cascade_params_bind(offset, count);
+			// See shadow_cascade_params_bind()'s declaration (shadows.h) and the mirrored
+			// comment in gropengldeferred.cpp: this full-screen pass can only carry one
+			// world_offset for every G-buffer texel it shades, which is exact for the
+			// common case (cockpit-model ships prerender their hull outside
+			// Lighting_mode::COCKPIT) and a known gap otherwise.
+			vec3d world_offset = (Lighting_mode == lighting_mode::COCKPIT && Viewer_obj != nullptr) ? Viewer_obj->pos : vmd_zero_vector;
+			bool allow_viewer_self_shadow = Lighting_mode == lighting_mode::COCKPIT && ship_render_player_ship_casts_shadow_on_cockpit();
+			shadow_cascade_params_bind(offset, count, world_offset, allow_viewer_self_shadow);
 		}
 	}
 

--- a/code/graphics/vulkan/VulkanRaytracing.h
+++ b/code/graphics/vulkan/VulkanRaytracing.h
@@ -192,23 +192,51 @@ private:
 
 	// Shared by walkSubmodelTree/addSingleSubmodelInstance: appends one TLAS
 	// instance referencing blasAddress, placed at the given world orient/pos.
+	// `mask` is the instance's ray-cull mask (vk::AccelerationStructureInstanceKHR::mask);
+	// defaults to 0xFF (visible to every ray). The one caller that needs
+	// something else is the viewer ship's own hull, which is tagged with a
+	// dedicated bit so shadow rays can selectively exclude it -- see
+	// gatherShadowCasterInstances()'s OBJ_SHIP case and shadows.sdr's
+	// traceShadowRay() for how the two ends of this scheme meet.
 	static void pushInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 		vk::DeviceAddress blasAddress,
 		const matrix& orient,
-		const vec3d& pos);
+		const vec3d& pos,
+		uint8_t mask = 0xFF);
 
 	void gatherShadowCasterInstances(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances);
+	// Adds one instance walk for Viewer_obj's cockpit polymodel (sip->cockpit_model_num),
+	// which -- unlike ships/asteroids/debris -- has no backing `object` for
+	// gatherShadowCasterInstances() to discover it through. Mirrors the gating
+	// render_viewer_shadow()'s cockpit block uses (shadows.cpp) so the cockpit only
+	// gets a TLAS instance when it would also get a rasterized shadow-map pass.
+	void gatherCockpitShadowCasterInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances);
+	// `skipDetailBoxCheck`: the detail-box gate compares against the global
+	// `Eye_position` (see submodelPassesDetailBox()), which is correct for
+	// world-anchored objects (ships/asteroids/debris/props) but not for the
+	// cockpit model -- render_viewer_shadow()'s rasterized cockpit shadow
+	// pass evaluates its own detail-box checks against a cockpit-relative eye
+	// position instead (shadows.cpp), which Eye_position does not replicate.
+	// Rather than derive that (would need cam_offset/rot_offset threaded down
+	// from shadows_render_all(), see design doc), the cockpit call
+	// (gatherCockpitShadowCasterInstance) passes true here to skip the check
+	// entirely -- cockpit models are small and sit right against the camera,
+	// so render-box/render-sphere culling is unlikely to matter at that
+	// range. Every other caller passes false (default), unaffected.
 	void walkSubmodelTree(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 		transform_stack& stack,
 		const polymodel* pm,
 		const polymodel_instance* pmi,
-		int submodel_num);
+		int submodel_num,
+		uint8_t mask = 0xFF,
+		bool skipDetailBoxCheck = false);
 	void addSingleSubmodelInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 		const polymodel* pm,
 		const polymodel_instance* pmi,
 		int submodel_num,
 		const matrix& orient,
-		const vec3d& pos);
+		const vec3d& pos,
+		uint8_t mask = 0xFF);
 
 	// One full set of grow-only TLAS resources per frame-in-flight slot, indexed
 	// by currentFrameIndex() -- NOT a single shared instance. buildTlas()

--- a/code/graphics/vulkan/VulkanRaytracing.h
+++ b/code/graphics/vulkan/VulkanRaytracing.h
@@ -192,23 +192,41 @@ private:
 
 	// Shared by walkSubmodelTree/addSingleSubmodelInstance: appends one TLAS
 	// instance referencing blasAddress, placed at the given world orient/pos.
+	// `mask` is the instance's ray-cull mask (vk::AccelerationStructureInstanceKHR::mask,
+	// see TLAS_MASK_VIEWER_HULL in shadows.h); defaults to 0xFF (visible to every ray).
 	static void pushInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 		vk::DeviceAddress blasAddress,
 		const matrix& orient,
-		const vec3d& pos);
+		const vec3d& pos,
+		uint8_t mask = 0xFF);
 
 	void gatherShadowCasterInstances(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances);
+	// Adds one instance walk for Viewer_obj's cockpit polymodel (sip->cockpit_model_num),
+	// which -- unlike ships/asteroids/debris -- has no backing `object` for
+	// gatherShadowCasterInstances() to discover it through. Mirrors the gating
+	// render_viewer_shadow()'s cockpit block uses (shadows.cpp) so the cockpit only
+	// gets a TLAS instance when it would also get a rasterized shadow-map pass.
+	void gatherCockpitShadowCasterInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances);
+	// `skipDetailBoxCheck`: the detail-box gate (submodelPassesDetailBox()) compares
+	// against the global `Eye_position`, which isn't correct for the cockpit model (its
+	// rasterized detail-box checks use a cockpit-relative eye position instead -- see
+	// shadows.cpp). gatherCockpitShadowCasterInstance() passes true to skip the check
+	// rather than derive that; cockpit models are small and sit right against the camera,
+	// so detail-box culling is unlikely to matter there. Every other caller defaults false.
 	void walkSubmodelTree(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 		transform_stack& stack,
 		const polymodel* pm,
 		const polymodel_instance* pmi,
-		int submodel_num);
+		int submodel_num,
+		uint8_t mask = 0xFF,
+		bool skipDetailBoxCheck = false);
 	void addSingleSubmodelInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 		const polymodel* pm,
 		const polymodel_instance* pmi,
 		int submodel_num,
 		const matrix& orient,
-		const vec3d& pos);
+		const vec3d& pos,
+		uint8_t mask = 0xFF);
 
 	// One full set of grow-only TLAS resources per frame-in-flight slot, indexed
 	// by currentFrameIndex() -- NOT a single shared instance. buildTlas()

--- a/code/graphics/vulkan/VulkanRaytracing.h
+++ b/code/graphics/vulkan/VulkanRaytracing.h
@@ -192,12 +192,8 @@ private:
 
 	// Shared by walkSubmodelTree/addSingleSubmodelInstance: appends one TLAS
 	// instance referencing blasAddress, placed at the given world orient/pos.
-	// `mask` is the instance's ray-cull mask (vk::AccelerationStructureInstanceKHR::mask);
-	// defaults to 0xFF (visible to every ray). The one caller that needs
-	// something else is the viewer ship's own hull, which is tagged with a
-	// dedicated bit so shadow rays can selectively exclude it -- see
-	// gatherShadowCasterInstances()'s OBJ_SHIP case and shadows.sdr's
-	// traceShadowRay() for how the two ends of this scheme meet.
+	// `mask` is the instance's ray-cull mask (vk::AccelerationStructureInstanceKHR::mask,
+	// see TLAS_MASK_VIEWER_HULL in shadows.h); defaults to 0xFF (visible to every ray).
 	static void pushInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 		vk::DeviceAddress blasAddress,
 		const matrix& orient,
@@ -211,18 +207,12 @@ private:
 	// render_viewer_shadow()'s cockpit block uses (shadows.cpp) so the cockpit only
 	// gets a TLAS instance when it would also get a rasterized shadow-map pass.
 	void gatherCockpitShadowCasterInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances);
-	// `skipDetailBoxCheck`: the detail-box gate compares against the global
-	// `Eye_position` (see submodelPassesDetailBox()), which is correct for
-	// world-anchored objects (ships/asteroids/debris/props) but not for the
-	// cockpit model -- render_viewer_shadow()'s rasterized cockpit shadow
-	// pass evaluates its own detail-box checks against a cockpit-relative eye
-	// position instead (shadows.cpp), which Eye_position does not replicate.
-	// Rather than derive that (would need cam_offset/rot_offset threaded down
-	// from shadows_render_all(), see design doc), the cockpit call
-	// (gatherCockpitShadowCasterInstance) passes true here to skip the check
-	// entirely -- cockpit models are small and sit right against the camera,
-	// so render-box/render-sphere culling is unlikely to matter at that
-	// range. Every other caller passes false (default), unaffected.
+	// `skipDetailBoxCheck`: the detail-box gate (submodelPassesDetailBox()) compares
+	// against the global `Eye_position`, which isn't correct for the cockpit model (its
+	// rasterized detail-box checks use a cockpit-relative eye position instead -- see
+	// shadows.cpp). gatherCockpitShadowCasterInstance() passes true to skip the check
+	// rather than derive that; cockpit models are small and sit right against the camera,
+	// so detail-box culling is unlikely to matter there. Every other caller defaults false.
 	void walkSubmodelTree(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 		transform_stack& stack,
 		const polymodel* pm,

--- a/code/graphics/vulkan/VulkanRaytracingTlas.cpp
+++ b/code/graphics/vulkan/VulkanRaytracingTlas.cpp
@@ -1,5 +1,6 @@
 // Per-frame TLAS: gathers the current shadow-casting object set (ships,
-// asteroids, debris) into one top-level acceleration structure each frame.
+// asteroids, debris, raw POFs/props) into one top-level acceleration
+// structure each frame.
 // Split out from VulkanRaytracing.cpp since this is the only part of the
 // raytracing manager that reaches into Ships/Asteroids/Debris/Objects, a
 // distinctly different dependency set from the BLAS cache in
@@ -14,6 +15,8 @@
 
 #include "asteroid/asteroid.h"
 #include "debris/debris.h"
+#include "globalincs/systemvars.h"
+#include "mod_table/mod_table.h"
 #include "model/model.h"
 #include "model/modelrender.h"
 #include "object/object.h"
@@ -40,12 +43,13 @@ static bool submodelPassesDetailBox(const polymodel* pm, int submodel_num, const
 void VulkanRaytracingManager::pushInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 	vk::DeviceAddress blasAddress,
 	const matrix& orient,
-	const vec3d& pos)
+	const vec3d& pos,
+	uint8_t mask)
 {
 	vk::AccelerationStructureInstanceKHR instance;
 	instance.transform = toVkTransform(orient, pos);
 	instance.instanceCustomIndex = 0;
-	instance.mask = 0xFF;
+	instance.mask = mask;
 	instance.instanceShaderBindingTableRecordOffset = 0;
 	instance.flags = static_cast<VkGeometryInstanceFlagsKHR>(vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable);
 	instance.accelerationStructureReference = blasAddress;
@@ -57,7 +61,8 @@ void VulkanRaytracingManager::addSingleSubmodelInstance(SCP_vector<vk::Accelerat
 	const polymodel_instance* pmi,
 	int submodel_num,
 	const matrix& orient,
-	const vec3d& pos)
+	const vec3d& pos,
+	uint8_t mask)
 {
 	if (submodel_num < 0 || submodel_num >= pm->n_models) {
 		return;
@@ -80,14 +85,16 @@ void VulkanRaytracingManager::addSingleSubmodelInstance(SCP_vector<vk::Accelerat
 		return;
 	}
 
-	pushInstance(instances, entry->address, orient, pos);
+	pushInstance(instances, entry->address, orient, pos, mask);
 }
 
 void VulkanRaytracingManager::walkSubmodelTree(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 	transform_stack& stack,
 	const polymodel* pm,
 	const polymodel_instance* pmi,
-	int submodel_num)
+	int submodel_num,
+	uint8_t mask,
+	bool skipDetailBoxCheck)
 {
 	if (submodel_num < 0 || submodel_num >= pm->n_models) {
 		return;
@@ -135,19 +142,19 @@ void VulkanRaytracingManager::walkSubmodelTree(SCP_vector<vk::AccelerationStruct
 	// producing self-shadowing flicker that only stabilized once the camera cleared the
 	// model's detail-box distance. A failing check also skips this submodel's whole
 	// subtree, exactly like the rasterized path (a culled parent hides its children too).
-	if (!submodelPassesDetailBox(pm, submodel_num, world_orient, world_pos)) {
+	if (!skipDetailBoxCheck && !submodelPassesDetailBox(pm, submodel_num, world_orient, world_pos)) {
 		stack.pop();
 		return;
 	}
 
 	const BlasEntry* entry = getOrBuildBlasEntry(pm->id, submodel_num);
 	if (entry != nullptr) {
-		pushInstance(instances, entry->address, world_orient, world_pos);
+		pushInstance(instances, entry->address, world_orient, world_pos, mask);
 	}
 
 	for (int child = sm.first_child; child >= 0; child = pm->submodel[child].next_sibling) {
 		if (!pm->submodel[child].flags[Model::Submodel_flags::Is_thruster]) {
-			walkSubmodelTree(instances, stack, pm, pmi, child);
+			walkSubmodelTree(instances, stack, pm, pmi, child, mask, skipDetailBoxCheck);
 		}
 	}
 
@@ -157,7 +164,7 @@ void VulkanRaytracingManager::walkSubmodelTree(SCP_vector<vk::AccelerationStruct
 void VulkanRaytracingManager::gatherShadowCasterInstances(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances)
 {
 	// Mirrors the object selection in shadows_render_all() (shadows.cpp) --
-	// ships/asteroids/debris -- but without its per-cascade frustum
+	// ships/asteroids/debris/raw POFs/props -- but without its per-cascade frustum
 	// pre-filter, which lives in shadows.cpp's private state (Shadow_frustums)
 	// and is specific to the rasterized cascade layout. Starting unfiltered is
 	// simpler and safe (never wrongly excludes a caster); spatial culling of
@@ -187,9 +194,20 @@ void VulkanRaytracingManager::gatherShadowCasterInstances(SCP_vector<vk::Acceler
 				continue;
 			}
 
+			// The viewer's own hull is tagged with a dedicated mask bit (0x80,
+			// nothing else set) rather than the default 0xFF: it needs to be
+			// selectively excludable by shadow rays traced from the cockpit's
+			// own shading pass (see traceShadowRay()/shadows.sdr and
+			// VulkanPostProcessingLighting.cpp), matching the rasterized
+			// path's unconditional exclusion of Viewer_obj from the main
+			// shadow cascades (shadows.cpp) while still letting every other
+			// ray (default 0xFF cull mask) see it, since it's still really
+			// there.
+			uint8_t instanceMask = (objp == Viewer_obj) ? 0x80 : 0xFF;
+
 			transform_stack stack;
 			stack.push(&objp->pos, &objp->orient);
-			walkSubmodelTree(instances, stack, pm, pmi, pm->detail[0]);
+			walkSubmodelTree(instances, stack, pm, pmi, pm->detail[0], instanceMask);
 			break;
 		}
 		case OBJ_ASTEROID: {
@@ -224,10 +242,76 @@ void VulkanRaytracingManager::gatherShadowCasterInstances(SCP_vector<vk::Acceler
 			addSingleSubmodelInstance(instances, pm, pmi, db.submodel_num, objp->orient, objp->pos);
 			break;
 		}
+		case OBJ_RAW_POF:
+		case OBJ_PROP: {
+			// Mirrors shadows.cpp's OBJ_RAW_POF/OBJ_PROP case: same shape as
+			// OBJ_SHIP (a polymodel + optional polymodel_instance), just
+			// resolved generically instead of via ship_info/Ships[].
+			int model_num = object_get_model_num(objp);
+			polymodel* pm = model_get(model_num);
+			if (pm == nullptr || pm->detail[0] < 0) {
+				continue;
+			}
+
+			int instance_num = object_get_model_instance_num(objp);
+			polymodel_instance* pmi = instance_num < 0 ? nullptr : model_get_instance(instance_num);
+
+			transform_stack stack;
+			stack.push(&objp->pos, &objp->orient);
+			walkSubmodelTree(instances, stack, pm, pmi, pm->detail[0]);
+			break;
+		}
 		default:
 			break;
 		}
 	}
+}
+
+void VulkanRaytracingManager::gatherCockpitShadowCasterInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances)
+{
+	object* objp = Viewer_obj;
+	if (objp == nullptr || objp->type != OBJ_SHIP || objp->instance < 0) {
+		return;
+	}
+
+	ship* shipp = &Ships[objp->instance];
+	ship_info* sip = &Ship_info[shipp->ship_info_index];
+
+	// Mirrors the renderCockpitModel computation in ship_render_player_ship()/
+	// render_viewer_shadow() (ship.cpp/shadows.cpp) -- kept as a fourth inline
+	// copy for consistency with those two, rather than factoring out a shared
+	// helper neither of them uses today.
+	const bool renderCockpitModel =
+		(Viewer_mode != VM_TOPDOWN) && sip->cockpit_model_num >= 0 && !Disable_cockpits;
+	if (!renderCockpitModel || Shadow_disable_overrides.disable_cockpit) {
+		return; // matches shadows.cpp:787's gate on the rasterized cockpit shadow pass
+	}
+
+	polymodel* cockpit_pm = model_get(sip->cockpit_model_num);
+	if (cockpit_pm == nullptr || cockpit_pm->detail[0] < 0) {
+		return;
+	}
+	polymodel_instance* cockpit_pmi =
+		shipp->cockpit_model_instance < 0 ? nullptr : model_get_instance(shipp->cockpit_model_instance);
+
+	// World-space anchor for the cockpit model. This is deliberately NOT the
+	// eye-relative offset ship_render_player_ship() passes to
+	// model_render_immediate() (ship.cpp, `cockpit_offset` unrotated but never
+	// combined with objp->pos) -- that's a camera-relative rendering convenience
+	// specific to the rasterized forward-draw call. The TLAS is a persistent
+	// world-space structure (gatherShadowCasterInstances' OBJ_SHIP case anchors
+	// at true objp->pos/objp->orient, same as here), so the cockpit instance must
+	// be anchored the same way. Direction of vm_vec_unrotate (local -> world) is
+	// the same convention used to turn ship-local points into world positions
+	// elsewhere (e.g. gun firing points, ship.cpp).
+	vec3d rotated_offset;
+	vm_vec_unrotate(&rotated_offset, &sip->cockpit_offset, &objp->orient);
+	vec3d cockpit_world_pos = objp->pos;
+	vm_vec_add2(&cockpit_world_pos, &rotated_offset);
+
+	transform_stack stack;
+	stack.push(&cockpit_world_pos, &objp->orient);
+	walkSubmodelTree(instances, stack, cockpit_pm, cockpit_pmi, cockpit_pm->detail[0], /* mask */ 0xFF, /* skipDetailBoxCheck */ true);
 }
 
 bool VulkanRaytracingManager::ensureInstanceCapacity(FrameTlasResources& frame, vk::DeviceSize requiredBytes)
@@ -364,6 +448,7 @@ void VulkanRaytracingManager::buildTlas()
 
 	SCP_vector<vk::AccelerationStructureInstanceKHR> instances;
 	gatherShadowCasterInstances(instances);
+	gatherCockpitShadowCasterInstance(instances);
 
 	if (instances.empty()) {
 		return; // keep whatever TLAS (if any) was built last time this slot was used

--- a/code/graphics/vulkan/VulkanRaytracingTlas.cpp
+++ b/code/graphics/vulkan/VulkanRaytracingTlas.cpp
@@ -16,6 +16,7 @@
 #include "asteroid/asteroid.h"
 #include "debris/debris.h"
 #include "globalincs/systemvars.h"
+#include "graphics/shadows.h"
 #include "mod_table/mod_table.h"
 #include "model/model.h"
 #include "model/modelrender.h"
@@ -194,16 +195,11 @@ void VulkanRaytracingManager::gatherShadowCasterInstances(SCP_vector<vk::Acceler
 				continue;
 			}
 
-			// The viewer's own hull is tagged with a dedicated mask bit (0x80,
-			// nothing else set) rather than the default 0xFF: it needs to be
-			// selectively excludable by shadow rays traced from the cockpit's
-			// own shading pass (see traceShadowRay()/shadows.sdr and
-			// VulkanPostProcessingLighting.cpp), matching the rasterized
-			// path's unconditional exclusion of Viewer_obj from the main
-			// shadow cascades (shadows.cpp) while still letting every other
-			// ray (default 0xFF cull mask) see it, since it's still really
-			// there.
-			uint8_t instanceMask = (objp == Viewer_obj) ? 0x80 : 0xFF;
+			// The viewer's own hull is tagged with TLAS_MASK_VIEWER_HULL instead of the
+			// default 0xFF so shadow rays can selectively exclude it -- see that
+			// constant's declaration (shadows.h) for how the two ends of this scheme
+			// meet.
+			uint8_t instanceMask = (objp == Viewer_obj) ? TLAS_MASK_VIEWER_HULL : 0xFF;
 
 			transform_stack stack;
 			stack.push(&objp->pos, &objp->orient);
@@ -277,14 +273,8 @@ void VulkanRaytracingManager::gatherCockpitShadowCasterInstance(SCP_vector<vk::A
 	ship* shipp = &Ships[objp->instance];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
-	// Mirrors the renderCockpitModel computation in ship_render_player_ship()/
-	// render_viewer_shadow() (ship.cpp/shadows.cpp) -- kept as a fourth inline
-	// copy for consistency with those two, rather than factoring out a shared
-	// helper neither of them uses today.
-	const bool renderCockpitModel =
-		(Viewer_mode != VM_TOPDOWN) && sip->cockpit_model_num >= 0 && !Disable_cockpits;
-	if (!renderCockpitModel || Shadow_disable_overrides.disable_cockpit) {
-		return; // matches shadows.cpp:787's gate on the rasterized cockpit shadow pass
+	if (!ship_player_cockpit_model_would_render(sip) || Shadow_disable_overrides.disable_cockpit) {
+		return; // matches render_viewer_shadow()'s gate on the rasterized cockpit shadow pass (shadows.cpp)
 	}
 
 	polymodel* cockpit_pm = model_get(sip->cockpit_model_num);

--- a/code/graphics/vulkan/VulkanRaytracingTlas.cpp
+++ b/code/graphics/vulkan/VulkanRaytracingTlas.cpp
@@ -1,5 +1,6 @@
 // Per-frame TLAS: gathers the current shadow-casting object set (ships,
-// asteroids, debris) into one top-level acceleration structure each frame.
+// asteroids, debris, raw POFs/props) into one top-level acceleration
+// structure each frame.
 // Split out from VulkanRaytracing.cpp since this is the only part of the
 // raytracing manager that reaches into Ships/Asteroids/Debris/Objects, a
 // distinctly different dependency set from the BLAS cache in
@@ -14,6 +15,9 @@
 
 #include "asteroid/asteroid.h"
 #include "debris/debris.h"
+#include "globalincs/systemvars.h"
+#include "graphics/shadows.h"
+#include "mod_table/mod_table.h"
 #include "model/model.h"
 #include "model/modelrender.h"
 #include "object/object.h"
@@ -40,12 +44,13 @@ static bool submodelPassesDetailBox(const polymodel* pm, int submodel_num, const
 void VulkanRaytracingManager::pushInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 	vk::DeviceAddress blasAddress,
 	const matrix& orient,
-	const vec3d& pos)
+	const vec3d& pos,
+	uint8_t mask)
 {
 	vk::AccelerationStructureInstanceKHR instance;
 	instance.transform = toVkTransform(orient, pos);
 	instance.instanceCustomIndex = 0;
-	instance.mask = 0xFF;
+	instance.mask = mask;
 	instance.instanceShaderBindingTableRecordOffset = 0;
 	instance.flags = static_cast<VkGeometryInstanceFlagsKHR>(vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable);
 	instance.accelerationStructureReference = blasAddress;
@@ -57,7 +62,8 @@ void VulkanRaytracingManager::addSingleSubmodelInstance(SCP_vector<vk::Accelerat
 	const polymodel_instance* pmi,
 	int submodel_num,
 	const matrix& orient,
-	const vec3d& pos)
+	const vec3d& pos,
+	uint8_t mask)
 {
 	if (submodel_num < 0 || submodel_num >= pm->n_models) {
 		return;
@@ -80,14 +86,16 @@ void VulkanRaytracingManager::addSingleSubmodelInstance(SCP_vector<vk::Accelerat
 		return;
 	}
 
-	pushInstance(instances, entry->address, orient, pos);
+	pushInstance(instances, entry->address, orient, pos, mask);
 }
 
 void VulkanRaytracingManager::walkSubmodelTree(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances,
 	transform_stack& stack,
 	const polymodel* pm,
 	const polymodel_instance* pmi,
-	int submodel_num)
+	int submodel_num,
+	uint8_t mask,
+	bool skipDetailBoxCheck)
 {
 	if (submodel_num < 0 || submodel_num >= pm->n_models) {
 		return;
@@ -135,19 +143,19 @@ void VulkanRaytracingManager::walkSubmodelTree(SCP_vector<vk::AccelerationStruct
 	// producing self-shadowing flicker that only stabilized once the camera cleared the
 	// model's detail-box distance. A failing check also skips this submodel's whole
 	// subtree, exactly like the rasterized path (a culled parent hides its children too).
-	if (!submodelPassesDetailBox(pm, submodel_num, world_orient, world_pos)) {
+	if (!skipDetailBoxCheck && !submodelPassesDetailBox(pm, submodel_num, world_orient, world_pos)) {
 		stack.pop();
 		return;
 	}
 
 	const BlasEntry* entry = getOrBuildBlasEntry(pm->id, submodel_num);
 	if (entry != nullptr) {
-		pushInstance(instances, entry->address, world_orient, world_pos);
+		pushInstance(instances, entry->address, world_orient, world_pos, mask);
 	}
 
 	for (int child = sm.first_child; child >= 0; child = pm->submodel[child].next_sibling) {
 		if (!pm->submodel[child].flags[Model::Submodel_flags::Is_thruster]) {
-			walkSubmodelTree(instances, stack, pm, pmi, child);
+			walkSubmodelTree(instances, stack, pm, pmi, child, mask, skipDetailBoxCheck);
 		}
 	}
 
@@ -157,7 +165,7 @@ void VulkanRaytracingManager::walkSubmodelTree(SCP_vector<vk::AccelerationStruct
 void VulkanRaytracingManager::gatherShadowCasterInstances(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances)
 {
 	// Mirrors the object selection in shadows_render_all() (shadows.cpp) --
-	// ships/asteroids/debris -- but without its per-cascade frustum
+	// ships/asteroids/debris/raw POFs/props -- but without its per-cascade frustum
 	// pre-filter, which lives in shadows.cpp's private state (Shadow_frustums)
 	// and is specific to the rasterized cascade layout. Starting unfiltered is
 	// simpler and safe (never wrongly excludes a caster); spatial culling of
@@ -187,9 +195,15 @@ void VulkanRaytracingManager::gatherShadowCasterInstances(SCP_vector<vk::Acceler
 				continue;
 			}
 
+			// The viewer's own hull is tagged with TLAS_MASK_VIEWER_HULL instead of the
+			// default 0xFF so shadow rays can selectively exclude it -- see that
+			// constant's declaration (shadows.h) for how the two ends of this scheme
+			// meet.
+			uint8_t instanceMask = (objp == Viewer_obj) ? TLAS_MASK_VIEWER_HULL : 0xFF;
+
 			transform_stack stack;
 			stack.push(&objp->pos, &objp->orient);
-			walkSubmodelTree(instances, stack, pm, pmi, pm->detail[0]);
+			walkSubmodelTree(instances, stack, pm, pmi, pm->detail[0], instanceMask);
 			break;
 		}
 		case OBJ_ASTEROID: {
@@ -224,10 +238,66 @@ void VulkanRaytracingManager::gatherShadowCasterInstances(SCP_vector<vk::Acceler
 			addSingleSubmodelInstance(instances, pm, pmi, db.submodel_num, objp->orient, objp->pos);
 			break;
 		}
+		case OBJ_RAW_POF:
+		case OBJ_PROP: {
+			// Mirrors shadows.cpp's OBJ_RAW_POF/OBJ_PROP case: same shape as
+			// OBJ_SHIP (a polymodel + optional polymodel_instance), just
+			// resolved generically instead of via ship_info/Ships[].
+			int model_num = object_get_model_num(objp);
+			polymodel* pm = model_get(model_num);
+			if (pm == nullptr || pm->detail[0] < 0) {
+				continue;
+			}
+
+			int instance_num = object_get_model_instance_num(objp);
+			polymodel_instance* pmi = instance_num < 0 ? nullptr : model_get_instance(instance_num);
+
+			transform_stack stack;
+			stack.push(&objp->pos, &objp->orient);
+			walkSubmodelTree(instances, stack, pm, pmi, pm->detail[0]);
+			break;
+		}
 		default:
 			break;
 		}
 	}
+}
+
+void VulkanRaytracingManager::gatherCockpitShadowCasterInstance(SCP_vector<vk::AccelerationStructureInstanceKHR>& instances)
+{
+	object* objp = Viewer_obj;
+	if (objp == nullptr || objp->type != OBJ_SHIP || objp->instance < 0) {
+		return;
+	}
+
+	ship* shipp = &Ships[objp->instance];
+	ship_info* sip = &Ship_info[shipp->ship_info_index];
+
+	if (!ship_player_cockpit_model_would_render(sip) || Shadow_disable_overrides.disable_cockpit) {
+		return; // matches render_viewer_shadow()'s gate on the rasterized cockpit shadow pass (shadows.cpp)
+	}
+
+	polymodel* cockpit_pm = model_get(sip->cockpit_model_num);
+	if (cockpit_pm == nullptr || cockpit_pm->detail[0] < 0) {
+		return;
+	}
+	polymodel_instance* cockpit_pmi =
+		shipp->cockpit_model_instance < 0 ? nullptr : model_get_instance(shipp->cockpit_model_instance);
+
+	// World-space anchor for the cockpit model. ship_cockpit_render_offset() (ship.h)
+	// gives the same rotated+swayed offset ship_render_player_ship() draws the cockpit
+	// with, but that offset is camera-relative there (never combined with objp->pos) --
+	// a rendering convenience specific to the rasterized forward-draw call. The TLAS is
+	// a persistent world-space structure (gatherShadowCasterInstances' OBJ_SHIP case
+	// anchors at true objp->pos/objp->orient, same as here), so adding it onto objp->pos
+	// here is what anchors the cockpit instance the same way.
+	vec3d cockpit_render_offset = ship_cockpit_render_offset(sip, objp);
+	vec3d cockpit_world_pos = objp->pos;
+	vm_vec_add2(&cockpit_world_pos, &cockpit_render_offset);
+
+	transform_stack stack;
+	stack.push(&cockpit_world_pos, &objp->orient);
+	walkSubmodelTree(instances, stack, cockpit_pm, cockpit_pmi, cockpit_pm->detail[0], /* mask */ 0xFF, /* skipDetailBoxCheck */ true);
 }
 
 bool VulkanRaytracingManager::ensureInstanceCapacity(FrameTlasResources& frame, vk::DeviceSize requiredBytes)
@@ -364,6 +434,7 @@ void VulkanRaytracingManager::buildTlas()
 
 	SCP_vector<vk::AccelerationStructureInstanceKHR> instances;
 	gatherShadowCasterInstances(instances);
+	gatherCockpitShadowCasterInstance(instances);
 
 	if (instances.empty()) {
 		return; // keep whatever TLAS (if any) was built last time this slot was used

--- a/code/graphics/vulkan/VulkanRaytracingTlas.cpp
+++ b/code/graphics/vulkan/VulkanRaytracingTlas.cpp
@@ -306,6 +306,14 @@ void VulkanRaytracingManager::gatherCockpitShadowCasterInstance(SCP_vector<vk::A
 	// elsewhere (e.g. gun firing points, ship.cpp).
 	vec3d rotated_offset;
 	vm_vec_unrotate(&rotated_offset, &sip->cockpit_offset, &objp->orient);
+	// Matches ship.cpp's sway addition (ship_render_player_ship()) so the TLAS
+	// proxy tracks the same per-frame jitter as the rendered cockpit geometry;
+	// otherwise the two drift apart by up to cockpit_sway_val * acceleration.
+	if (!Disable_cockpit_sway) {
+		vec3d sway_offset;
+		vm_vec_copy_scale(&sway_offset, &objp->phys_info.acceleration, sip->cockpit_sway_val);
+		vm_vec_add2(&rotated_offset, &sway_offset);
+	}
 	vec3d cockpit_world_pos = objp->pos;
 	vm_vec_add2(&cockpit_world_pos, &rotated_offset);
 

--- a/code/graphics/vulkan/VulkanRenderer.h
+++ b/code/graphics/vulkan/VulkanRenderer.h
@@ -246,6 +246,24 @@ class VulkanRenderer {
 	void copySceneDepthForParticles();
 
 	/**
+	 * @brief Park the scene depth so the cockpit can render on a cleared depth buffer
+	 *
+	 * Called by vulkan_post_process_save_zbuffer(). Ends the current scene render
+	 * pass, copies scene depth → backup image, then resumes the pass with
+	 * loadOp=eLoad. The caller clears the depth buffer afterwards. No-op when a
+	 * save is already outstanding, or outside scene rendering.
+	 */
+	void saveSceneDepth();
+
+	/**
+	 * @brief Put the parked scene depth back, discarding what the cockpit wrote
+	 *
+	 * Called by vulkan_post_process_restore_zbuffer(). No-op unless saveSceneDepth()
+	 * parked something.
+	 */
+	void restoreSceneDepth();
+
+	/**
 	 * @brief Check if scene depth copy is available for sampling this frame
 	 */
 	bool isSceneDepthCopied() const { return m_sceneDepthCopiedThisFrame; }
@@ -335,6 +353,12 @@ class VulkanRenderer {
 	 * after a mid-scene copy (copyEffectTexture / copySceneDepthForParticles)
 	 */
 	void resumeScenePassAfterCopy();
+
+	/**
+	 * @brief Restore the color attachment layouts a depth-only copy left behind,
+	 * then resume the scene (or G-buffer) render pass
+	 */
+	void resumeScenePassAfterDepthCopy();
 
 	bool initDisplayDevice() const;
 
@@ -473,6 +497,7 @@ class VulkanRenderer {
 	std::unique_ptr<VulkanPostProcessor> m_postProcessor;
 	bool m_sceneRendering = false;
 	bool m_sceneDepthCopiedThisFrame = false;
+	bool m_sceneDepthSaved = false;    // True between saveSceneDepth() and restoreSceneDepth()
 	bool m_useGbufRenderPass = false;  // True when scene uses G-buffer (deferred lighting)
 
 	bool m_supportsShaderViewportLayerOutput = false;  // VK_EXT_shader_viewport_index_layer

--- a/code/graphics/vulkan/VulkanRendererLoop.cpp
+++ b/code/graphics/vulkan/VulkanRendererLoop.cpp
@@ -139,6 +139,7 @@ void VulkanRenderer::setupFrame()
 
 	// Reset per-frame flags
 	m_sceneDepthCopiedThisFrame = false;
+	m_sceneDepthSaved = false;
 
 	// Reset per-frame draw statistics
 	Assertion(m_drawManager, "Vulkan DrawManager not initialized in setupFrame!");
@@ -431,9 +432,18 @@ void VulkanRenderer::copySceneDepthForParticles()
 	// Copy scene depth → samplable depth copy (handles all depth image transitions)
 	m_postProcessor->copySceneDepth(m_currentCommandBuffer);
 
+	resumeScenePassAfterDepthCopy();
+
+	m_sceneDepthCopiedThisFrame = true;
+}
+
+// Shared tail of every mid-scene copy that touches only depth: put the color
+// attachments back the way the resumed loadOp=eLoad pass expects them, then resume.
+void VulkanRenderer::resumeScenePassAfterDepthCopy()
+{
 	// Transition scene color: eShaderReadOnlyOptimal → eColorAttachmentOptimal
 	// (needed for the resumed render pass with loadOp=eLoad, which expects
-	// initialLayout=eColorAttachmentOptimal; copySceneDepth only touches depth)
+	// initialLayout=eColorAttachmentOptimal; a depth copy only touches depth)
 	{
 		ImageBarrier2 barrier;
 		barrier.image = m_postProcessor->getSceneColorImage();
@@ -460,8 +470,64 @@ void VulkanRenderer::copySceneDepthForParticles()
 
 	// Resume the scene render pass with loadOp=eLoad
 	resumeScenePassAfterCopy();
+}
 
-	m_sceneDepthCopiedThisFrame = true;
+// The cockpit model is rendered around the camera, inside the ship hull that the scene
+// pass already drew, so it needs a depth buffer that does not know about that hull --
+// otherwise the hull wins the depth test and shows through the cockpit. OpenGL swaps
+// the depth attachment to Cockpit_depth_texture for the duration; Vulkan bakes the
+// attachment into the framebuffer, so the scene depth is copied aside and cleared
+// instead. Only the scene depth image is parked: with MSAA the cockpit renders against
+// the multisampled depth, which the G-buffer pass clears on its own, and
+// gr_deferred_lighting_msaa() resolves back into the scene depth before restore runs.
+void VulkanRenderer::saveSceneDepth()
+{
+	if (m_sceneDepthSaved || !m_sceneRendering || !m_postProcessor || !m_postProcessor->isInitialized()) {
+		return;
+	}
+
+	// resumeScenePassAfterCopy() knows the scene pass and the non-MSAA G-buffer pass only.
+	// Both callers (ship_render_player_ship) run between one deferred pass and the next, so
+	// the multisampled G-buffer pass is never the live one -- resuming the wrong pass would
+	// desync the state tracker and build pipelines against it, so catch a future move here.
+	Assertion(m_stateTracker->getCurrentSampleCount() == vk::SampleCountFlagBits::e1,
+		"Tried to park the scene depth while a multisampled render pass was active!");
+
+	// End the current scene render pass
+	// This transitions: color → eShaderReadOnlyOptimal, depth → eDepthStencilAttachmentOptimal
+	// For G-buffer: all 6 color attachments → eShaderReadOnlyOptimal
+	m_currentCommandBuffer.endRenderPass();
+
+	m_postProcessor->saveSceneDepth(m_currentCommandBuffer);
+
+	resumeScenePassAfterDepthCopy();
+
+	m_sceneDepthSaved = true;
+}
+
+void VulkanRenderer::restoreSceneDepth()
+{
+	if (!m_sceneDepthSaved) {
+		return;
+	}
+
+	// Cleared first: a scene that ends between the save and the restore (a failed
+	// resize dropping the post-processor, say) must not leave the flag set for the
+	// next frame's restore to act on stale content.
+	m_sceneDepthSaved = false;
+
+	if (!m_sceneRendering || !m_postProcessor || !m_postProcessor->isInitialized()) {
+		return;
+	}
+
+	Assertion(m_stateTracker->getCurrentSampleCount() == vk::SampleCountFlagBits::e1,
+		"Tried to put the scene depth back while a multisampled render pass was active!");
+
+	m_currentCommandBuffer.endRenderPass();
+
+	m_postProcessor->restoreSceneDepth(m_currentCommandBuffer);
+
+	resumeScenePassAfterDepthCopy();
 }
 
 void VulkanRenderer::beginRenderTarget(tcache_slot_vulkan* ts, int face)

--- a/code/graphics/vulkan/VulkanRendererSetup.cpp
+++ b/code/graphics/vulkan/VulkanRendererSetup.cpp
@@ -1190,6 +1190,7 @@ bool VulkanRenderer::recreateSwapChain()
 		m_drawManager->onResize();
 	}
 	m_sceneDepthCopiedThisFrame = false;
+	m_sceneDepthSaved = false;
 
 	// Update VulkanRenderFrame handles to point to the new swap chain, and
 	// recreate their semaphores: an acquire that succeeded against the old swap

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -371,7 +371,7 @@ void obj_render_queue_all()
 	scene.init_render();
 
 	if (Shadow_quality != ShadowQuality::Disabled) {
-		shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades);
+		shadow_cascade_params_bind(Num_cockpit_shadow_cascades, Num_shadow_cascades, vmd_zero_vector);
 	}
 
 	scene.render_all(ZBUFFER_TYPE_FULL);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8112,6 +8112,10 @@ static bool ship_render_player_renderShipModel(const ship_info* sip) {
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK) || !(Viewer_mode & VM_EXTERNAL));
 }
 
+bool ship_player_cockpit_model_would_render(const ship_info* sip) {
+	return (Viewer_mode != VM_TOPDOWN) && sip->cockpit_model_num >= 0 && !Disable_cockpits;
+}
+
 bool ship_render_player_ship_casts_shadow_on_cockpit() {
 	if (Viewer_obj == nullptr)
 		return false;
@@ -8139,9 +8143,7 @@ bool ship_render_player_has_closeup_visuals() {
 	ship* shipp = &Ships[Viewer_obj->instance];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
-	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
-
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
+	const bool renderCockpitModel = ship_player_cockpit_model_would_render(sip);
 	const bool renderShipModel = ship_render_player_renderShipModel(sip);
 
 	return renderCockpitModel || renderShipModel;
@@ -8154,7 +8156,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 
 	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
 
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
+	const bool renderCockpitModel = ship_player_cockpit_model_would_render(sip);
 	const bool renderShipModel = ship_render_player_renderShipModel(sip);
 	Cockpit_active = renderCockpitModel;
 
@@ -8254,23 +8256,32 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		cockpit_shadow_rendering_active = true;
 	}
 
-	// This pass draws two different objects (hull, cockpit) in two different
-	// internal frames -- see the two model_render_immediate() calls below --
-	// so each needs its own RT shadow-ray world-space correction; a single
-	// shadow_cascade_params_bind() call can't serve both. Derivations:
-	//
-	// Hull draw uses &eye_offset as its position arg (eye-relative frame), so
-	// reconstructed + (objp->pos - eye_offset) lands in the same true-world
-	// space the shadow TLAS is built in.
-	//
-	// Cockpit draw uses &cockpit_offset (rotate(sip->cockpit_offset) + sway,
-	// origin-relative frame -- see below), so reconstructed + objp->pos lands
-	// there instead. See shadow_cascade_static_data::shadow_ray_world_offset
-	// (uniform_structs.h) for the full derivation.
+	// Hull and cockpit render in different internal frames (see the &eye_offset vs.
+	// &cockpit_offset draws below), so each needs its own RT shadow-ray world-space
+	// correction -- see shadow_cascade_static_data::shadow_ray_world_offset
+	// (uniform_structs.h) for the derivation.
 	vec3d hull_shadow_ray_world_offset;
 	vm_vec_sub(&hull_shadow_ray_world_offset, &objp->pos, &eye_offset);
 	const vec3d& cockpit_shadow_ray_world_offset = objp->pos;
 	const bool cockpit_shadow_allows_hull_self_shadow = ship_render_player_ship_casts_shadow_on_cockpit();
+
+	model_render_params ship_render_info;
+	model_render_params cockpit_render_info;
+	vec3d cockpit_offset = sip->cockpit_offset;
+
+	auto renderHull = [&](int render_pass) {
+		if (cockpit_shadow_rendering_active) {
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, hull_shadow_ray_world_offset);
+		}
+		model_render_immediate(&ship_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset, render_pass);
+	};
+	auto renderCockpit = [&](int render_pass) {
+		if (cockpit_shadow_rendering_active) {
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, cockpit_shadow_ray_world_offset,
+				cockpit_shadow_allows_hull_self_shadow);
+		}
+		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, render_pass);
+	};
 
 	if (light_deferredcockpit_enabled()) {
 		gr_deferred_lighting_begin(true);
@@ -8288,10 +8299,6 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		render_flags |= MR_NO_GLOWMAPS;
 	}
 
-	model_render_params ship_render_info;
-	model_render_params cockpit_render_info;
-	vec3d cockpit_offset = sip->cockpit_offset;
-
 	//Properly render ship and cockpit model
 	if (deferredRenderShipModel) {
 		ship_render_info.set_detail_level_lock(0);
@@ -8301,10 +8308,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		if (sip->uses_team_colors)
 			ship_render_info.set_team_color(shipp->team_name, shipp->secondary_team_name, 0, 0);
 
-		if (cockpit_shadow_rendering_active) {
-			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, hull_shadow_ray_world_offset);
-		}
-		model_render_immediate(&ship_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset, MODEL_RENDER_OPAQUE);
+		renderHull(MODEL_RENDER_OPAQUE);
 		gr_zbuffer_clear(true);
 	}
 	if (renderCockpitModel) {
@@ -8314,11 +8318,8 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		vm_vec_unrotate(&cockpit_offset, &cockpit_offset, &objp->orient);
 		if (!Disable_cockpit_sway)
 			cockpit_offset += sip->cockpit_sway_val * objp->phys_info.acceleration;
-		if (cockpit_shadow_rendering_active) {
-			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, cockpit_shadow_ray_world_offset,
-				cockpit_shadow_allows_hull_self_shadow);
-		}
-		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, MODEL_RENDER_OPAQUE);
+
+		renderCockpit(MODEL_RENDER_OPAQUE);
 	}
 
 	if (light_deferredcockpit_enabled()) {
@@ -8346,18 +8347,11 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	gr_zbuffer_set(ZBUFFER_TYPE_READ);
 
 	if (deferredRenderShipModel) {
-		if (cockpit_shadow_rendering_active) {
-			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, hull_shadow_ray_world_offset);
-		}
-		model_render_immediate(&ship_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset, MODEL_RENDER_TRANS);
+		renderHull(MODEL_RENDER_TRANS);
 	}
 
 	if (renderCockpitModel) {
-		if (cockpit_shadow_rendering_active) {
-			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, cockpit_shadow_ray_world_offset,
-				cockpit_shadow_allows_hull_self_shadow);
-		}
-		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, MODEL_RENDER_TRANS);
+		renderCockpit(MODEL_RENDER_TRANS);
 	}
 
 	if (light_deferredcockpit_enabled()) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8245,13 +8245,32 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	Shadow_view_matrix_render = gr_view_matrix;
 
 	matrix4 shadow_view_light_backup = Shadow_view_matrix_light;
+	bool cockpit_shadow_rendering_active = false;
 	if (shadow_maybe_start_frame(Shadow_disable_overrides.disable_cockpit)) {
 		Shadow_override = false;
 		Shadow_view_matrix_light.a1d[12] = 0;
 		Shadow_view_matrix_light.a1d[13] = 0;
 		Shadow_view_matrix_light.a1d[14] = 0;
-		shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades);
+		cockpit_shadow_rendering_active = true;
 	}
+
+	// This pass draws two different objects (hull, cockpit) in two different
+	// internal frames -- see the two model_render_immediate() calls below --
+	// so each needs its own RT shadow-ray world-space correction; a single
+	// shadow_cascade_params_bind() call can't serve both. Derivations:
+	//
+	// Hull draw uses &eye_offset as its position arg (eye-relative frame), so
+	// reconstructed + (objp->pos - eye_offset) lands in the same true-world
+	// space the shadow TLAS is built in.
+	//
+	// Cockpit draw uses &cockpit_offset (rotate(sip->cockpit_offset) + sway,
+	// origin-relative frame -- see below), so reconstructed + objp->pos lands
+	// there instead. See shadow_cascade_static_data::shadow_ray_world_offset
+	// (uniform_structs.h) for the full derivation.
+	vec3d hull_shadow_ray_world_offset;
+	vm_vec_sub(&hull_shadow_ray_world_offset, &objp->pos, &eye_offset);
+	const vec3d& cockpit_shadow_ray_world_offset = objp->pos;
+	const bool cockpit_shadow_allows_hull_self_shadow = ship_render_player_ship_casts_shadow_on_cockpit();
 
 	if (light_deferredcockpit_enabled()) {
 		gr_deferred_lighting_begin(true);
@@ -8282,6 +8301,9 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		if (sip->uses_team_colors)
 			ship_render_info.set_team_color(shipp->team_name, shipp->secondary_team_name, 0, 0);
 
+		if (cockpit_shadow_rendering_active) {
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, hull_shadow_ray_world_offset);
+		}
 		model_render_immediate(&ship_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset, MODEL_RENDER_OPAQUE);
 		gr_zbuffer_clear(true);
 	}
@@ -8292,6 +8314,10 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		vm_vec_unrotate(&cockpit_offset, &cockpit_offset, &objp->orient);
 		if (!Disable_cockpit_sway)
 			cockpit_offset += sip->cockpit_sway_val * objp->phys_info.acceleration;
+		if (cockpit_shadow_rendering_active) {
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, cockpit_shadow_ray_world_offset,
+				cockpit_shadow_allows_hull_self_shadow);
+		}
 		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, MODEL_RENDER_OPAQUE);
 	}
 
@@ -8320,10 +8346,17 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	gr_zbuffer_set(ZBUFFER_TYPE_READ);
 
 	if (deferredRenderShipModel) {
+		if (cockpit_shadow_rendering_active) {
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, hull_shadow_ray_world_offset);
+		}
 		model_render_immediate(&ship_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset, MODEL_RENDER_TRANS);
 	}
 
 	if (renderCockpitModel) {
+		if (cockpit_shadow_rendering_active) {
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, cockpit_shadow_ray_world_offset,
+				cockpit_shadow_allows_hull_self_shadow);
+		}
 		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, MODEL_RENDER_TRANS);
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8119,6 +8119,19 @@ static bool ship_render_player_renderShipModel(const ship_info* sip) {
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK) || !(Viewer_mode & VM_EXTERNAL));
 }
 
+bool ship_player_cockpit_model_would_render(const ship_info* sip) {
+	return (Viewer_mode != VM_TOPDOWN) && sip->cockpit_model_num >= 0 && !Disable_cockpits;
+}
+
+vec3d ship_cockpit_render_offset(const ship_info* sip, const object* objp) {
+	vec3d offset;
+	vm_vec_unrotate(&offset, &sip->cockpit_offset, &objp->orient);
+	if (!Disable_cockpit_sway) {
+		offset += sip->cockpit_sway_val * objp->phys_info.acceleration;
+	}
+	return offset;
+}
+
 bool ship_render_player_ship_casts_shadow_on_cockpit() {
 	if (Viewer_obj == nullptr)
 		return false;
@@ -8146,9 +8159,7 @@ bool ship_render_player_has_closeup_visuals() {
 	ship* shipp = &Ships[Viewer_obj->instance];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
-	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
-
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
+	const bool renderCockpitModel = ship_player_cockpit_model_would_render(sip);
 	const bool renderShipModel = ship_render_player_renderShipModel(sip);
 
 	return renderCockpitModel || renderShipModel;
@@ -8161,7 +8172,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 
 	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
 
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
+	const bool renderCockpitModel = ship_player_cockpit_model_would_render(sip);
 	const bool renderShipModel = ship_render_player_renderShipModel(sip);
 	Cockpit_active = renderCockpitModel;
 
@@ -8252,13 +8263,41 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	Shadow_view_matrix_render = gr_view_matrix;
 
 	matrix4 shadow_view_light_backup = Shadow_view_matrix_light;
+	bool cockpit_shadow_rendering_active = false;
 	if (shadow_maybe_start_frame(Shadow_disable_overrides.disable_cockpit)) {
 		Shadow_override = false;
 		Shadow_view_matrix_light.a1d[12] = 0;
 		Shadow_view_matrix_light.a1d[13] = 0;
 		Shadow_view_matrix_light.a1d[14] = 0;
-		shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades);
+		cockpit_shadow_rendering_active = true;
 	}
+
+	// Hull and cockpit render in different internal frames (see the &eye_offset vs.
+	// &cockpit_offset draws below), so each needs its own RT shadow-ray world-space
+	// correction -- see shadow_cascade_static_data::shadow_ray_world_offset
+	// (uniform_structs.h) for the derivation.
+	vec3d hull_shadow_ray_world_offset;
+	vm_vec_sub(&hull_shadow_ray_world_offset, &objp->pos, &eye_offset);
+	const vec3d& cockpit_shadow_ray_world_offset = objp->pos;
+	const bool cockpit_shadow_allows_hull_self_shadow = ship_render_player_ship_casts_shadow_on_cockpit();
+
+	model_render_params ship_render_info;
+	model_render_params cockpit_render_info;
+	vec3d cockpit_offset = vmd_zero_vector;
+
+	auto renderHull = [&](int render_pass) {
+		if (cockpit_shadow_rendering_active) {
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, hull_shadow_ray_world_offset);
+		}
+		model_render_immediate(&ship_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset, render_pass);
+	};
+	auto renderCockpit = [&](int render_pass) {
+		if (cockpit_shadow_rendering_active) {
+			shadow_cascade_params_bind(0, Num_cockpit_shadow_cascades, cockpit_shadow_ray_world_offset,
+				cockpit_shadow_allows_hull_self_shadow);
+		}
+		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, render_pass);
+	};
 
 	if (light_deferredcockpit_enabled()) {
 		gr_deferred_lighting_begin(true);
@@ -8276,10 +8315,6 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		render_flags |= MR_NO_GLOWMAPS;
 	}
 
-	model_render_params ship_render_info;
-	model_render_params cockpit_render_info;
-	vec3d cockpit_offset = sip->cockpit_offset;
-
 	//Properly render ship and cockpit model
 	if (deferredRenderShipModel) {
 		ship_render_info.set_detail_level_lock(0);
@@ -8289,17 +8324,16 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		if (sip->uses_team_colors)
 			ship_render_info.set_team_color(shipp->team_name, shipp->secondary_team_name, 0, 0);
 
-		model_render_immediate(&ship_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset, MODEL_RENDER_OPAQUE);
+		renderHull(MODEL_RENDER_OPAQUE);
 		gr_zbuffer_clear(true);
 	}
 	if (renderCockpitModel) {
 		cockpit_render_info.set_detail_level_lock(0);
 		cockpit_render_info.set_flags(render_flags);
 		cockpit_render_info.set_replacement_textures(Player_cockpit_textures);
-		vm_vec_unrotate(&cockpit_offset, &cockpit_offset, &objp->orient);
-		if (!Disable_cockpit_sway)
-			cockpit_offset += sip->cockpit_sway_val * objp->phys_info.acceleration;
-		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, MODEL_RENDER_OPAQUE);
+		cockpit_offset = ship_cockpit_render_offset(sip, objp);
+
+		renderCockpit(MODEL_RENDER_OPAQUE);
 	}
 
 	if (light_deferredcockpit_enabled()) {
@@ -8327,11 +8361,11 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	gr_zbuffer_set(ZBUFFER_TYPE_READ);
 
 	if (deferredRenderShipModel) {
-		model_render_immediate(&ship_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset, MODEL_RENDER_TRANS);
+		renderHull(MODEL_RENDER_TRANS);
 	}
 
 	if (renderCockpitModel) {
-		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, MODEL_RENDER_TRANS);
+		renderCockpit(MODEL_RENDER_TRANS);
 	}
 
 	if (light_deferredcockpit_enabled()) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1778,6 +1778,12 @@ extern void ship_process_post( object * objp, float frametime );
 extern void ship_render( object * obj, model_draw_list * scene );
 extern bool ship_render_player_ship_casts_shadow_on_cockpit();
 extern bool ship_render_player_has_closeup_visuals();
+// True if the player ship's cockpit model would be rendered right now (viewer mode,
+// cockpit-model presence, and the Disable_cockpits override). Shared by every path that
+// needs to know whether a cockpit is currently on-screen: ship_render_player_ship(),
+// render_viewer_shadow() (shadows.cpp), and gatherCockpitShadowCasterInstance()
+// (VulkanRaytracingTlas.cpp).
+extern bool ship_player_cockpit_model_would_render(const ship_info* sip);
 extern void ship_render_player_ship( object * objp, const vec3d* offset = nullptr, const matrix* rot_offset = nullptr, const fov_t* fov_override = nullptr);
 extern void ship_delete( object * objp );
 extern int ship_check_collision_fast( object * obj, object * other_obj, vec3d * hitpos );

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1780,6 +1780,19 @@ extern void ship_process_post( object * objp, float frametime );
 extern void ship_render( object * obj, model_draw_list * scene );
 extern bool ship_render_player_ship_casts_shadow_on_cockpit();
 extern bool ship_render_player_has_closeup_visuals();
+// True if the player ship's cockpit model would be rendered right now (viewer mode,
+// cockpit-model presence, and the Disable_cockpits override). Shared by every path that
+// needs to know whether a cockpit is currently on-screen: ship_render_player_ship(),
+// render_viewer_shadow() (shadows.cpp), and gatherCockpitShadowCasterInstance()
+// (VulkanRaytracingTlas.cpp).
+extern bool ship_player_cockpit_model_would_render(const ship_info* sip);
+// The cockpit model's render offset: sip->cockpit_offset rotated into world orientation,
+// plus acceleration-driven sway (unless Disable_cockpit_sway). This is the camera-relative
+// offset used to draw the cockpit model, NOT combined with objp->pos -- callers that need
+// a world-space position must add objp->pos themselves. Shared by every path that draws or
+// otherwise anchors the cockpit model: ship_render_player_ship(), render_viewer_shadow()
+// (shadows.cpp), and gatherCockpitShadowCasterInstance() (VulkanRaytracingTlas.cpp).
+extern vec3d ship_cockpit_render_offset(const ship_info* sip, const object* objp);
 extern void ship_render_player_ship( object * objp, const vec3d* offset = nullptr, const matrix* rot_offset = nullptr, const fov_t* fov_override = nullptr);
 extern void ship_delete( object * objp );
 extern int ship_check_collision_fast( object * obj, object * other_obj, vec3d * hitpos );


### PR DESCRIPTION
## Summary

This branch fixes three problems with player cockpit rendering under Vulkan:

1. The ship hull could show through the cockpit model, because the two shared one depth buffer.
2. RT shadows on small objects shimmered when the viewer was far from the mission origin.

## Fix 1: RT shadows on cockpits

The shadow acceleration structure (TLAS) did not include the cockpit model. It also
did not include `OBJ_RAW_POF` and `OBJ_PROP` objects. The shadow ray for the cockpit
pass used the wrong ray origin. Together, these problems meant that cockpits did not
receive shadows.

Changes:

- Add the cockpit model to the TLAS gather (`gatherCockpitShadowCasterInstance()`). Add
  `OBJ_RAW_POF` and `OBJ_PROP` objects too. This matches the object set that the rasterized
  shadow path already uses. The gate is the new `shadows_cockpit_casts_shadow()`, which both paths share.
- Give each TLAS instance a ray-cull mask (`TLAS_MASK_*` in `shadows.h`). Tag the viewer's
  own ship hull with `TLAS_MASK_VIEWER_HULL`. Shadow rays exclude this bit outside the
  cockpit pass, so the hull does not shadow itself. During the cockpit pass,
  `ship_render_player_ship_casts_shadow_on_cockpit()` still lets the hull cast a shadow onto the cockpit.
- Add `shadow_ray_view_origin` and `shadow_ray_cull_mask` to the shadow uniform block
  (`shadow_cascade_static_data`, std140, 96 bytes, checked by a `static_assert`). The
  cockpit pass renders in a camera-relative frame, so the shader cannot rebuild the ray
  origin from `inv_view_matrix` alone. The shader now uses `mat3(inv_view) * viewPos + shadow_ray_view_origin`.
- Add `shadow_ray_params`. `shadow_cascade_params_bind()` takes it, so the hull draw and the
  cockpit draw in `ship_render_player_ship()` each bind their own ray origin and cull mask.
  The old two-argument overload stays for ordinary passes.
- Add `shadow_cascade_params_bind_deferred()`. This function removes duplicate
  cascade-selection code from the OpenGL and Vulkan deferred-lighting passes.
- Add `ship_cockpit_render_offset()`. This function computes the cockpit's rotated
  and swayed offset in one place. The render path, the rasterized shadow path, and
  the TLAS path all call it, so the three paths cannot drift apart.
- Update the cascade parameter buffer with a full `gr_update_buffer_data()` call. The bind
  now runs several times each frame with different content. The Vulkan streaming buffer
  bump-allocates fresh memory only for a full update, so the partial update overwrote data that was still in use.

## Fix 2: TLAS-relative coordinates

Float32 has about 1 mm steps at 10 km and about 8 mm at 100 km. Cockpit-scale RT shadows
shimmered far from the mission origin.

- Translate every TLAS instance by `-Shadow_rt_tlas_origin`. The TLAS build sets this
  origin to `Eye_position` once each frame. `shadow_rt_relative()` converts a world position.
- The CPU computes `shadow_ray_view_origin` from exact differences, so the shader never
  adds two large numbers.
- The detail-box check in the TLAS walk converts the eye position to the same frame.

## Fix 3: cockpit depth in Vulkan

OpenGL swaps the depth buffer before it draws the cockpit. The swap keeps the ship
hull's depth values away from the cockpit draw. The Vulkan backend did nothing in
`vulkan_post_process_save_zbuffer()` and `vulkan_post_process_restore_zbuffer()`, so
the hull could block the view of the cockpit.

- Add a backup depth image to `VulkanPostProcessor`.
- Add `saveSceneDepth()`. It copies the scene depth into the backup image. The save
  function then clears the live depth buffer for the cockpit draw, as OpenGL does.
- Add `restoreSceneDepth()`. It copies the backup image back after the cockpit draw, so
  later passes that read scene depth (for example lightshafts) see the scene depth.
- Split the mid-scene depth copy in `VulkanRenderer` into `endScenePassForDepthCopy()` and
  `resumeScenePassAfterDepthCopy()`. The new save and restore code shares them.
  With MSAA, only the scene depth image is parked. The G-buffer pass clears the multisampled
  depth, and the MSAA resolve writes back into the scene depth before the restore.

## Known gaps

- The deferred lighting pass shades the whole G-buffer in one draw call. The pass
  can apply only one ray origin per draw. This is correct for the common
  case. It is not correct when `Cockpit_shares_coordinate_space` is true, or when a
  ship has no cockpit model. This case needs a per-pixel offset, or the offset must
  move into the G-buffer data itself. This branch does not fix this case.
- The TLAS walk skips the detail-box check for the cockpit model. The rasterized path uses
  a cockpit-relative eye position. The TLAS walk does not compute this position.

## Testing

- `ninja code` and `ninja Freespace2` build with no errors.
- Confirmed in-game: player cockpit shadows now render correctly.
