### PR TITLE
Configurable primary selection

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -143,6 +143,8 @@ typedef struct ai_class {
 	float	ai_secondary_range_mult[NUM_SKILL_LEVELS];
 	bool	ai_class_autoscale;		//Defaults to true, but can be turned off in order to disable extra scaling of some AI behaviors
 									//based on AI class index
+	::util::ParsedRandomFloatRange primary_select_delay;
+	::util::ParsedRandomFloatRange primary_select_delay_on_change;
 	::util::ParsedRandomFloatRange primary_selection_random_factor;
 	float primary_selection_oneshot_modifier;
 	float primary_selection_status_quo_bias;
@@ -379,7 +381,9 @@ typedef struct ai_info {
 	int		ai_chance_to_use_missiles_on_plr;
 	float	ai_max_aim_update_delay;
 	float	ai_turret_max_aim_update_delay;
-	::util::ParsedRandomFloatRange primary_selection_random_factor;
+	::util::ParsedRandomFloatRange	primary_select_delay;
+	::util::ParsedRandomFloatRange	primary_select_delay_on_change;
+	::util::ParsedRandomFloatRange	primary_selection_random_factor;
 	float primary_selection_oneshot_modifier;
 	float primary_selection_status_quo_bias;
 	flagset<AI::Profile_Flags> ai_profile_flags;	//Holds AI_Profiles flags (possibly overriden by AI class) that actually apply to AI

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -21,6 +21,7 @@
 #include "parse/sexp.h"
 #include "physics/physics.h"
 #include "ship/ship_flags.h"
+#include "utils/RandomRange.h"
 
 class ship_weapon;
 class ship_subsys;
@@ -142,7 +143,7 @@ typedef struct ai_class {
 	float	ai_secondary_range_mult[NUM_SKILL_LEVELS];
 	bool	ai_class_autoscale;		//Defaults to true, but can be turned off in order to disable extra scaling of some AI behaviors
 									//based on AI class index
-	float primary_selection_random_factor;
+	::util::ParsedRandomFloatRange primary_selection_random_factor;
 	float primary_selection_oneshot_modifier;
 	float primary_selection_status_quo_bias;
 
@@ -344,6 +345,7 @@ typedef struct ai_info {
 	float		prev_dot_to_goal;					//	dot of fvec to goal last frame, used to see if making progress towards goal.
 	vec3d	goal_point;							//	Used in AIM_SAFETY, AIM_STILL and in circling.
 	vec3d	prev_goal_point;					//	Previous location of goal point, used at least for evading.
+	float	enemy_shield_is_down;
 	
 	//Values copied from the AI class
 	float	ai_accuracy, ai_evasion, ai_courage, ai_patience;
@@ -377,7 +379,7 @@ typedef struct ai_info {
 	int		ai_chance_to_use_missiles_on_plr;
 	float	ai_max_aim_update_delay;
 	float	ai_turret_max_aim_update_delay;
-	float primary_selection_random_factor;
+	::util::ParsedRandomFloatRange primary_selection_random_factor;
 	float primary_selection_oneshot_modifier;
 	float primary_selection_status_quo_bias;
 	flagset<AI::Profile_Flags> ai_profile_flags;	//Holds AI_Profiles flags (possibly overriden by AI class) that actually apply to AI

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -143,11 +143,11 @@ typedef struct ai_class {
 	float	ai_secondary_range_mult[NUM_SKILL_LEVELS];
 	bool	ai_class_autoscale;		//Defaults to true, but can be turned off in order to disable extra scaling of some AI behaviors
 									//based on AI class index
-	::util::ParsedRandomFloatRange primary_select_delay;
-	::util::ParsedRandomFloatRange primary_select_delay_on_change;
-	::util::ParsedRandomFloatRange primary_selection_random_factor;
-	float primary_selection_oneshot_modifier;
-	float primary_selection_status_quo_bias;
+	::util::ParsedRandomFloatRange primary_select_delay[NUM_SKILL_LEVELS];
+	::util::ParsedRandomFloatRange primary_select_delay_on_change[NUM_SKILL_LEVELS];
+	::util::ParsedRandomFloatRange primary_selection_random_factor[NUM_SKILL_LEVELS];
+	float primary_selection_oneshot_modifier[NUM_SKILL_LEVELS];
+	float primary_selection_status_quo_bias[NUM_SKILL_LEVELS];
 
 } ai_class;
 

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -347,7 +347,7 @@ typedef struct ai_info {
 	float		prev_dot_to_goal;					//	dot of fvec to goal last frame, used to see if making progress towards goal.
 	vec3d	goal_point;							//	Used in AIM_SAFETY, AIM_STILL and in circling.
 	vec3d	prev_goal_point;					//	Previous location of goal point, used at least for evading.
-	float	enemy_shield_is_down;
+	bool	enemy_shield_is_down;
 	
 	//Values copied from the AI class
 	float	ai_accuracy, ai_evasion, ai_courage, ai_patience;

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -142,6 +142,10 @@ typedef struct ai_class {
 	float	ai_secondary_range_mult[NUM_SKILL_LEVELS];
 	bool	ai_class_autoscale;		//Defaults to true, but can be turned off in order to disable extra scaling of some AI behaviors
 									//based on AI class index
+	float primary_selection_random_factor;
+	float primary_selection_oneshot_modifier;
+	float primary_selection_status_quo_bias;
+
 } ai_class;
 
 //	Submode definitions.
@@ -373,6 +377,9 @@ typedef struct ai_info {
 	int		ai_chance_to_use_missiles_on_plr;
 	float	ai_max_aim_update_delay;
 	float	ai_turret_max_aim_update_delay;
+	float primary_selection_random_factor;
+	float primary_selection_oneshot_modifier;
+	float primary_selection_status_quo_bias;
 	flagset<AI::Profile_Flags> ai_profile_flags;	//Holds AI_Profiles flags (possibly overriden by AI class) that actually apply to AI
 
 	ship_subsys*	targeted_subsys;			// Targeted subobject on current target.  NULL if none;

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -127,6 +127,7 @@ namespace AI {
         Require_turret_to_have_target_in_fov,
         Shockwaves_damage_small_ship_subsystems,
         Smart_afterburner_management,
+		Always_do_primary_select_when_target_change,
 		Configurable_primary_weapon_selection,
         Smart_primary_weapon_selection,
         Smart_secondary_weapon_selection,

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -127,6 +127,7 @@ namespace AI {
         Require_turret_to_have_target_in_fov,
         Shockwaves_damage_small_ship_subsystems,
         Smart_afterburner_management,
+		Configurable_primary_weapon_selection,
         Smart_primary_weapon_selection,
         Smart_secondary_weapon_selection,
         Smart_shield_management,

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -127,7 +127,6 @@ namespace AI {
         Require_turret_to_have_target_in_fov,
         Shockwaves_damage_small_ship_subsystems,
         Smart_afterburner_management,
-		Always_do_primary_select_when_target_change,
 		Configurable_primary_weapon_selection,
         Smart_primary_weapon_selection,
         Smart_secondary_weapon_selection,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -203,14 +203,14 @@ void parse_ai_profiles_tbl(const char *filename)
 					parse_float_list(profile->in_range_time, NUM_SKILL_LEVELS);
 
 				if (optional_string("$Primary select delay:")) {
-					for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
-						profile->primary_select_delay[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+					for (int level = 0; level < NUM_SKILL_LEVELS; level++) {
+						profile->primary_select_delay[level] = ::util::ParsedRandomFloatRange::parseRandomRange();
 					}
 				}
 			
 				if (optional_string("$Primary select delay on target change:")) {
-					for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
-						profile->primary_select_delay_on_change[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+					for (int level = 0; level < NUM_SKILL_LEVELS; level++) {
+						profile->primary_select_delay_on_change[level] = ::util::ParsedRandomFloatRange::parseRandomRange();
 					}
 				}
 

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -382,7 +382,9 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$big ships can attack beam turrets on untargeted ships:", AI::Profile_Flags::Big_ships_can_attack_beam_turrets_on_untargeted_ships);
 
-				set_flag(profile, "$Configurable primary weapon selection:", AI::Profile_Flags::Configurable_primary_weapon_selection);
+				set_flag(profile, "$always do primary select when target change:", AI::Profile_Flags::Always_do_primary_select_when_target_change);
+
+				set_flag(profile, "$configurable primary weapon selection:", AI::Profile_Flags::Configurable_primary_weapon_selection);
 
 				set_flag(profile, "$smart primary weapon selection:", AI::Profile_Flags::Smart_primary_weapon_selection);
 

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -936,7 +936,7 @@ void ai_profile_t::reset()
         player_autoaim_fov[i] = 0;
 
 		primary_select_delay[i] = ::util::UniformFloatRange(5.0f);
-		primary_select_delay_on_change[i] = ::util::UniformFloatRange(FLT_MAX);
+		primary_select_delay_on_change[i] = ::util::UniformFloatRange(9999.0f);
     }
 
     for (int i = 0; i <= MAX_DETAIL_VALUE; ++i) {

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -202,6 +202,18 @@ void parse_ai_profiles_tbl(const char *filename)
 				if (optional_string("$AI In Range Time:"))
 					parse_float_list(profile->in_range_time, NUM_SKILL_LEVELS);
 
+				if (optional_string("$Primary select delay:")) {
+					for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
+						profile->primary_select_delay[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+					}
+				}
+			
+				if (optional_string("$Primary select delay on target change:")) {
+					for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
+						profile->primary_select_delay_on_change[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+					}
+				}
+
 				if (optional_string("$AI Always Links Ammo Weapons:"))
 					parse_float_list(profile->link_ammo_levels_always, NUM_SKILL_LEVELS);
 
@@ -381,8 +393,6 @@ void parse_ai_profiles_tbl(const char *filename)
 					parse_float_list(profile->detail_distance_mult, MAX_DETAIL_VALUE + 1);
 
 				set_flag(profile, "$big ships can attack beam turrets on untargeted ships:", AI::Profile_Flags::Big_ships_can_attack_beam_turrets_on_untargeted_ships);
-
-				set_flag(profile, "$always do primary select when target change:", AI::Profile_Flags::Always_do_primary_select_when_target_change);
 
 				set_flag(profile, "$configurable primary weapon selection:", AI::Profile_Flags::Configurable_primary_weapon_selection);
 
@@ -924,6 +934,9 @@ void ai_profile_t::reset()
         delay_bomb_arm_timer[i] = 0;
         chance_to_use_missiles_on_plr[i] = 0;
         player_autoaim_fov[i] = 0;
+
+		primary_select_delay[i] = ::util::UniformFloatRange(5.0f);
+		primary_select_delay_on_change[i] = ::util::UniformFloatRange(FLT_MAX);
     }
 
     for (int i = 0; i <= MAX_DETAIL_VALUE; ++i) {

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -382,6 +382,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$big ships can attack beam turrets on untargeted ships:", AI::Profile_Flags::Big_ships_can_attack_beam_turrets_on_untargeted_ships);
 
+				set_flag(profile, "$Configurable primary weapon selection:", AI::Profile_Flags::Configurable_primary_weapon_selection);
+
 				set_flag(profile, "$smart primary weapon selection:", AI::Profile_Flags::Smart_primary_weapon_selection);
 
 				set_flag(profile, "$smart secondary weapon selection:", AI::Profile_Flags::Smart_secondary_weapon_selection);

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -203,14 +203,14 @@ void parse_ai_profiles_tbl(const char *filename)
 					parse_float_list(profile->in_range_time, NUM_SKILL_LEVELS);
 
 				if (optional_string("$Primary select delay:")) {
-					for (int level = 0; level < NUM_SKILL_LEVELS; level++) {
-						profile->primary_select_delay[level] = ::util::ParsedRandomFloatRange::parseRandomRange();
+					for (auto& entry : profile->primary_select_delay) {
+						entry = ::util::ParsedRandomFloatRange::parseRandomRange();
 					}
 				}
 			
 				if (optional_string("$Primary select delay on target change:")) {
-					for (int level = 0; level < NUM_SKILL_LEVELS; level++) {
-						profile->primary_select_delay_on_change[level] = ::util::ParsedRandomFloatRange::parseRandomRange();
+					for (auto& entry : profile->primary_select_delay_on_change) {
+						entry = ::util::ParsedRandomFloatRange::parseRandomRange();
 					}
 				}
 

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -13,6 +13,7 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/systemvars.h"
 #include "ai/ai_flags.h"
+#include "utils/RandomRange.h"
 
 // AI Path types
 #define	AI_PATH_MODE_NORMAL 0
@@ -69,6 +70,8 @@ public:
 	float stalemate_dist_thresh[NUM_SKILL_LEVELS];			// SUSHI: The maximum distance the AI and target must be within for a stalemate
 	float max_aim_update_delay[NUM_SKILL_LEVELS];			// SUSHI: The maximum delay before the AI updates their aim against small ships
 	float turret_max_aim_update_delay[NUM_SKILL_LEVELS];	// SUSHI: As above, but for turrets updating their aim
+	::util::ParsedRandomFloatRange primary_select_delay[NUM_SKILL_LEVELS];				// Time in seconds before next time the AI updates its primary weapon choice
+	::util::ParsedRandomFloatRange primary_select_delay_on_change[NUM_SKILL_LEVELS];	// Same, but for special updates taking place when the target ship or subsystem changes, or target's shields change
 
 	//	Multiplicative delay factors for increasing skill levels.
 	float ship_fire_delay_scale_hostile[NUM_SKILL_LEVELS];

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6217,22 +6217,17 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 		
 		float weapon_value = std::max(effective_dps, oneshot_value) * aip->primary_selection_random_factor.next();
 
-		SCP_unordered_map<int, float> armor_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR];
-		SCP_unordered_map<int, float> shiptype_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_TYPE];
-		SCP_unordered_map<int, float> shipclass_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_CLASS];
-		SCP_unordered_map<int, float> weaponclass_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::WEAPON_CLASS];
-
-		if (relevant_armor_type_idx >= 0 && armor_flags.contains(relevant_armor_type_idx)) {
-			weapon_value *= armor_flags[relevant_armor_type_idx];
+		if (wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR].contains(relevant_armor_type_idx)) {
+			weapon_value *= wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR][relevant_armor_type_idx];
 		}
-		if (relevant_ship_type_idx >= 0 && shiptype_flags.contains(relevant_ship_type_idx)) {
-			weapon_value *= armor_flags[relevant_ship_type_idx];
+		if (wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_TYPE].contains(relevant_ship_type_idx)) {
+			weapon_value *= wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_TYPE][relevant_ship_type_idx];
 		}
-		if (relevant_ship_class_idx >= 0 && shipclass_flags.contains(relevant_ship_class_idx)) {
-			weapon_value *= armor_flags[relevant_ship_class_idx];
+		if (wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_CLASS].contains(relevant_ship_class_idx)) {
+			weapon_value *= wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_CLASS][relevant_ship_class_idx];
 		}
-		if (relevant_weapon_class_idx >= 0 && weaponclass_flags.contains(relevant_weapon_class_idx)) {
-			weapon_value *= armor_flags[relevant_weapon_class_idx];
+		if (wip->primary_selection_target_flags[PrimarySelectionTargetType::WEAPON_CLASS].contains(relevant_weapon_class_idx)) {
+			weapon_value *= wip->primary_selection_target_flags[PrimarySelectionTargetType::WEAPON_CLASS][relevant_weapon_class_idx];
 		}
 
 		if (i == swp->current_primary_bank) {

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1610,9 +1610,9 @@ int set_target_objnum(ai_info *aip, int objnum)
 		aip->target_signature = (objnum >= 0) ? Objects[objnum].signature : -1;
 		// clear targeted subsystem
 		set_targeted_subsys(aip, NULL, -1);
-		int candidate_timestamp = timestamp(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)));
+		int candidate_timestamp = timestamp(std::max(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)), 0));
 		// we don't want to bother checking for an early selection if the ai's going to do it sooner anyway
-		if (aip->primary_select_timestamp > candidate_timestamp) {
+		if (timestamp_until(aip->primary_select_timestamp) > timestamp_until(candidate_timestamp)) {
 			aip->primary_select_timestamp = candidate_timestamp;
 		}
 	}
@@ -1640,9 +1640,9 @@ ship_subsys *set_targeted_subsys(ai_info *aip, ship_subsys *new_subsys, int pare
 				ship_primary_changed(&Ships[aip->shipnum]);	// AL: maybe send multiplayer information when AI ship changes primaries
 			}
 		} else {
-			int candidate_timestamp = timestamp(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)));
+			int candidate_timestamp = timestamp(std::max(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)), 0));
 			// we don't want to bother checking for an early selection if the ai's going to do it sooner anyway
-			if (aip->primary_select_timestamp > candidate_timestamp) {
+			if (timestamp_until(aip->primary_select_timestamp) > timestamp_until(candidate_timestamp)) {
 				aip->primary_select_timestamp = candidate_timestamp;
 			}
 		}
@@ -6576,9 +6576,9 @@ int ai_fire_primary_weapon(object *objp)
 	}
 
 	float relevant_shields_left = -1.0f;
