### PR TITLE
handle ship editor re-entrancy in FRED

### DIFF
--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -245,6 +245,9 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 	// activate the localizer hash table
 	fhash_flush();
 
+	// Guard against reentrant ship-editor write-back while the mission is loaded.  The guard is released once the mission has stabilized.
+	Ship_editor_dialog.bypass_all++;
+
 	clear_mission(flags & MPF_FAST_RELOAD);
 
 	// message 1: required version
@@ -259,6 +262,7 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 		}
 
 		Fred_view_wnd->MessageBox(name);
+		Ship_editor_dialog.bypass_all--;
 		create_new_mission();
 		return false;
 	}
@@ -407,6 +411,9 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 
 	set_modified(0);
 	stars_post_level_init();
+
+	// mission is fully built and consistent now; allow the editors to repopulate
+	Ship_editor_dialog.bypass_all--;
 
 	recreate_dialogs();
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -873,11 +873,16 @@ void create_new_mission()
 
 void reset_mission()
 {
+	// Guard against reentrant ship-editor write-back while the mission is reset.
+	Ship_editor_dialog.bypass_all++;
+
 	clear_mission();
 
 	create_player(&vmd_zero_vector, &vmd_identity_matrix);
 
 	stars_post_level_init();
+
+	Ship_editor_dialog.bypass_all--;
 }
 
 void clear_mission(bool fast_reload)


### PR DESCRIPTION
Prevent the mission from being modified via the ship editor's window update when it is already being cleared or loaded.  This mirrors existing guards in `delete_object` and `delete_ship`.

No other FRED2 dialogs are vulnerable.  QtFRED uses a different ship editor mechanism which is not affected by this issue.