### PR TITLE
Fix COMMS_MENU_SELECT control usage with 'Hide  Rearm/Repair items' and cleanup selection visibility

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -221,7 +221,7 @@ void hud_squadmsg_start()
 	Num_menu_items = -1;													// reset the menu items
 	First_menu_item = 0;
 	Selected_menu_item = First_menu_item;                            // make first menu item a selected object
-	Display_selector = false;
+	Display_selector = Always_show_selected_item_in_comms_gauge;
 
 	Squad_msg_mode = SM_MODE_TYPE_SELECT;							// start off at the base state
 	Msg_mode_timestamp = _timestamp(DEFAULT_MSG_TIMEOUT);		// initialize our timer to bogus value
@@ -495,27 +495,37 @@ void hud_squadmsg_selection_move_down() {
 	//Check if comms menu is up
 	if (Player->flags & PLAYER_FLAGS_MSG_MODE)
 	{
-		//move down
-		++Selected_menu_item;
 		Display_selector = true;
 
 		//play scrolling sound and reset the comms window timeout timer, so the window doesn't disappear while we select our item
 		gamesnd_play_iface(InterfaceSounds::SCROLL);
 		Msg_mode_timestamp = _timestamp(DEFAULT_MSG_TIMEOUT);
 
-		//Move to next page if we went outside of current one
-		if (Selected_menu_item == MAX_MENU_DISPLAY 
-			&& (First_menu_item + MAX_MENU_DISPLAY < Num_menu_items))
+		//move down, skipping over any hidden items (such as using Hide_main_rearm_items_in_comms_gauge). 
+		//bound it by the item count to ensure it does not loop forever.
+		for (int i = 0; i < Num_menu_items; i++)
 		{
-			hud_squadmsg_page_down();
-			Selected_menu_item = 0;
-		}
+			//move down
+			++Selected_menu_item;
 
-		//Select the first menu item if we went outside items range, so we can loop around
-		if (First_menu_item + Selected_menu_item >= Num_menu_items) 
-		{
-			First_menu_item = 0;
-			Selected_menu_item = First_menu_item;
+			//Move to next page if we went outside of current one
+			if (Selected_menu_item == MAX_MENU_DISPLAY
+				&& (First_menu_item + MAX_MENU_DISPLAY < Num_menu_items))
+			{
+				hud_squadmsg_page_down();
+				Selected_menu_item = 0;
+			}
+
+			//Select the first menu item if we went outside items range, so we can loop around
+			if (First_menu_item + Selected_menu_item >= Num_menu_items)
+			{
+				First_menu_item = 0;
+				Selected_menu_item = First_menu_item;
+			}
+
+			//stop once we land on a visible item
+			if (MsgItems[First_menu_item + Selected_menu_item].active >= 0)
+				break;
 		}
 	}
 }