-	int candidate_timestamp = timestamp(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)));
+	int candidate_timestamp = timestamp(std::max(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)), 0));
 	// we don't want to bother checking for an early selection if the ai's going to do it sooner anyway
-	if (enemy_objp && (aip->primary_select_timestamp > candidate_timestamp)) {
+	if (enemy_objp && (timestamp_until(aip->primary_select_timestamp) > timestamp_until(candidate_timestamp))) {
 		vec3d ship_local_pos = objp->pos;
 		vm_vec_sub2(&ship_local_pos, &enemy_objp->pos);
 		vm_vec_rotate(&ship_local_pos, &ship_local_pos, &enemy_objp->orient);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5722,26 +5722,8 @@ static int ai_select_primary_weapon_OLD(const object *objp, Weapon::Info_Flags f
 	return swp->current_primary_bank;
 }
 
-//	If:
-//		flags == Weapon::Info_Flags::Puncture
-//	Then Select a Puncture weapon.
-//	Else
-//		Select Any ol' weapon.
-//	Returns primary_bank index.
-/**
- * Etc. Etc. This is like the 4th rewrite of the code here. Special thanks to Bobboau
- * for finding the get_shield_strength function.
- * 
- * The AI will now intelligently choose the best weapon to use based on the overall shield
- * status of the target.
- */
-int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flags flags)
+std::optional<int> select_primary_setup(ship *shipp, ship *other_shipp, ship_weapon *swp, object *other_objp)
 {
-	// Pointer Set Up
-	ship	*shipp = &Ships[objp->instance];
-	ship	*other_shipp = nullptr;
-	ship_weapon *swp = &shipp->weapons;
-
 	// Debugging
 	if (other_objp==NULL)
 	{
@@ -5794,6 +5776,34 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 
 	// we're not prioritizing a specific primary weapon
 	shipp->flags.remove(Ship::Ship_Flags::Force_primary_unlinking);
+
+	return std::nullopt;
+}
+
+//	If:
+//		flags == Weapon::Info_Flags::Puncture
+//	Then Select a Puncture weapon.
+//	Else
+//		Select Any ol' weapon.
+//	Returns primary_bank index.
+/**
+ * Etc. Etc. This is like the 4th rewrite of the code here. Special thanks to Bobboau
+ * for finding the get_shield_strength function.
+ * 
+ * The AI will now intelligently choose the best weapon to use based on the overall shield
+ * status of the target.
+ */
+int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flags flags)
+{
+	// Pointer Set Up
+	ship	*shipp = &Ships[objp->instance];
+	ship	*other_shipp = nullptr;
+	ship_weapon *swp = &shipp->weapons;
+
+	auto early_return_value = select_primary_setup(shipp, other_shipp, swp, other_objp);
+	if (early_return_value.has_value()) {
+		return early_return_value.value();
+	}
 
 
 	//not using the new AI, use the old version of this function instead.
@@ -5987,6 +5997,24 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 		swp->current_primary_bank = i_shieldfactor_prev_bank;		// Select the best weapon
 		nprintf(("AI", "%i: Ship %s selecting weapon %s (>50%% shields)\n", Framecount, shipp->ship_name, Weapon_info[swp->primary_bank_weapons[i_shieldfactor_prev_bank]].name));
 		return i_shieldfactor_prev_bank;							// Return
+	}
+}
+
+// Cleaner version of primary selection, with high modder control.
+int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weapon::Info_Flags flags)
+{
+	ship	*shipp = &Ships[objp->instance];
+	ship	*other_shipp = nullptr;
+	ship_weapon *swp = &shipp->weapons;
+
+	auto early_return_value = select_primary_setup(shipp, other_shipp, swp, other_objp);
+	if (early_return_value.has_value()) {
+		return early_return_value.value();
+	}
+
+	for (auto& wip_i : swp->primary_bank_weapons) {
+		auto wip = &Weapon_info[wip_i];
+		
 	}
 }
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -691,7 +691,7 @@ void init_ai_class(ai_class *aicp)
 		aicp->ai_secondary_range_mult[i] = FLT_MIN;
 	}
 	aicp->ai_class_autoscale = true;	//Retail behavior is to do the stupid autoscaling
-	aicp->primary_selection_random_factor = 1.0f;
+	aicp->primary_selection_random_factor = ::util::UniformFloatRange(1.0f);
 	aicp->primary_selection_oneshot_modifier = 2.0f;
 	aicp->primary_selection_status_quo_bias = 1.0f;
 }
@@ -801,7 +801,7 @@ void parse_ai_class()
 		stuff_boolean(&aicp->ai_class_autoscale);
 
 	if (optional_string("$Primary selection random factor:"))
-		stuff_float(&aicp->primary_selection_random_factor);
+		aicp->primary_selection_random_factor = ::util::ParsedRandomFloatRange::parseRandomRange();
 
 	if (optional_string("$Primary selection oneshot modifier:"))
 		stuff_float(&aicp->primary_selection_oneshot_modifier);
@@ -919,6 +919,8 @@ void parse_ai_class()
 		parse_float_list(aicp->ai_turret_max_aim_update_delay, NUM_SKILL_LEVELS);
 
 	set_aic_flag(aicp, "$big ships can attack beam turrets on untargeted ships:", AI::Profile_Flags::Big_ships_can_attack_beam_turrets_on_untargeted_ships);
+
+	set_aic_flag(aicp, "$always do primary select when target change:", AI::Profile_Flags::Always_do_primary_select_when_target_change);
 	
 	set_aic_flag(aicp, "$configurable primary weapon selection:", AI::Profile_Flags::Configurable_primary_weapon_selection);
 
@@ -1557,6 +1559,10 @@ vec3d ai_get_acc_limit(vec3d* vel_limit, const object* objp) {
 }
 
 
+int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flags flags);
+
+int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weapon::Info_Flags flags, float relevant_shields_left);
+
 //	Set aip->target_objnum to objnum
 //	Update aip->previous_target_objnum.
 //	If new target (objnum) is different than old target, reset target_time.
@@ -1589,14 +1595,17 @@ int set_target_objnum(ai_info *aip, int objnum)
 		aip->target_signature = (objnum >= 0) ? Objects[objnum].signature : -1;
 		// clear targeted subsystem
 		set_targeted_subsys(aip, NULL, -1);
+		if (aip->ai_profile_flags[AI::Profile_Flags::Always_do_primary_select_when_target_change]) {
+			object *target_object = nullptr;
+			if (aip->target_objnum >= 0) {
+				target_object = &Objects[aip->target_objnum];
+			}
+			ai_select_primary_weapon_configurable(&Objects[Ships[aip->shipnum].objnum], target_object, Weapon::Info_Flags::Puncture, -1.0f);
+		}
 	}
 	
 	return aip->target_objnum;
 }
