### PR TITLE
tiny tweak fix to the comm menu

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -461,6 +461,7 @@ void hud_squadmsg_do_mode( int mode )
 	MsgItems.clear();
 	Rebuild_MsgItems = true;
 	First_menu_item = 0;
+	Selected_menu_item = 0;   // keep offset consistent with the reset page across submenu transitions
 }
 
 void hud_squadmsg_page_down()


### PR DESCRIPTION
Reset the selected item when we open a new menu.  This keeps the display state and internal state in sync if the player mixes arrow presses and number presses.  Follow-up to #7688.