@@ -525,29 +535,39 @@ void hud_squadmsg_selection_move_up() {
 	//Check if comms menu is up
 	if (Player->flags & PLAYER_FLAGS_MSG_MODE)
 	{
-		//move up
-		--Selected_menu_item;
 		Display_selector = true;
 
 		//play scrolling sound and reset the comms window timeout timer, so the window doesn't disappear while we select our item
 		gamesnd_play_iface(InterfaceSounds::SCROLL);
 		Msg_mode_timestamp = _timestamp(DEFAULT_MSG_TIMEOUT);
 
-		//Move to previous page if it exists
-		if (Selected_menu_item < 0 && First_menu_item > 0)
+		//move down, skipping over any hidden items (such as using Hide_main_rearm_items_in_comms_gauge).
+		//bound it by the item count to ensure it does not loop forever.
+		for (int i = 0; i < Num_menu_items; i++)
 		{
-			hud_squadmsg_page_up();
-			Selected_menu_item = MAX_MENU_DISPLAY - 1; //if we're moving to previous page in the first place, we assume it was already populated to the max
-		}
+			//move up
+			--Selected_menu_item;
 
-		//Select the last menu item if we went outside items range, so we can loop around
-		else if (Selected_menu_item < 0) 
-		{
-			//Assuming MAX_MENU_DISPLAY = 10, set First_menu_item to the nearest lower multiple of 10
-			//So if we have 85 items in comms menu, looping back from 1st page to last would set First_menu_item to 80
-			//exactly like pageUp/pageDown does
-			First_menu_item = ((Num_menu_items - 1) / MAX_MENU_DISPLAY) * MAX_MENU_DISPLAY;
-			Selected_menu_item = Num_menu_items - 1 - First_menu_item;
+			//Move to previous page if it exists
+			if (Selected_menu_item < 0 && First_menu_item > 0)
+			{
+				hud_squadmsg_page_up();
+				Selected_menu_item = MAX_MENU_DISPLAY - 1; //if we're moving to previous page in the first place, we assume it was already populated to the max
+			}
+
+			//Select the last menu item if we went outside items range, so we can loop around
+			else if (Selected_menu_item < 0)
+			{
+				//Assuming MAX_MENU_DISPLAY = 10, set First_menu_item to the nearest lower multiple of 10
+				//So if we have 85 items in comms menu, looping back from 1st page to last would set First_menu_item to 80
+				//exactly like pageUp/pageDown does
+				First_menu_item = ((Num_menu_items - 1) / MAX_MENU_DISPLAY) * MAX_MENU_DISPLAY;
+				Selected_menu_item = Num_menu_items - 1 - First_menu_item;
+			}
+
+			//stop once we land on a visible item
+			if (MsgItems[First_menu_item + Selected_menu_item].active >= 0)
+				break;
 		}
 	}
 }

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -496,8 +496,18 @@ void hud_squadmsg_selection_move( bool up ) {
 		//The selection moves +/-1 through the whole menu, wrapping around at either end.
 		//First_menu_item and Selected_menu_item are just the page and the offset within the page.
 		int num_items = sz2i(MsgItems.size());
+		int step = up ? -1 : 1;
 		int selected_index = First_menu_item + Selected_menu_item;
-		selected_index = (selected_index + (up ? -1 : 1) + num_items) % num_items;
+
+		//skip over any hidden items (such as when using Hide_main_rearm_items_in_comms_gauge).
+		//bound the search by the item count so a fully hidden menu does not loop forever.
+		for (int i = 0; i < num_items; i++) {
+			selected_index = (selected_index + step + num_items) % num_items;
+
+			//stop once we land on a visible item
+			if (MsgItems[selected_index].active >= 0)
+				break;
+		}
 
 		Selected_menu_item = selected_index % MAX_MENU_DISPLAY;
 		First_menu_item = selected_index - Selected_menu_item;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -174,6 +174,7 @@ bool Use_new_scanning_behavior;
 bool Lua_API_returns_nil_instead_of_invalid_object;
 bool Dont_show_callsigns_in_escort_list;
 bool Hide_main_rearm_items_in_comms_gauge;
+bool Always_show_selected_item_in_comms_gauge;
 bool Fix_scripted_velocity;
 color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 bool Preload_briefing_icon_models;
@@ -497,6 +498,10 @@ void parse_mod_table(const char *filename)
 
 			if (optional_string("$Hide main Rearm/Repair items in Comms Gauge:")) {
 				stuff_boolean(&Hide_main_rearm_items_in_comms_gauge);
+			}
+
+			if (optional_string("$Always show selected item in Comms Gauge:")) {
+				stuff_boolean(&Always_show_selected_item_in_comms_gauge);
 			}
 
 			optional_string("#SEXP SETTINGS");
@@ -1941,6 +1946,7 @@ void mod_table_reset()
 	Use_new_scanning_behavior = false;
 	Lua_API_returns_nil_instead_of_invalid_object = false;
 	Dont_show_callsigns_in_escort_list = false;
+	Always_show_selected_item_in_comms_gauge = false;
 	Hide_main_rearm_items_in_comms_gauge = false;
 	Fix_scripted_velocity = false;
 	// These colors were taken from missionscreencommon.cpp line 591 which

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -194,6 +194,7 @@ extern bool Use_new_scanning_behavior;
 extern bool Lua_API_returns_nil_instead_of_invalid_object;
 extern bool Dont_show_callsigns_in_escort_list;
 extern bool Hide_main_rearm_items_in_comms_gauge;
+extern bool Always_show_selected_item_in_comms_gauge;
 extern bool Fix_scripted_velocity;
 extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 extern bool Preload_briefing_icon_models;


### PR DESCRIPTION
The game settings flag '$Hide main Rearm/Repair items in Comms Gauge:' hides the 'Rearm and Repair' lines in the HUD Comms menu from appearing, which is useful for mods that do not have repair ships and thus those lines confuse players. Unfortunately, the newer `COMMS_MENU_SELECT` control bindings do not properly account for hidden menu items, so using those controls on a comms menu with 'Rearm and Repair' hidden means the selection index gets off and also confuses the player.

This PR fixes that by allowing `hud_squadmsg_selection_move_down()` and `hud_squadmsg_selection_move_up()` to skip hidden menu items. Tested and works as expected.


For folks using the COMMS_MENU_SELECT controls, there is also a current UI confusion when the comms menu is first brought up because the first item is selected, but the `Display_selector` does not show. Thus, players are unsure what item is actively selected even though one is actively selected. In the original comms menu select PR this was set to on by default, but then switched to off by default by a different developer a bit later. This choice is especially useful for mods that have many players with gamepads such as Event Horizon. Alternatively, mods that already have many number keys utilized for other gameplay aspects seem to prefer to keep the comms menu visuals as is and only show the selection if the player uses those keys. 

Given there is clearly arguments for both reasons, ideally modders should be able to choose how it displays for their own mods (always or off for the first pop-up of the Comms menu).  Thus, this PR adds that as a cleanup game option, too. This also was tested and works as expected.