-
-int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flags flags);
-
-int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weapon::Info_Flags flags);
 
 /**
  * Make new_subsys the targeted subsystem of ship *aip.
@@ -1611,10 +1620,10 @@ ship_subsys *set_targeted_subsys(ai_info *aip, ship_subsys *new_subsys, int pare
 
 	if ( new_subsys ) {
 		// Make new_subsys target
-		if (new_subsys->system_info->type == SUBSYSTEM_ENGINE) {
+		if (new_subsys->system_info->type == SUBSYSTEM_ENGINE || aip->ai_profile_flags[AI::Profile_Flags::Always_do_primary_select_when_target_change]) {
 			if ( aip != Player_ai ) {
 				Assert( aip->shipnum >= 0 );
-				ai_select_primary_weapon_configurable(&Objects[Ships[aip->shipnum].objnum], &Objects[parent_objnum], Weapon::Info_Flags::Puncture);
+				ai_select_primary_weapon_configurable(&Objects[Ships[aip->shipnum].objnum], &Objects[parent_objnum], Weapon::Info_Flags::Puncture, -1.0f);
 				ship_primary_changed(&Ships[aip->shipnum]);	// AL: maybe send multiplayer information when AI ship changes primaries
 			}
 		}
@@ -6016,7 +6025,7 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 }
 
 // More comprehensive version of primary selection, with high modder control.
-int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weapon::Info_Flags flags)
+int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weapon::Info_Flags flags, float relevant_shields_left = -1.0f)
 {
 	ship	*shipp = &Ships[objp->instance];
 	ship	*target_shipp = nullptr;
@@ -6040,17 +6049,25 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 	bool is_beam;
 
 	ship_subsys *target_subsys = Ai_info[shipp->ai_index].targeted_subsys;
-	float relevant_shields_left = 100.0f; //TODO: get shield quadrant stuff
 	int relevant_armor_type_idx = -1;
 	int relevant_ship_type_idx = -1;
 	int relevant_ship_class_idx = -1;
 	int relevant_weapon_class_idx = -1;
 
+	if (relevant_shields_left < 0.0f) {
+		vec3d ship_local_pos = objp->pos;
+		vm_vec_sub2(&ship_local_pos, &other_objp->pos);
+		vm_vec_rotate(&ship_local_pos, &ship_local_pos, &other_objp->orient);
+		int relevant_quadrant = get_quadrant(&ship_local_pos, other_objp);
+		if (relevant_quadrant > 0 && relevant_quadrant < sz2i(other_objp->shield_quadrant.size())) {
+			relevant_shields_left = shield_get_quad(other_objp, relevant_quadrant) - ship_shield_hitpoint_threshold(other_objp, false);
+		}
+	}
+	
 	SCP_unordered_map<int, float> weapon_values = {};
 
-	// TODO: handle non-ship target cases
-
-	for (auto& wip_i : swp->primary_bank_weapons) {
+	for (int i; i < MAX_SHIP_PRIMARY_BANKS; i++) {
+		int wip_i = swp->primary_bank_weapons[i];
 		if (wip_i < 0) {
 			continue;
 		}
@@ -6064,7 +6081,6 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 		if (has_shockwave) {
 			shockwave_damage = sci->damage;
 		}
-
 
 		if (target_shipp) {
 			relevant_ship_type_idx = Ship_info[target_shipp->ship_info_index].class_type;
@@ -6137,7 +6153,22 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 
 		dph += shockwave_damage;
 
-		//TODO: decide whether to take $Shots (/$Cycle_multishot) into account
+		int shot_count;
+		FiringPattern firing_pattern;
+		if (sinfop->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+			firing_pattern = sinfop->dyn_firing_patterns_allowed[i][swp->dynamic_firing_pattern[i]];
+		} else {
+			firing_pattern = wip->firing_pattern;
+		}
+		if (sinfop->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+			shot_count = wip->cycle_multishot;
+		} else if (wip->b_info.beam_shots) {
+			shot_count = wip->shots;
+		} else if (firing_pattern != FiringPattern::STANDARD) {
+			shot_count = wip->cycle_multishot;
+		} else {
+			shot_count = wip->shots;
+		}
 
 		ai_info *aip = &Ai_info[shipp->ai_index];
 		float effective_dps;
@@ -6169,9 +6200,10 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 		if (fire_rate * wip->energy_consumed > (shipp->max_weapon_regen_per_second * sinfop->max_weapon_reserve)) {
 			fire_rate = (fire_rate + ((shipp->max_weapon_regen_per_second * sinfop->max_weapon_reserve) / wip->energy_consumed)) / 2.0f;
 		}
-		effective_dps = (dph * burst_shots) * fire_rate;
+		int num_slots = model_get(sinfop->model_num)->gun_banks[i].num_slots;
+		effective_dps = (dph * i2fl(shot_count) * i2fl(num_slots) * burst_shots) * fire_rate;
 		
-		float weapon_value = std::max(effective_dps, oneshot_value) * aip->primary_selection_random_factor;
+		float weapon_value = std::max(effective_dps, oneshot_value) * aip->primary_selection_random_factor.next();
 
 		SCP_unordered_map<int, float> armor_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR];
 		SCP_unordered_map<int, float> shiptype_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_TYPE];
@@ -6516,13 +6548,30 @@ int ai_fire_primary_weapon(object *objp)
 		enemy_sip = NULL;
 	}
 
+	bool shield_changed = false;
+	float relevant_shields_left = -1.0f;
+	if (aip->ai_profile_flags[AI::Profile_Flags::Always_do_primary_select_when_target_change] && enemy_objp) {
+		vec3d ship_local_pos = objp->pos;
+		vm_vec_sub2(&ship_local_pos, &enemy_objp->pos);
+		vm_vec_rotate(&ship_local_pos, &ship_local_pos, &enemy_objp->orient);
+		int relevant_quadrant = get_quadrant(&ship_local_pos, enemy_objp);
+		if (relevant_quadrant > 0 && relevant_quadrant < sz2i(enemy_objp->shield_quadrant.size())) {
+			relevant_shields_left = std::max(shield_get_quad(enemy_objp, relevant_quadrant) - ship_shield_hitpoint_threshold(enemy_objp, false), 0.0f);
+			bool shield_is_down = relevant_shields_left > 0.0f;
+			if (shield_is_down != aip->enemy_shield_is_down) {
+				shield_changed = true;
+				aip->enemy_shield_is_down = shield_is_down;
+			}
+		}
+	}
+
 	//plieblang - added check for size of Preferred_primaries to force reevaluation if good-primary-time has been used in the meantime
-	if ( (swp->current_primary_bank < 0) || (swp->current_primary_bank >= swp->num_primary_banks) || timestamp_elapsed(aip->primary_select_timestamp)) {
+	if ( (swp->current_primary_bank < 0) || (swp->current_primary_bank >= swp->num_primary_banks) || timestamp_elapsed(aip->primary_select_timestamp) || shield_changed) {
 		Weapon::Info_Flags flags = Weapon::Info_Flags::NUM_VALUES;
 		if ( aip->targeted_subsys != NULL ) {
 			flags = Weapon::Info_Flags::Puncture;
 		}
-		ai_select_primary_weapon_configurable(objp, enemy_objp, flags);
+		ai_select_primary_weapon_configurable(objp, enemy_objp, flags, relevant_shields_left);
 		ship_primary_changed(shipp);	// AL: maybe send multiplayer information when AI ship changes primaries
 		aip->primary_select_timestamp = timestamp(5 * MILLISECONDS_PER_SECOND);	//	Maybe change primary weapon five seconds from now.
 	}
@@ -16005,6 +16054,7 @@ void init_ai_object(int objnum)
 	aip->goal_check_time = timestamp(0);
 	aip->last_predicted_enemy_pos = near_vec;
 	aip->prev_goal_point = near_vec;
+	aip->enemy_shield_is_down = false;
 	aip->goal_point = near_vec;
 	aip->time_enemy_in_range = 0.0f;
 	aip->time_enemy_near = 0.0f;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -691,6 +691,8 @@ void init_ai_class(ai_class *aicp)
 		aicp->ai_secondary_range_mult[i] = FLT_MIN;
 	}
 	aicp->ai_class_autoscale = true;	//Retail behavior is to do the stupid autoscaling
+	aicp->primary_select_delay = ::util::UniformFloatRange(5.0f);
+	aicp->primary_select_delay_on_change = ::util::UniformFloatRange(FLT_MAX);
 	aicp->primary_selection_random_factor = ::util::UniformFloatRange(1.0f);
 	aicp->primary_selection_oneshot_modifier = 2.0f;
 	aicp->primary_selection_status_quo_bias = 1.0f;
@@ -799,6 +801,12 @@ void parse_ai_class()
 
 	if (optional_string("$Autoscale by AI Class Index:"))
 		stuff_boolean(&aicp->ai_class_autoscale);
+
+	if (optional_string("$Primary select delay:"))
+		aicp->primary_select_delay = ::util::ParsedRandomFloatRange::parseRandomRange();
+
+	if (optional_string("$Primary select delay on target change:"))
+		aicp->primary_select_delay_on_change = ::util::ParsedRandomFloatRange::parseRandomRange();
 
 	if (optional_string("$Primary selection random factor:"))
 		aicp->primary_selection_random_factor = ::util::ParsedRandomFloatRange::parseRandomRange();
@@ -1595,12 +1603,10 @@ int set_target_objnum(ai_info *aip, int objnum)
 		aip->target_signature = (objnum >= 0) ? Objects[objnum].signature : -1;
 		// clear targeted subsystem
 		set_targeted_subsys(aip, NULL, -1);
-		if (aip->ai_profile_flags[AI::Profile_Flags::Always_do_primary_select_when_target_change]) {
-			object *target_object = nullptr;
-			if (aip->target_objnum >= 0) {
-				target_object = &Objects[aip->target_objnum];
-			}
-			ai_select_primary_weapon_configurable(&Objects[Ships[aip->shipnum].objnum], target_object, Weapon::Info_Flags::Puncture, -1.0f);
+		int candidate_timestamp = timestamp(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)));
+		// we don't want to bother checking for an early selection if the ai's going to do it sooner anyway
+		if (aip->primary_select_timestamp > candidate_timestamp) {
+			aip->primary_select_timestamp = candidate_timestamp;
 		}
 	}
 	
@@ -1620,11 +1626,17 @@ ship_subsys *set_targeted_subsys(ai_info *aip, ship_subsys *new_subsys, int pare
 
 	if ( new_subsys ) {
 		// Make new_subsys target
-		if (new_subsys->system_info->type == SUBSYSTEM_ENGINE || aip->ai_profile_flags[AI::Profile_Flags::Always_do_primary_select_when_target_change]) {
+		if (new_subsys->system_info->type == SUBSYSTEM_ENGINE) {
 			if ( aip != Player_ai ) {
 				Assert( aip->shipnum >= 0 );
 				ai_select_primary_weapon_configurable(&Objects[Ships[aip->shipnum].objnum], &Objects[parent_objnum], Weapon::Info_Flags::Puncture, -1.0f);
 				ship_primary_changed(&Ships[aip->shipnum]);	// AL: maybe send multiplayer information when AI ship changes primaries
+			}
+		} else {
+			int candidate_timestamp = timestamp(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)));
+			// we don't want to bother checking for an early selection if the ai's going to do it sooner anyway
+			if (aip->primary_select_timestamp > candidate_timestamp) {
+				aip->primary_select_timestamp = candidate_timestamp;
 			}
 		}
 
@@ -6556,9 +6568,10 @@ int ai_fire_primary_weapon(object *objp)
 		enemy_sip = NULL;
 	}
 
-	bool shield_changed = false;
 	float relevant_shields_left = -1.0f;
-	if (aip->ai_profile_flags[AI::Profile_Flags::Always_do_primary_select_when_target_change] && enemy_objp) {
+	int candidate_timestamp = timestamp(fl2i(aip->primary_select_delay_on_change.next() * i2fl(MILLISECONDS_PER_SECOND)));
+	// we don't want to bother checking for an early selection if the ai's going to do it sooner anyway
+	if (enemy_objp && (aip->primary_select_timestamp > candidate_timestamp)) {
 		vec3d ship_local_pos = objp->pos;
 		vm_vec_sub2(&ship_local_pos, &enemy_objp->pos);
 		vm_vec_rotate(&ship_local_pos, &ship_local_pos, &enemy_objp->orient);
@@ -6567,21 +6580,21 @@ int ai_fire_primary_weapon(object *objp)
 			relevant_shields_left = std::max(shield_get_quad(enemy_objp, relevant_quadrant) - ship_shield_hitpoint_threshold(enemy_objp, false), 0.0f);
 			bool shield_is_down = relevant_shields_left > 0.0f;
 			if (shield_is_down != aip->enemy_shield_is_down) {
-				shield_changed = true;
 				aip->enemy_shield_is_down = shield_is_down;
+				aip->primary_select_timestamp = candidate_timestamp;
 			}
 		}
 	}
 
 	//plieblang - added check for size of Preferred_primaries to force reevaluation if good-primary-time has been used in the meantime
-	if ( (swp->current_primary_bank < 0) || (swp->current_primary_bank >= swp->num_primary_banks) || timestamp_elapsed(aip->primary_select_timestamp) || shield_changed) {
+	if ( (swp->current_primary_bank < 0) || (swp->current_primary_bank >= swp->num_primary_banks) || timestamp_elapsed(aip->primary_select_timestamp)) {
 		Weapon::Info_Flags flags = Weapon::Info_Flags::NUM_VALUES;
 		if ( aip->targeted_subsys != NULL ) {
 			flags = Weapon::Info_Flags::Puncture;
 		}
 		ai_select_primary_weapon_configurable(objp, enemy_objp, flags, relevant_shields_left);
 		ship_primary_changed(shipp);	// AL: maybe send multiplayer information when AI ship changes primaries
-		aip->primary_select_timestamp = timestamp(5 * MILLISECONDS_PER_SECOND);	//	Maybe change primary weapon five seconds from now.
+		aip->primary_select_timestamp = timestamp(aip->primary_select_delay.next() * MILLISECONDS_PER_SECOND);	//	Maybe change primary weapon in a while (five seconds by default).
 	}
 
 	// if the ship has no primary weapon selected, whether because it has no primary banks or because no bank contains a weapon, then there is nothing to fire
@@ -16208,6 +16221,9 @@ void init_aip_from_class_and_profile(ai_info *aip, ai_class *aicp, ai_profile_t 
 	aip->ai_get_away_chance = aicp->ai_get_away_chance[Game_skill_level];	
 	aip->ai_secondary_range_mult = aicp->ai_secondary_range_mult[Game_skill_level];
 	aip->ai_class_autoscale = aicp->ai_class_autoscale;
+
+	aip->primary_select_delay = aicp->primary_select_delay;
+	aip->primary_select_delay_on_change = aicp->primary_select_delay_on_change;
 
 	aip->primary_selection_random_factor = aicp->primary_selection_random_factor;
 	aip->primary_selection_oneshot_modifier = aicp->primary_selection_oneshot_modifier;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -691,6 +691,9 @@ void init_ai_class(ai_class *aicp)
 		aicp->ai_secondary_range_mult[i] = FLT_MIN;
 	}
 	aicp->ai_class_autoscale = true;	//Retail behavior is to do the stupid autoscaling
+	aicp->primary_selection_random_factor = 1.0f;
+	aicp->primary_selection_oneshot_modifier = 2.0f;
+	aicp->primary_selection_status_quo_bias = 1.0f;
 }
 
 void set_aic_flag(ai_class *aicp, const char *name, AI::Profile_Flags flag)
@@ -796,6 +799,15 @@ void parse_ai_class()
 
 	if (optional_string("$Autoscale by AI Class Index:"))
 		stuff_boolean(&aicp->ai_class_autoscale);
+
+	if (optional_string("$Primary selection random factor:"))
+		stuff_float(&aicp->primary_selection_random_factor);
+
+	if (optional_string("$Primary selection oneshot modifier:"))
+		stuff_float(&aicp->primary_selection_oneshot_modifier);
+
+	if (optional_string("$Primary selection status quo bias:"))
+		stuff_float(&aicp->primary_selection_status_quo_bias);
 
 	//Parse optional values for stuff imported from ai_profiles
 	if (optional_string("$AI Countermeasure Firing Chance:"))
@@ -5843,7 +5855,7 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 
 	float enemy_remaining_shield = get_shield_pct(other_objp);
 
-	if ( other_is_ship )
+	if ( other_shipp )
 	{
 		ship_info* other_sip = &Ship_info[other_shipp->ship_info_index];
 
@@ -5901,7 +5913,7 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 				return -1;
 		}
 		swp->current_primary_bank = i_hullfactor_prev_bank;		// Select the best weapon
-		nprintf(("AI", "%i: Ship %s selecting weapon %s (no shields) vs target %s\n", Framecount, shipp->ship_name, Weapon_info[swp->primary_bank_weapons[i_hullfactor_prev_bank]].name, (other_is_ship ? other_shipp->ship_name : "non-ship") ));
+		nprintf(("AI", "%i: Ship %s selecting weapon %s (no shields) vs target %s\n", Framecount, shipp->ship_name, Weapon_info[swp->primary_bank_weapons[i_hullfactor_prev_bank]].name, (other_shipp ? other_shipp->ship_name : "non-ship") ));
 		return i_hullfactor_prev_bank;							// Return
 	}
 
@@ -6000,22 +6012,165 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 	}
 }
 
-// Cleaner version of primary selection, with high modder control.
+// More comprehensive version of primary selection, with high modder control.
 int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weapon::Info_Flags flags)
 {
 	ship	*shipp = &Ships[objp->instance];
-	ship	*other_shipp = nullptr;
+	ship	*target_shipp = nullptr;
 	ship_weapon *swp = &shipp->weapons;
+	ship_info *sinfop = &Ship_info[shipp->ship_info_index];
 
-	auto early_return_value = select_primary_setup(shipp, other_shipp, swp, other_objp);
+	auto early_return_value = select_primary_setup(shipp, target_shipp, swp, other_objp);
 	if (early_return_value.has_value()) {
 		return early_return_value.value();
 	}
 
+	weapon_info *wip;
+	shockwave_create_info *sci;
+	bool has_shockwave;
+	bool is_beam;
+
+	ship_subsys *target_subsys = Ai_info[shipp->ai_index].targeted_subsys;
+	float relevant_shields_left = 100.0f;
+
+	SCP_unordered_map<int, float> weapon_values = {};
+
+	// TODO: handle non-ship target cases
+
 	for (auto& wip_i : swp->primary_bank_weapons) {
-		auto wip = &Weapon_info[wip_i];
+		if (wip_i < 0) {
+			continue;
+		}
+		wip = &Weapon_info[wip_i];
+		sci = &wip->shockwave;
+		has_shockwave = (sci->inner_rad != 0.0f || sci->outer_rad != 0.0f);
+		is_beam = wip->wi_flags[Weapon::Info_Flags::Beam];
+		float dph = wip->damage; // damage per hit
+		float damage_scale = -1.0f;
+		float shockwave_damage = 0.0f;
+		if (has_shockwave) {
+			shockwave_damage = sci->damage;
+		}
+
+
+		if (target_shipp) {
+			if (relevant_shields_left > 0.0f) {
+				damage_scale = weapon_get_damage_scale(wip, nullptr, other_objp);
+				dph *= damage_scale;
+				dph = Armor_types[target_shipp->shield_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+				if (!is_beam || Beams_use_damage_factors) {
+					dph *= wip->shield_factor;
+				}
+			} else if (target_subsys) {
+				if (!is_beam || Beams_use_damage_factors) {
+					if (target_subsys->flags[Ship::Subsystem_Flags::Damage_as_hull]) {
+						dph *= wip->armor_factor;
+						dph = Armor_types[target_subsys->armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+					} else {
+						dph *= wip->subsystem_factor;
+						dph = Armor_types[target_subsys->armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+					}
+				}
+			} else {
+				if (damage_scale == -1.0f) {
+					damage_scale = weapon_get_damage_scale(wip, nullptr, other_objp);
+				}
+				dph *= damage_scale;
+				dph = Armor_types[target_shipp->armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+				if (!is_beam || Beams_use_damage_factors) {
+					if (wip->wi_flags[Weapon::Info_Flags::Puncture]) {
+							dph /= 4;
+						}
+						dph *= wip->armor_factor;
+				}
+			}
+			if (has_shockwave) {
+				shockwave_damage = sci->damage;
+				if (Weapon_shockwaves_respect_huge || sci->speed <= 0.0f) {
+					if (damage_scale == -1.0f) {
+						damage_scale = weapon_get_damage_scale(wip, nullptr, other_objp);
+					}
+					shockwave_damage *= damage_scale;
+				}
+				if (relevant_shields_left) {
+					shockwave_damage = Armor_types[target_shipp->shield_armor_type_idx].GetDamage(shockwave_damage, sci->damage_type_idx, 1.0, is_beam);
+				} else if (target_subsys) {
+					shockwave_damage = Armor_types[target_subsys->armor_type_idx].GetDamage(shockwave_damage, sci->damage_type_idx, 1.0, is_beam);
+				} else {
+					shockwave_damage = Armor_types[target_shipp->armor_type_idx].GetDamage(shockwave_damage, sci->damage_type_idx, 1.0, is_beam);
+				}
+			}
+		} else if ( other_objp->type == OBJ_WEAPON ) {
+			ArmorType *weapon_armor = &Armor_types[Weapon_info[Weapons[other_objp->instance].weapon_info_index].armor_type_idx];
+			dph = weapon_armor->GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+			if (has_shockwave) {
+				shockwave_damage = weapon_armor->GetDamage(dph, sci->damage_type_idx, 1.0, is_beam);
+				if (sci->speed <= 0.0f) {
+					shockwave_damage *= weapon_get_damage_scale(wip, nullptr, other_objp);
+				}
+			}
+		} else {
+			if (has_shockwave && sci->speed <= 0.0f) {
+				shockwave_damage *= weapon_get_damage_scale(wip, nullptr, other_objp);
+			}
+		}
+
+		dph += shockwave_damage;
+
+		ai_info *aip = &Ai_info[shipp->ai_index];
+		float effective_dps;
+		float oneshot_value = 0.0f;
+		float relevant_hits_left;
+		if (relevant_shields_left > 0.0f) {
+			relevant_hits_left = relevant_shields_left;
+		} else if (target_subsys) {
+			relevant_hits_left = target_subsys->current_hits;
+		} else {
+			relevant_hits_left = other_objp->hull_strength;
+		}
+		int burst_shots = wip->burst_shots + 1;
+		int effective_burst_shots = std::max(burst_shots, fl2i(shipp->weapon_energy / (wip->energy_consumed * burst_shots)));
+		if (dph * effective_burst_shots >= relevant_hits_left) {
+			oneshot_value = dph * aip->primary_selection_oneshot_modifier;
+		}
+		float fire_rate;
+		if (wip->burst_shots > 1 && wip->burst_flags[Weapon::Burst_Flags::Random_length]) {
+			fire_rate = (wip->burst_shots / (wip->fire_wait + wip->burst_delay * (wip->burst_shots - 1)) + (1 / wip->fire_wait)) / 2;
+		}
+		else if (wip->burst_shots > 1) {
+			fire_rate = wip->burst_shots / (wip->fire_wait + wip->burst_delay * (wip->burst_shots - 1));
+		}
+		else {
+			fire_rate = 1 / wip->fire_wait;
+		}
+		// if fire can't be sustained indefinitely given energy consumption, take the average between max fire rate and fire rate when we're drained and have to wait for each shot
+		if (fire_rate * wip->energy_consumed > (shipp->max_weapon_regen_per_second * sinfop->max_weapon_reserve)) {
+			fire_rate = (fire_rate + ((shipp->max_weapon_regen_per_second * sinfop->max_weapon_reserve) / wip->energy_consumed)) / 2.0f;
+		}
+		effective_dps = (dph * burst_shots) * fire_rate;
 		
+		float weapon_value = std::max(effective_dps, oneshot_value) * aip->primary_selection_random_factor;
+
+
+		//TODO: handle weapon selection flags
+
+
+
+
+
+
+		if (wip_i == swp->current_primary_bank) {
+			weapon_value *= aip->primary_selection_status_quo_bias;
+		}
+		weapon_values.emplace(wip_i, weapon_value);
 	}
+	std::pair<int, float> best_pair = std::make_pair(-1, 0.0f);
+	for (auto pair : weapon_values) {
+		if (std::max(pair.second, 0.0f) >= best_pair.second) {
+			best_pair = pair;
+		}
+	}
+	return best_pair.first;
 }
 
 /**
@@ -15963,6 +16118,10 @@ void init_aip_from_class_and_profile(ai_info *aip, ai_class *aicp, ai_profile_t 
 	aip->ai_get_away_chance = aicp->ai_get_away_chance[Game_skill_level];	
 	aip->ai_secondary_range_mult = aicp->ai_secondary_range_mult[Game_skill_level];
 	aip->ai_class_autoscale = aicp->ai_class_autoscale;
+
+	aip->primary_selection_random_factor = aicp->primary_selection_random_factor;
+	aip->primary_selection_oneshot_modifier = aicp->primary_selection_oneshot_modifier;
+	aip->primary_selection_status_quo_bias = aicp->primary_selection_status_quo_bias;
 
 	//Apply overrides from ai class to ai profiles values
 	//Only override values which were explicitly set in the AI class

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5763,6 +5763,10 @@ std::optional<int> select_primary_setup(ship *shipp, ship *target_shipp, ship_we
 	if (swp->num_primary_banks <= 0)
 		return -1;
 
+	// if we only have one bank to choose from, just short-circuit
+	if (swp->num_primary_banks == 1 && swp->current_primary_bank == 0)
+		return swp->current_primary_bank;
+
 	if (target_shipp)
 	{
 		//if the good-primary-time sexp has been used, return that weapon immediately
@@ -6073,7 +6077,7 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 	
 	SCP_unordered_map<int, float> weapon_values = {};
 
-	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++) {
+	for (int i = 0; i < swp->num_primary_banks; i++) {
 		int wip_i = swp->primary_bank_weapons[i];
 		if (wip_i < 0) {
 			continue;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -677,6 +677,11 @@ void init_ai_class(ai_class *aicp)
 		aicp->ai_evasion[i] = FLT_MIN;
 		aicp->ai_courage[i] = FLT_MIN;
 		aicp->ai_patience[i] = FLT_MIN;
+		aicp->primary_select_delay[i] = ::util::UniformFloatRange(FLT_MIN);
+		aicp->primary_select_delay_on_change[i] = ::util::UniformFloatRange(FLT_MIN);
+		aicp->primary_selection_random_factor[i] = ::util::UniformFloatRange(1.0f);
+		aicp->primary_selection_oneshot_modifier[i] = 2.0f;
+		aicp->primary_selection_status_quo_bias[i] = 1.0f;
 	}
     aicp->ai_profile_flags.reset();
     aicp->ai_profile_flags_set.reset();
@@ -691,11 +696,6 @@ void init_ai_class(ai_class *aicp)
 		aicp->ai_secondary_range_mult[i] = FLT_MIN;
 	}
 	aicp->ai_class_autoscale = true;	//Retail behavior is to do the stupid autoscaling
-	aicp->primary_select_delay = ::util::UniformFloatRange(5.0f);
-	aicp->primary_select_delay_on_change = ::util::UniformFloatRange(FLT_MAX);
-	aicp->primary_selection_random_factor = ::util::UniformFloatRange(1.0f);
-	aicp->primary_selection_oneshot_modifier = 2.0f;
-	aicp->primary_selection_status_quo_bias = 1.0f;
 }
 
 void set_aic_flag(ai_class *aicp, const char *name, AI::Profile_Flags flag)
@@ -801,29 +801,38 @@ void parse_ai_class()
 
 	if (optional_string("$Autoscale by AI Class Index:"))
 		stuff_boolean(&aicp->ai_class_autoscale);
-
-	if (optional_string("$Primary select delay:"))
-		aicp->primary_select_delay = ::util::ParsedRandomFloatRange::parseRandomRange();
-
-	if (optional_string("$Primary select delay on target change:"))
-		aicp->primary_select_delay_on_change = ::util::ParsedRandomFloatRange::parseRandomRange();
-
-	if (optional_string("$Primary selection random factor:"))
-		aicp->primary_selection_random_factor = ::util::ParsedRandomFloatRange::parseRandomRange();
-
-	if (optional_string("$Primary selection oneshot modifier:"))
-		stuff_float(&aicp->primary_selection_oneshot_modifier);
-
-	if (optional_string("$Primary selection status quo bias:"))
-		stuff_float(&aicp->primary_selection_status_quo_bias);
-
+		
 	//Parse optional values for stuff imported from ai_profiles
 	if (optional_string("$AI Countermeasure Firing Chance:"))
-		parse_float_list(aicp->ai_cmeasure_fire_chance, NUM_SKILL_LEVELS);
-
+	parse_float_list(aicp->ai_cmeasure_fire_chance, NUM_SKILL_LEVELS);
+	
 	if (optional_string("$AI In Range Time:"))
-		parse_float_list(aicp->ai_in_range_time, NUM_SKILL_LEVELS);
+	parse_float_list(aicp->ai_in_range_time, NUM_SKILL_LEVELS);
+	
+	if (optional_string("$Primary select delay:")) {
+		for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
+			aicp->primary_select_delay[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+		}
+	}
 
+	if (optional_string("$Primary select delay on target change:")) {
+		for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
+			aicp->primary_select_delay_on_change[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+		}
+	}
+
+	if (optional_string("$Primary selection random factor:")) {
+		for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
+			aicp->primary_selection_random_factor[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+		}
+	}
+
+	if (optional_string("$Primary selection oneshot modifier:"))
+		parse_float_list(aicp->primary_selection_oneshot_modifier, NUM_SKILL_LEVELS);
+
+	if (optional_string("$Primary selection status quo bias:"))
+		parse_float_list(aicp->primary_selection_status_quo_bias, NUM_SKILL_LEVELS);
+		
 	if (optional_string("$AI Always Links Ammo Weapons:"))
 		parse_float_list(aicp->ai_link_ammo_levels_always, NUM_SKILL_LEVELS);
 
@@ -927,8 +936,6 @@ void parse_ai_class()
 		parse_float_list(aicp->ai_turret_max_aim_update_delay, NUM_SKILL_LEVELS);
 
 	set_aic_flag(aicp, "$big ships can attack beam turrets on untargeted ships:", AI::Profile_Flags::Big_ships_can_attack_beam_turrets_on_untargeted_ships);
-
-	set_aic_flag(aicp, "$always do primary select when target change:", AI::Profile_Flags::Always_do_primary_select_when_target_change);
 	
 	set_aic_flag(aicp, "$configurable primary weapon selection:", AI::Profile_Flags::Configurable_primary_weapon_selection);
 
@@ -1652,7 +1659,7 @@ ship_subsys *set_targeted_subsys(ai_info *aip, ship_subsys *new_subsys, int pare
 	}
 	
 	return aip->targeted_subsys;
-}											  
+}
 
 /**
  * Called to init the data for single ai object.  
@@ -16222,12 +16229,9 @@ void init_aip_from_class_and_profile(ai_info *aip, ai_class *aicp, ai_profile_t 
 	aip->ai_secondary_range_mult = aicp->ai_secondary_range_mult[Game_skill_level];
 	aip->ai_class_autoscale = aicp->ai_class_autoscale;
 
-	aip->primary_select_delay = aicp->primary_select_delay;
-	aip->primary_select_delay_on_change = aicp->primary_select_delay_on_change;
-
-	aip->primary_selection_random_factor = aicp->primary_selection_random_factor;
-	aip->primary_selection_oneshot_modifier = aicp->primary_selection_oneshot_modifier;
-	aip->primary_selection_status_quo_bias = aicp->primary_selection_status_quo_bias;
+	aip->primary_selection_random_factor = aicp->primary_selection_random_factor[Game_skill_level];
+	aip->primary_selection_oneshot_modifier = aicp->primary_selection_oneshot_modifier[Game_skill_level];
+	aip->primary_selection_status_quo_bias = aicp->primary_selection_status_quo_bias[Game_skill_level];
 
 	//Apply overrides from ai class to ai profiles values
 	//Only override values which were explicitly set in the AI class
@@ -16277,6 +16281,10 @@ void init_aip_from_class_and_profile(ai_info *aip, ai_class *aicp, ai_profile_t 
 		profile->max_aim_update_delay[Game_skill_level] : aicp->ai_max_aim_update_delay[Game_skill_level];
 	aip->ai_turret_max_aim_update_delay = (aicp->ai_turret_max_aim_update_delay[Game_skill_level] == FLT_MIN) ? 
 		profile->turret_max_aim_update_delay[Game_skill_level] : aicp->ai_turret_max_aim_update_delay[Game_skill_level];
+	aip->primary_select_delay = (aicp->primary_select_delay[Game_skill_level].min() == FLT_MIN && aicp->primary_select_delay[Game_skill_level].max() == FLT_MIN) ?
+		profile->primary_select_delay[Game_skill_level] :  aicp->primary_select_delay[Game_skill_level];
+	aip->primary_select_delay_on_change = (aicp->primary_select_delay_on_change[Game_skill_level].min() == FLT_MIN && aicp->primary_select_delay_on_change[Game_skill_level].max() == FLT_MIN) ?
+		profile->primary_select_delay_on_change[Game_skill_level] :  aicp->primary_select_delay_on_change[Game_skill_level];
 
 	//Combine AI profile and AI class flags
     aip->ai_profile_flags = profile->flags | (aicp->ai_profile_flags & aicp->ai_profile_flags_set);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -804,26 +804,26 @@ void parse_ai_class()
 		
 	//Parse optional values for stuff imported from ai_profiles
 	if (optional_string("$AI Countermeasure Firing Chance:"))
-	parse_float_list(aicp->ai_cmeasure_fire_chance, NUM_SKILL_LEVELS);
+		parse_float_list(aicp->ai_cmeasure_fire_chance, NUM_SKILL_LEVELS);
 	
 	if (optional_string("$AI In Range Time:"))
-	parse_float_list(aicp->ai_in_range_time, NUM_SKILL_LEVELS);
+		parse_float_list(aicp->ai_in_range_time, NUM_SKILL_LEVELS);
 	
 	if (optional_string("$Primary select delay:")) {
-		for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
-			aicp->primary_select_delay[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+		for (auto& entry : aicp->primary_select_delay)  {
+			entry = ::util::ParsedRandomFloatRange::parseRandomRange();
 		}
 	}
 
 	if (optional_string("$Primary select delay on target change:")) {
-		for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
-			aicp->primary_select_delay_on_change[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+		for (auto& entry : aicp->primary_select_delay_on_change) {
+			entry = ::util::ParsedRandomFloatRange::parseRandomRange();
 		}
 	}
 
 	if (optional_string("$Primary selection random factor:")) {
-		for (int i = 0; i < NUM_SKILL_LEVELS; i++) {
-			aicp->primary_selection_random_factor[i] = ::util::ParsedRandomFloatRange::parseRandomRange();
+		for (auto& entry : aicp->primary_selection_random_factor) {
+			entry = ::util::ParsedRandomFloatRange::parseRandomRange();
 		}
 	}
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5747,7 +5747,7 @@ static int ai_select_primary_weapon_OLD(const object *objp, Weapon::Info_Flags f
 	return swp->current_primary_bank;
 }
 
-std::optional<int> select_primary_setup(ship *shipp, ship *other_shipp, ship_weapon *swp, object *other_objp)
+std::optional<int> select_primary_setup(ship *shipp, ship *target_shipp, ship_weapon *swp, object *other_objp)
 {
 	// Debugging
 	if (other_objp==NULL)
@@ -5763,18 +5763,14 @@ std::optional<int> select_primary_setup(ship *shipp, ship *other_shipp, ship_wea
 	if (swp->num_primary_banks <= 0)
 		return -1;
 
-	bool other_is_ship = (other_objp->type == OBJ_SHIP);
-
-	if (other_is_ship)
+	if (target_shipp)
 	{
-		other_shipp = &Ships[other_objp->instance];
-
 		//if the good-primary-time sexp has been used, return that weapon immediately
 		//if smart primary weapon selection isn't set, turning this override behavior off might not do anything
 		//however this seems acceptable
 		for (const auto &ppi : Preferred_primary_info)
 		{
-			if (ppi.subject.matches(shipp) && ppi.target.matches(other_shipp))
+			if (ppi.subject.matches(shipp) && ppi.target.matches(target_shipp))
 			{
 				int weapon_idx = ppi.weapon_index;
 
@@ -5824,6 +5820,10 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 	ship	*shipp = &Ships[objp->instance];
 	ship	*other_shipp = nullptr;
 	ship_weapon *swp = &shipp->weapons;
+
+	if (other_objp->type == OBJ_SHIP) {
+		other_shipp = &Ships[other_objp->instance];
+	}
 
 	auto early_return_value = select_primary_setup(shipp, other_shipp, swp, other_objp);
 	if (early_return_value.has_value()) {
@@ -6032,6 +6032,10 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 	ship_weapon *swp = &shipp->weapons;
 	ship_info *sinfop = &Ship_info[shipp->ship_info_index];
 
+	if (other_objp->type == OBJ_SHIP) {
+		target_shipp = &Ships[other_objp->instance];
+	}
+
 	//if we're not using configurable, use the previous version of this function instead.
 	if (!(Ai_info[shipp->ai_index].ai_profile_flags[AI::Profile_Flags::Configurable_primary_weapon_selection]))
 	{
@@ -6048,7 +6052,10 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 	bool has_shockwave;
 	bool is_beam;
 
-	ship_subsys *target_subsys = Ai_info[shipp->ai_index].targeted_subsys;
+	ship_subsys *target_subsys = nullptr;
+	if (Ai_info[shipp->ai_index].targeted_subsys) {
+		target_subsys = Ai_info[shipp->ai_index].targeted_subsys;
+	}
 	int relevant_armor_type_idx = -1;
 	int relevant_ship_type_idx = -1;
 	int relevant_ship_class_idx = -1;
@@ -6059,14 +6066,14 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 		vm_vec_sub2(&ship_local_pos, &other_objp->pos);
 		vm_vec_rotate(&ship_local_pos, &ship_local_pos, &other_objp->orient);
 		int relevant_quadrant = get_quadrant(&ship_local_pos, other_objp);
-		if (relevant_quadrant > 0 && relevant_quadrant < sz2i(other_objp->shield_quadrant.size())) {
+		if (relevant_quadrant >= 0 && relevant_quadrant < sz2i(other_objp->shield_quadrant.size())) {
 			relevant_shields_left = shield_get_quad(other_objp, relevant_quadrant) - ship_shield_hitpoint_threshold(other_objp, false);
 		}
 	}
 	
 	SCP_unordered_map<int, float> weapon_values = {};
 
-	for (int i; i < MAX_SHIP_PRIMARY_BANKS; i++) {
+	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++) {
 		int wip_i = swp->primary_bank_weapons[i];
 		if (wip_i < 0) {
 			continue;
@@ -6082,27 +6089,30 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 			shockwave_damage = sci->damage;
 		}
 
-		if (target_shipp) {
+		if (target_shipp != nullptr) {
 			relevant_ship_type_idx = Ship_info[target_shipp->ship_info_index].class_type;
 			relevant_ship_class_idx = target_shipp->ship_info_index;
 			if (relevant_shields_left > 0.0f) {
 				damage_scale = weapon_get_damage_scale(wip, nullptr, other_objp);
 				dph *= damage_scale;
 				relevant_armor_type_idx = target_shipp->shield_armor_type_idx;
-				dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+				if (relevant_armor_type_idx >= 0) {
+					dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+				}
 				if (!is_beam || Beams_use_damage_factors) {
 					dph *= wip->shield_factor;
 				}
-			} else if (target_subsys) {
+			} else if (target_subsys != nullptr) {
 				if (!is_beam || Beams_use_damage_factors) {
-					relevant_armor_type_idx = target_subsys->armor_type_idx;
 					if (target_subsys->flags[Ship::Subsystem_Flags::Damage_as_hull]) {
 						dph *= wip->armor_factor;
-						dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
 					} else {
 						dph *= wip->subsystem_factor;
-						dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
 					}
+				}
+				relevant_armor_type_idx = target_subsys->armor_type_idx;
+				if (relevant_armor_type_idx >= 0) {
+					dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
 				}
 			} else {
 				if (damage_scale == -1.0f) {
@@ -6110,7 +6120,9 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 				}
 				dph *= damage_scale;
 				relevant_armor_type_idx = target_shipp->armor_type_idx;
-				dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+				if (relevant_armor_type_idx >= 0) {
+					dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+				}
 				if (!is_beam || Beams_use_damage_factors) {
 					if (wip->wi_flags[Weapon::Info_Flags::Puncture]) {
 							dph /= 4;
@@ -6126,12 +6138,8 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 					}
 					shockwave_damage *= damage_scale;
 				}
-				if (relevant_shields_left) {
-					shockwave_damage = Armor_types[target_shipp->shield_armor_type_idx].GetDamage(shockwave_damage, sci->damage_type_idx, 1.0, is_beam);
-				} else if (target_subsys) {
-					shockwave_damage = Armor_types[target_subsys->armor_type_idx].GetDamage(shockwave_damage, sci->damage_type_idx, 1.0, is_beam);
-				} else {
-					shockwave_damage = Armor_types[target_shipp->armor_type_idx].GetDamage(shockwave_damage, sci->damage_type_idx, 1.0, is_beam);
+				if (relevant_armor_type_idx >= 0) {
+					shockwave_damage = Armor_types[relevant_armor_type_idx].GetDamage(shockwave_damage, sci->damage_type_idx, 1.0, is_beam);
 				}
 			}
 		} else if ( other_objp->type == OBJ_WEAPON ) {
@@ -6223,10 +6231,10 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 			weapon_value *= armor_flags[relevant_weapon_class_idx];
 		}
 
-		if (wip_i == swp->current_primary_bank) {
+		if (i == swp->current_primary_bank) {
 			weapon_value *= aip->primary_selection_status_quo_bias;
 		}
-		weapon_values.emplace(wip_i, weapon_value);
+		weapon_values.emplace(i, weapon_value);
 	}
 	std::pair<int, float> best_pair = std::make_pair(-1, 0.0f);
 	for (auto pair : weapon_values) {
@@ -6234,6 +6242,7 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 			best_pair = pair;
 		}
 	}
+	swp->current_primary_bank = best_pair.first;
 	return best_pair.first;
 }
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -919,6 +919,8 @@ void parse_ai_class()
 		parse_float_list(aicp->ai_turret_max_aim_update_delay, NUM_SKILL_LEVELS);
 
 	set_aic_flag(aicp, "$big ships can attack beam turrets on untargeted ships:", AI::Profile_Flags::Big_ships_can_attack_beam_turrets_on_untargeted_ships);
+	
+	set_aic_flag(aicp, "$configurable primary weapon selection:", AI::Profile_Flags::Configurable_primary_weapon_selection);
 
 	set_aic_flag(aicp, "$smart primary weapon selection:", AI::Profile_Flags::Smart_primary_weapon_selection);
 
@@ -1594,6 +1596,8 @@ int set_target_objnum(ai_info *aip, int objnum)
 
 int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flags flags);
 
+int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weapon::Info_Flags flags);
+
 /**
  * Make new_subsys the targeted subsystem of ship *aip.
  */
