### PR TITLE
Vulkan: S3TC support is optional in mobile gpus

### DIFF
--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -818,7 +818,7 @@ bool VulkanRenderer::isTextureCompressionS3TCSupported() const
 
 	constexpr vk::FormatFeatureFlags required = vk::FormatFeatureFlagBits::eSampledImage | vk::FormatFeatureFlagBits::eSampledImageFilterLinear;
 
-	return std::all_of(formats.begin(), formats.end(), [this](vk::Format fmt) {
+	return std::all_of(formats.begin(), formats.end(), [this, required](vk::Format fmt) {
 		const auto props = m_physicalDevice.getFormatProperties(fmt);
 		return (props.optimalTilingFeatures & required) == required;
 	});

--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -800,6 +800,33 @@ bool VulkanRenderer::isTextureCompressionBCSupported() const
 	return m_deviceFeatures.textureCompressionBC == VK_TRUE;
 }
 
+bool VulkanRenderer::isTextureCompressionS3TCSupported() const
+{
+	if (!m_physicalDevice) {
+		return false;
+	}
+
+	if (m_deviceFeatures.textureCompressionBC == VK_TRUE)
+		return true;
+
+	constexpr std::array<vk::Format, 3> formats = {
+		vk::Format::eBc1RgbaUnormBlock, // DXT1
+		vk::Format::eBc2UnormBlock,     // DXT3
+		vk::Format::eBc3UnormBlock,     // DXT5
+	};
+
+	constexpr vk::FormatFeatureFlags required = vk::FormatFeatureFlagBits::eSampledImage | vk::FormatFeatureFlagBits::eSampledImageFilterLinear;
+
+	for (auto fmt : formats) {
+		const auto props = m_physicalDevice.getFormatProperties(fmt);
+		if ((props.optimalTilingFeatures & required) != required) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 bool VulkanRenderer::isDepthClampSupported() const
 {
 	if (!m_physicalDevice) {

--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -817,14 +817,10 @@ bool VulkanRenderer::isTextureCompressionS3TCSupported() const
 
 	constexpr vk::FormatFeatureFlags required = vk::FormatFeatureFlagBits::eSampledImage | vk::FormatFeatureFlagBits::eSampledImageFilterLinear;
 
-	for (auto fmt : formats) {
+	return std::all_of(formats.begin(), formats.end(), [this](vk::Format fmt) {
 		const auto props = m_physicalDevice.getFormatProperties(fmt);
-		if ((props.optimalTilingFeatures & required) != required) {
-			return false;
-		}
-	}
-
-	return true;
+		return (props.optimalTilingFeatures & required) == required;
+	});
 }
 
 bool VulkanRenderer::isDepthClampSupported() const

--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -17,6 +17,7 @@
 #include "mod_table/mod_table.h"
 
 #include <SDL3/SDL_vulkan.h>
+#include <algorithm>
 
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 

--- a/code/graphics/vulkan/VulkanRenderer.h
+++ b/code/graphics/vulkan/VulkanRenderer.h
@@ -193,6 +193,11 @@ class VulkanRenderer {
 	bool isTextureCompressionBCSupported() const;
 
 	/**
+	 * @brief Check if BC 1/2/3 texture compression is supported
+	 */
+	bool isTextureCompressionS3TCSupported() const;
+
+	/**
 	 * @brief Check if depth clamping is supported (used by the shadow pass)
 	 */
 	bool isDepthClampSupported() const;

--- a/code/graphics/vulkan/gr_vulkan.cpp
+++ b/code/graphics/vulkan/gr_vulkan.cpp
@@ -140,7 +140,8 @@ bool vulkan_is_capable(gr_capability capability)
 		return getRendererInstance()->isTextureCompressionBCSupported();
 	case gr_capability::CAPABILITY_S3TC:
 		// Vulkan always supports BC1/BC2/BC3 (S3TC equivalent) as core features
-		return true;
+		// But this is optional on mobile gpus, so check anyway
+		return getRendererInstance()->isTextureCompressionS3TCSupported();
 	case gr_capability::CAPABILITY_LARGE_SHADER:
 		// Same troubleshooting switch as OpenGL: -no_large_shaders splits the model
 		// ubershader into per-flag-combination variants for drivers that choke on the


### PR DESCRIPTION
S3TC support (BC1/2/3) was assumed to be always present, but this is considered optional for mobile gpus. This change should allow for software decompression to be used instead of crashing.

I went the extra mile to actually check for individual BC1/2/3 support if textureCompressionBC (the full BCn set) returns false, you never know with these drivers.