@@ -1610,7 +1614,7 @@ ship_subsys *set_targeted_subsys(ai_info *aip, ship_subsys *new_subsys, int pare
 		if (new_subsys->system_info->type == SUBSYSTEM_ENGINE) {
 			if ( aip != Player_ai ) {
 				Assert( aip->shipnum >= 0 );
-				ai_select_primary_weapon(&Objects[Ships[aip->shipnum].objnum], &Objects[parent_objnum], Weapon::Info_Flags::Puncture);
+				ai_select_primary_weapon_configurable(&Objects[Ships[aip->shipnum].objnum], &Objects[parent_objnum], Weapon::Info_Flags::Puncture);
 				ship_primary_changed(&Ships[aip->shipnum]);	// AL: maybe send multiplayer information when AI ship changes primaries
 			}
 		}
@@ -5817,7 +5821,6 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 		return early_return_value.value();
 	}
 
-
 	//not using the new AI, use the old version of this function instead.
 	if (!(Ai_info[shipp->ai_index].ai_profile_flags[AI::Profile_Flags::Smart_primary_weapon_selection]))
 	{
@@ -6020,6 +6023,12 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 	ship_weapon *swp = &shipp->weapons;
 	ship_info *sinfop = &Ship_info[shipp->ship_info_index];
 
+	//if we're not using configurable, use the previous version of this function instead.
+	if (!(Ai_info[shipp->ai_index].ai_profile_flags[AI::Profile_Flags::Configurable_primary_weapon_selection]))
+	{
+		return ai_select_primary_weapon(objp, other_objp, flags);
+	}
+
 	auto early_return_value = select_primary_setup(shipp, target_shipp, swp, other_objp);
 	if (early_return_value.has_value()) {
 		return early_return_value.value();
@@ -6031,7 +6040,11 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 	bool is_beam;
 
 	ship_subsys *target_subsys = Ai_info[shipp->ai_index].targeted_subsys;
-	float relevant_shields_left = 100.0f;
+	float relevant_shields_left = 100.0f; //TODO: get shield quadrant stuff
+	int relevant_armor_type_idx = -1;
+	int relevant_ship_type_idx = -1;
+	int relevant_ship_class_idx = -1;
+	int relevant_weapon_class_idx = -1;
 
 	SCP_unordered_map<int, float> weapon_values = {};
 
@@ -6054,21 +6067,25 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 
 
 		if (target_shipp) {
+			relevant_ship_type_idx = Ship_info[target_shipp->ship_info_index].class_type;
+			relevant_ship_class_idx = target_shipp->ship_info_index;
 			if (relevant_shields_left > 0.0f) {
 				damage_scale = weapon_get_damage_scale(wip, nullptr, other_objp);
 				dph *= damage_scale;
-				dph = Armor_types[target_shipp->shield_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+				relevant_armor_type_idx = target_shipp->shield_armor_type_idx;
+				dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
 				if (!is_beam || Beams_use_damage_factors) {
 					dph *= wip->shield_factor;
 				}
 			} else if (target_subsys) {
 				if (!is_beam || Beams_use_damage_factors) {
+					relevant_armor_type_idx = target_subsys->armor_type_idx;
 					if (target_subsys->flags[Ship::Subsystem_Flags::Damage_as_hull]) {
 						dph *= wip->armor_factor;
-						dph = Armor_types[target_subsys->armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+						dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
 					} else {
 						dph *= wip->subsystem_factor;
-						dph = Armor_types[target_subsys->armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+						dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
 					}
 				}
 			} else {
@@ -6076,7 +6093,8 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 					damage_scale = weapon_get_damage_scale(wip, nullptr, other_objp);
 				}
 				dph *= damage_scale;
-				dph = Armor_types[target_shipp->armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+				relevant_armor_type_idx = target_shipp->armor_type_idx;
+				dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
 				if (!is_beam || Beams_use_damage_factors) {
 					if (wip->wi_flags[Weapon::Info_Flags::Puncture]) {
 							dph /= 4;
@@ -6101,10 +6119,12 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 				}
 			}
 		} else if ( other_objp->type == OBJ_WEAPON ) {
-			ArmorType *weapon_armor = &Armor_types[Weapon_info[Weapons[other_objp->instance].weapon_info_index].armor_type_idx];
-			dph = weapon_armor->GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
+			weapon *target_weapon = &Weapons[other_objp->instance];
+			relevant_armor_type_idx = Weapon_info[target_weapon->weapon_info_index].armor_type_idx;
+			relevant_weapon_class_idx = target_weapon->weapon_info_index;
+			dph = Armor_types[relevant_armor_type_idx].GetDamage(dph, wip->damage_type_idx, 1.0, is_beam);
 			if (has_shockwave) {
-				shockwave_damage = weapon_armor->GetDamage(dph, sci->damage_type_idx, 1.0, is_beam);
+				shockwave_damage = Armor_types[relevant_armor_type_idx].GetDamage(dph, sci->damage_type_idx, 1.0, is_beam);
 				if (sci->speed <= 0.0f) {
 					shockwave_damage *= weapon_get_damage_scale(wip, nullptr, other_objp);
 				}
@@ -6116,6 +6136,8 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 		}
 
 		dph += shockwave_damage;
+
+		//TODO: decide whether to take $Shots (/$Cycle_multishot) into account
 
 		ai_info *aip = &Ai_info[shipp->ai_index];
 		float effective_dps;
@@ -6151,13 +6173,23 @@ int ai_select_primary_weapon_configurable(object *objp, object *other_objp, Weap
 		
 		float weapon_value = std::max(effective_dps, oneshot_value) * aip->primary_selection_random_factor;
 
+		SCP_unordered_map<int, float> armor_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR];
+		SCP_unordered_map<int, float> shiptype_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_TYPE];
+		SCP_unordered_map<int, float> shipclass_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_CLASS];
+		SCP_unordered_map<int, float> weaponclass_flags = wip->primary_selection_target_flags[PrimarySelectionTargetType::WEAPON_CLASS];
 
-		//TODO: handle weapon selection flags
-
-
-
-
-
+		if (relevant_armor_type_idx >= 0 && armor_flags.contains(relevant_armor_type_idx)) {
+			weapon_value *= armor_flags[relevant_armor_type_idx];
+		}
+		if (relevant_ship_type_idx >= 0 && shiptype_flags.contains(relevant_ship_type_idx)) {
+			weapon_value *= armor_flags[relevant_ship_type_idx];
+		}
+		if (relevant_ship_class_idx >= 0 && shipclass_flags.contains(relevant_ship_class_idx)) {
+			weapon_value *= armor_flags[relevant_ship_class_idx];
+		}
+		if (relevant_weapon_class_idx >= 0 && weaponclass_flags.contains(relevant_weapon_class_idx)) {
+			weapon_value *= armor_flags[relevant_weapon_class_idx];
+		}
 
 		if (wip_i == swp->current_primary_bank) {
 			weapon_value *= aip->primary_selection_status_quo_bias;
@@ -6490,7 +6522,7 @@ int ai_fire_primary_weapon(object *objp)
 		if ( aip->targeted_subsys != NULL ) {
 			flags = Weapon::Info_Flags::Puncture;
 		}
-		ai_select_primary_weapon(objp, enemy_objp, flags);
+		ai_select_primary_weapon_configurable(objp, enemy_objp, flags);
 		ship_primary_changed(shipp);	// AL: maybe send multiplayer information when AI ship changes primaries
 		aip->primary_select_timestamp = timestamp(5 * MILLISECONDS_PER_SECOND);	//	Maybe change primary weapon five seconds from now.
 	}

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6601,7 +6601,7 @@ int ai_fire_primary_weapon(object *objp)
 		}
 		ai_select_primary_weapon_configurable(objp, enemy_objp, flags, relevant_shields_left);
 		ship_primary_changed(shipp);	// AL: maybe send multiplayer information when AI ship changes primaries
-		aip->primary_select_timestamp = timestamp(aip->primary_select_delay.next() * MILLISECONDS_PER_SECOND);	//	Maybe change primary weapon in a while (five seconds by default).
+		aip->primary_select_timestamp = timestamp(fl2i(aip->primary_select_delay.next() * i2fl(MILLISECONDS_PER_SECOND)));	//	Maybe change primary weapon in a while (five seconds by default).
 	}
 
 	// if the ship has no primary weapon selected, whether because it has no primary banks or because no bank contains a weapon, then there is nothing to fire

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -15,6 +15,7 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/flagset.h"
 #include "gamesnd/gamesnd.h"
+#include "ship/ship.h"
 
 class object;
 struct CFILE;

--- a/code/decals/decals.h
+++ b/code/decals/decals.h
@@ -7,6 +7,8 @@
 #include "utils/RandomRange.h"
 #include "utils/reset_on_move.h"
 
+class ship;
+
 namespace decals {
 
 class DecalDefinition {

--- a/code/graphics/openxr.cpp
+++ b/code/graphics/openxr.cpp
@@ -6,6 +6,7 @@
 #include "mod_table/mod_table.h"
 #include "render/3d.h"
 #include "starfield/starfield.h"
+#include "hud/hudparse.h"
 
 std::unique_ptr<star[]> Stars_XRBuffer;
 

--- a/code/lab/dialogs/lab_ui.h
+++ b/code/lab/dialogs/lab_ui.h
@@ -3,6 +3,7 @@
 #include "model/model.h"
 #include "model/animation/modelanimation.h"
 #include "species_defs/species_defs.h"
+#include "weapon/weapon.h"
 
 enum class LabTurretAimType {
 	RANDOM,

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -12,7 +12,9 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/systemvars.h"
 #include "graphics/2d.h"
-#include "hud/hudtarget.h"
+#include "globalincs/version.h"
+
+enum class leadIndicatorBehavior;
 
 // Typedef for Overhead View styles
 typedef enum {

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -948,7 +948,7 @@ int get_quadrant(const vec3d *hit_pnt, const object *shipobjp)
 		float closest_dist = FLT_MAX;
 
 		for (unsigned int i=0; i<Ships[shipobjp->instance].shield_points.size(); i++) {
-			float dist = vm_vec_dist(hit_pnt, &Ships[shipobjp->instance].shield_points.at(i));
+			float dist = vm_vec_dist_squared(hit_pnt, &Ships[shipobjp->instance].shield_points.at(i));
 
 			if (dist < closest_dist) {
 				closest = i;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -720,6 +720,15 @@ struct weapon_info
 
 	animation::ModelAnimationSet animations;
 
+	enum class PrimarySelectionTargetType {
+		ARMOR,
+		SHIP_TYPE,
+		SHIP_CLASS,
+		WEAPON_CLASS,
+	};
+
+	std::array<SCP_unordered_map<int, float>, 4> primary_selection_target_flags;
+
 	enum class WeaponLaunchCurveOutputs {
 		// outputs
 		FIRE_WAIT_MULT,

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -372,6 +372,15 @@ struct WeaponLaunchCurveData {
 	float target_radius;
 };
 
+enum PrimarySelectionTargetType {
+	ARMOR,
+	SHIP_TYPE,
+	SHIP_CLASS,
+	WEAPON_CLASS,
+
+	MAX,
+};
+
 struct weapon_info;
 extern SCP_vector<weapon_info> Weapon_info;
 
@@ -720,14 +729,7 @@ struct weapon_info
 
 	animation::ModelAnimationSet animations;
 
-	enum class PrimarySelectionTargetType {
-		ARMOR,
-		SHIP_TYPE,
-		SHIP_CLASS,
-		WEAPON_CLASS,
-	};
-
-	std::array<SCP_unordered_map<int, float>, 4> primary_selection_target_flags;
+	std::array<SCP_unordered_map<int, float>, PrimarySelectionTargetType::MAX> primary_selection_target_flags;
 
 	enum class WeaponLaunchCurveOutputs {
 		// outputs

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4396,7 +4396,7 @@ void populate_primary_selection_flags()
 {
 	for (int i = 0; i < sz2i(Weapon_info.size()); i++) {
 		weapon_info *wip = &Weapon_info[i];
-		for (int flavor; flavor < PrimarySelectionTargetType::MAX; flavor++) {
+		for (int flavor = 0; flavor < PrimarySelectionTargetType::MAX; flavor++) {
 			for (auto& [index_name, mult] : primary_selection_target_flags_temp[i][flavor]) {
 				int index;
 				switch (flavor) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2126,6 +2126,32 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if (optional_string("$Disallow Support Rearm:")) {
 		stuff_boolean(&wip->disallow_rearm);
 	}
+	
+	if (optional_string("$Primary Selection Target Flags:")) {
+		SCP_string type;
+		int instance_index;
+		float value;
+		while (optional_string("+")) {
+			stuff_string(type, F_NAME);
+			if (type == "ARMOR:") {
+				stuff_string(fname, F_NAME, NAME_LENGTH);
+				instance_index = armor_type_get_idx(fname);
+				stuff_float(&value);
+				wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR].emplace(instance_index, value);
+			} else if (type == "SHIP_TYPE:") {
+				stuff_string(fname, F_NAME, NAME_LENGTH);
+				instance_index = ship_type_name_lookup(fname);
+				stuff_float(&value);
+				wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR].emplace(instance_index, value);
+			} else if (type == "SHIP_CLASS:") {
+
+			} else if (type == "WEAPON_CLASS:") {
+
+			} else {
+
+			}
+		}
+	}
 	   
 	if (optional_string("+Weapon Range:")) {
 		stuff_float(&wip->weapon_range);
@@ -9053,36 +9079,37 @@ void weapon_get_laser_color(color *c, object *objp)
  */
 float weapon_get_damage_scale(const weapon_info *wip, const object *wep, const object *target)
 {
-	weapon *wp;	
-	int from_player = 0;
 	float total_scale = 1.0f;
 	float hull_pct;
 	int is_big_damage_ship = 0;
-
+	
 	// Goober5000 - additional sanity (target can be NULL)
 	Assert(wip);
-	Assert(wep);
-
+	
 	// sanity
-	if((wip == NULL) || (wep == NULL) || (target == NULL)){
+	if((wip == nullptr) || (target == nullptr)){
 		return 1.0f;
 	}
-
-	// don't scale any damage if its not a weapon	
-	if((wep->type != OBJ_WEAPON) || (wep->instance < 0) || (wep->instance >= MAX_WEAPONS)){
-		return 1.0f;
-	}
-	wp = &Weapons[wep->instance];
-
-	// was the weapon fired by the player
-	from_player = 0;
-	if((wep->parent >= 0) && (wep->parent < MAX_OBJECTS) && (Objects[wep->parent].flags[Object::Object_Flags::Player_ship])){
-		from_player = 1;
-	}
-		
-	// if this is a lockarm weapon, and it was fired unlocked
-	if((wip->wi_flags[Weapon::Info_Flags::Lockarm]) && !(wp->weapon_flags[Weapon::Weapon_Flags::Locked_when_fired])){		
-		total_scale *= 0.1f;
+	
+	int from_player = 0;
+	if (wep) {
+		weapon *wp;	
+		// don't scale any damage if its not a weapon	
+		if((wep->type != OBJ_WEAPON) || (wep->instance < 0) || (wep->instance >= MAX_WEAPONS)){
+			return 1.0f;
+		}
+		wp = &Weapons[wep->instance];
+	
+		// was the weapon fired by the player
+		from_player = 0;
+		if((wep->parent >= 0) && (wep->parent < MAX_OBJECTS) && (Objects[wep->parent].flags[Object::Object_Flags::Player_ship])){
+			from_player = 1;
+		}
+			
+		// if this is a lockarm weapon, and it was fired unlocked
+		if((wip->wi_flags[Weapon::Info_Flags::Lockarm]) && !(wp->weapon_flags[Weapon::Weapon_Flags::Locked_when_fired])){		
+			total_scale *= 0.1f;
+		}
 	}
 	
 	// if the hit object was a ship and we're doing damage scaling

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2133,22 +2133,34 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		float value;
 		while (optional_string("+")) {
 			stuff_string(type, F_NAME);
+			stuff_string(fname, F_NAME, NAME_LENGTH);
+			stuff_float(&value);
 			if (type == "ARMOR:") {
-				stuff_string(fname, F_NAME, NAME_LENGTH);
 				instance_index = armor_type_get_idx(fname);
-				stuff_float(&value);
+				if (instance_index < 0) {
+					error_display(0, "Weapon '%s', primary selection target flags: '%s' is not a valid armor type!\n", wip->name, fname);
+				}
 				wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR].emplace(instance_index, value);
 			} else if (type == "SHIP_TYPE:") {
-				stuff_string(fname, F_NAME, NAME_LENGTH);
 				instance_index = ship_type_name_lookup(fname);
-				stuff_float(&value);
-				wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR].emplace(instance_index, value);
+				if (instance_index < 0) {
+					error_display(0, "Weapon '%s', primary selection target flags: '%s' is not a valid ship type!\n", wip->name, fname);
+				}
+				wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_TYPE].emplace(instance_index, value);
 			} else if (type == "SHIP_CLASS:") {
-
+				instance_index = ship_info_lookup(fname);
+				if (instance_index < 0) {
+					error_display(0, "Weapon '%s', primary selection target flags: '%s' is not a valid ship class!\n", wip->name, fname);
+				}
+				wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_CLASS].emplace(instance_index, value);
 			} else if (type == "WEAPON_CLASS:") {
-
+				instance_index = weapon_info_lookup(fname);
+				if (instance_index < 0) {
+					error_display(0, "Weapon '%s', primary selection target flags: '%s' is not a valid weapon class!\n", wip->name, fname);
+				}
+				wip->primary_selection_target_flags[PrimarySelectionTargetType::WEAPON_CLASS].emplace(instance_index, value);
 			} else {
-
+				error_display(0, "Invalid primary selection target flag type '%s' in weapon '%s'!", type.c_str(), wip->name);
 			}
 		}
 	}
@@ -10172,6 +10184,10 @@ void weapon_info::reset()
 
 	// Reset using default constructor
 	this->impact_decal = decals::creation_info();
+
+	for (i = 0; i < PrimarySelectionTargetType::MAX; i++) {
+		this->primary_selection_target_flags[i] = {};
+	}
 
 	this->on_create_program = actions::ProgramSet();
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -773,6 +773,8 @@ static particle::ParticleEffectHandle convertLegacyPspewBuffer(const pspew_legac
 			hasAnim ? bm_load_either(pspew_buffer.particle_spew_anim.c_str()) : particle::Anim_bitmap_id_smoke)); //Bitmap or Anim
 }
 
+SCP_unordered_map<int, std::array<SCP_unordered_map<SCP_string, float>, PrimarySelectionTargetType::MAX>> primary_selection_target_flags_temp;
+
 /**
  * Parse the information for a specific ship type.
  * Return weapon index if successful, otherwise return -1
@@ -2128,37 +2130,27 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 	
 	if (optional_string("$Primary Selection Target Flags:")) {
+		const int wi_index = static_cast<int>(wip - Weapon_info.data());
 		SCP_string type;
-		int instance_index;
+		SCP_string type_name;
 		float value;
-		while (optional_string("+")) {
+		for (int i = 0; i < PrimarySelectionTargetType::MAX; i++) {
+			primary_selection_target_flags_temp[i] = {};
+		}
+		while (optional_string("+Condition Type:")) {
 			stuff_string(type, F_NAME);
-			stuff_string(fname, F_NAME, NAME_LENGTH);
+			required_string("+Target Class:");
+			stuff_string(type_name, F_NAME);
+			required_string("+Value Multiplier:");
 			stuff_float(&value);
-			if (type == "ARMOR:") {
-				instance_index = armor_type_get_idx(fname);
-				if (instance_index < 0) {
-					error_display(0, "Weapon '%s', primary selection target flags: '%s' is not a valid armor type!\n", wip->name, fname);
-				}
-				wip->primary_selection_target_flags[PrimarySelectionTargetType::ARMOR].emplace(instance_index, value);
-			} else if (type == "SHIP_TYPE:") {
-				instance_index = ship_type_name_lookup(fname);
-				if (instance_index < 0) {
-					error_display(0, "Weapon '%s', primary selection target flags: '%s' is not a valid ship type!\n", wip->name, fname);
-				}
-				wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_TYPE].emplace(instance_index, value);
-			} else if (type == "SHIP_CLASS:") {
-				instance_index = ship_info_lookup(fname);
-				if (instance_index < 0) {
-					error_display(0, "Weapon '%s', primary selection target flags: '%s' is not a valid ship class!\n", wip->name, fname);
-				}
-				wip->primary_selection_target_flags[PrimarySelectionTargetType::SHIP_CLASS].emplace(instance_index, value);
-			} else if (type == "WEAPON_CLASS:") {
-				instance_index = weapon_info_lookup(fname);
-				if (instance_index < 0) {
-					error_display(0, "Weapon '%s', primary selection target flags: '%s' is not a valid weapon class!\n", wip->name, fname);
-				}
-				wip->primary_selection_target_flags[PrimarySelectionTargetType::WEAPON_CLASS].emplace(instance_index, value);
+			if (type == "ARMOR") {
+				primary_selection_target_flags_temp[wi_index][PrimarySelectionTargetType::ARMOR].emplace(type_name, value);
+			} else if (type == "SHIP TYPE") {
+				primary_selection_target_flags_temp[wi_index][PrimarySelectionTargetType::SHIP_TYPE].emplace(type_name, value);
+			} else if (type == "SHIP CLASS") {
+				primary_selection_target_flags_temp[wi_index][PrimarySelectionTargetType::SHIP_CLASS].emplace(type_name, value);
+			} else if (type == "WEAPON CLASS") {
+				primary_selection_target_flags_temp[wi_index][PrimarySelectionTargetType::WEAPON_CLASS].emplace(type_name, value);
 			} else {
 				error_display(0, "Invalid primary selection target flag type '%s' in weapon '%s'!", type.c_str(), wip->name);
 			}
@@ -4400,6 +4392,34 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	return w_id;
 }
 
+void populate_primary_selection_flags()
+{
+	for (int i = 0; i < sz2i(Weapon_info.size()); i++) {
+		weapon_info *wip = &Weapon_info[i];
+		for (int flavor; flavor < PrimarySelectionTargetType::MAX; flavor++) {
+			for (auto& [index_name, mult] : primary_selection_target_flags_temp[i][flavor]) {
+				int index;
+				switch (flavor) {
+					case PrimarySelectionTargetType::ARMOR:
+						index = armor_type_get_idx(index_name.c_str());
+						break;
+					case PrimarySelectionTargetType::SHIP_TYPE:
+						index = ship_type_name_lookup(index_name.c_str());
+						break;
+					case PrimarySelectionTargetType::SHIP_CLASS:
+						index = ship_info_lookup(index_name.c_str());
+						break;
+					case PrimarySelectionTargetType::WEAPON_CLASS:
+						index = weapon_info_lookup(index_name.c_str());
+						break;
+				}
+				wip->primary_selection_target_flags[flavor].emplace(index, mult);
+			}
+		}
+	}
+	primary_selection_target_flags_temp.clear();
+}
+
 /**
  * For all weapons that spawn weapons, given an index at weaponp->spawn_type,
  * convert the strings in Spawn_names to indices in the Weapon_types array.
@@ -5162,7 +5182,7 @@ void weapon_do_post_parse()
 	translate_spawn_types();
 }
 
-// Called after ship_init() to resolve proximity ship type/class names into indices.
+// Called after ship_init() to resolve proximity ship type/class names into indices, as well as doing the same for primary selection flags.
 void weapon_post_ship_init()
 {
 	const int num_weapons = static_cast<int>(Weapon_info.size());
@@ -5195,6 +5215,8 @@ void weapon_post_ship_init()
 
 	Pending_proximity_type_names.clear();
 	Pending_proximity_class_names.clear();
+
+	populate_primary_selection_flags();
 }
 
 /**


### PR DESCRIPTION
The current primary weapon selection logic for the AI is a complicated set of hardcoded rules from eighteen years ago, and does not take into account many major changes to damage calculations since then. This PR introduces a new system, gated behind an AI_profiles flag like the previous iteration, which is intended to be elegant, comprehensive, and easily configurable by the modder.

The function goes through all available primary weapons and determines their damage per hit against the current target (shields, subsystem, or hull, depending on what the ship has targeted and whether the facing shield quadrant is up or down), taking into account as much of the damage calculation logic as was feasible. The biggest shortcoming here is the weapon hit curves: those assume that we have a weapon object, which at decision time we just don't, so I wasn't able to take them into account.

Next, we calculate the DPS, taking into account rate of fire, bursts, multishot, and energy consumption. There's some additional logic to check whether the weapon will kill the target in one shot (or one burst), and, if so, to give it some extra value in accordance with an AI class parameter.

The biggest limitation at this stage is consideration of weapon accuracy. Because projectile hit chance depends on target maneuvering choices, and target maneuvering choices will often depend on player input (either because the target is the player, or because it's reacting to the player), it is strictly impossible for us to perfectly calculate hit chance. Approximation is possible, but very difficult, and in practice would require hardcoding lots of assumptions, which I dislike doing, or exposing those assumptions to the modder, which would get very messy. So, at least for the moment, accuracy is disregarded and the function assumes that every projectile fired by the weapon will connect.

These limitations can be compensated for, when necessary, using the primary selection target flags system. I'm open to alternative naming suggestions, since 'flags' are really not quite what these are. For a given weapon, the modder may specify a set of modifiers to be activated under certain conditions, and multiply the weapon's value by a specified factor. A condition may be an armor type, a ship type, a ship class, or a weapon class. For example, the modder might give a heavy cannon a multiplier of 100 when used against cruisers, to ensure this weapon will always be used against those targets when available. Conversely, a multiplier of 0 will totally forbid use of the weapon against the target. Note that the traditional ad-hoc flags that controlled use of weapons against certain targets -- like the `Huge` flag forbidding use of the weapon against fighters -- are totally ignored by this system, except insofar as they affect damage.

Once we have the effective DPS and we've applied all the modifiers, we just take the weapon with the highest value.

I considered adding a set of modular curves to modify the final weapon value, or possibly other parts of the calculation, over inputs like target radius, target speed, distance to target, etc. I may still do that in the future, but at the moment I'm really not sure it would add much. The flags can be very granular if you want them to be, and the kind of dynamic attribute changes that would demand curves tend to change quickly enough that weapon-swapping isn't very useful anyway.

I also introduced a couple of AI parameters to provide more control over when the AI tries to choose a new primary -- a parameter for the delay between attempts, and an option to do a special check after a configurable delay when the target or target subsystem changes, or the target's shields drop or regenerate.