### PR TITLE
Refactor selection screen data storage to remove fixed arrays

### DIFF
--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -85,11 +85,6 @@ shader Icon_shaders[NUM_ICON_FRAMES];
 loadout_data Player_loadout;	// what the ship and weapon loadout is... used since we want to use the 
 								// same loadout if the mission is played again
 
-//wss_unit	Wss_slots[MAX_WSS_SLOTS];				// slot data struct
-//int		Wl_pool[MAX_WEAPON_TYPES];				// weapon pool 
-//int		Ss_pool[MAX_SHIP_CLASSES];				// ship pool
-//int		Wss_num_wings;								// number of player wings
-
 wss_unit	Wss_slots_teams[MAX_TVT_TEAMS][MAX_WSS_SLOTS];
 SCP_map<int, int>	Wl_pool_teams[MAX_TVT_TEAMS];
 SCP_map<int, int>	Ss_pool_teams[MAX_TVT_TEAMS];
@@ -1148,7 +1143,7 @@ void wss_maybe_restore_loadout()
 			++last_loadout_ships[slot->ship_class];
 
 			for ( j = 0; j < MAX_SHIP_WEAPONS; j++ ) {
-				if ((slot->wep[j] >= 0) && (slot->wep[j] < weapon_info_size())) {
+				if (Weapon_info.in_bounds(slot->wep[j])) {
 					last_loadout_weapons[slot->wep[j]] += slot->wep_count[j]; 
 				}
 			}
@@ -1161,7 +1156,7 @@ void wss_maybe_restore_loadout()
 			++this_loadout_ships[Wss_slots[i].ship_class];
 
 			for ( j = 0; j < MAX_SHIP_WEAPONS; j++ ) {
-				if ((Wss_slots[i].wep[j] >= 0) && (Wss_slots[i].wep[j] < weapon_info_size())) {
+				if (Weapon_info.in_bounds(Wss_slots[i].wep[j])) {
 					this_loadout_weapons[Wss_slots[i].wep[j]] += Wss_slots[i].wep_count[j];
 				}
 			}
@@ -1196,7 +1191,7 @@ void wss_maybe_restore_loadout()
 	for ( i = 0; i < MAX_WSS_SLOTS; i++ ) {
 		slot = &Player_loadout.unit_data[i];
 
-		if ((slot->ship_class >= 0) && (slot->ship_class < ship_info_size())) {
+		if (Ship_info.in_bounds(slot->ship_class)) {
 			--this_loadout_ships[slot->ship_class];
 			Assertion((this_loadout_ships[slot->ship_class] >= 0), "Attempting to restore the previous missions loadout has resulted in an invalid number of ships available");
 
@@ -1205,7 +1200,7 @@ void wss_maybe_restore_loadout()
 		Wss_slots[i].ship_class = slot->ship_class;
 
 		for ( j = 0; j < MAX_SHIP_WEAPONS; j++ ) {
-			if ((slot->ship_class >= 0) && (slot->wep[j] >= 0) && (slot->wep[j] < weapon_info_size())) {
+			if (Ship_info.in_bounds(slot->ship_class) && Weapon_info.in_bounds(slot->wep[j])) {
 				this_loadout_weapons[slot->wep[j]] -= slot->wep_count[j];
 				Assertion((this_loadout_weapons[slot->wep[j]] >= 0), "Attempting to restore the previous missions loadout has resulted in an invalid number of weapons available");
 			}

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -86,19 +86,26 @@ int anim_timer_start = 0;
 typedef struct ss_icon_info
 {
 	int				icon_bmaps[NUM_ICON_FRAMES];
-	int				current_icon_bitmap;
-	int				model_index;
+	int				current_icon_bitmap = -1;
+	int				model_index = -1;
 	generic_anim	ss_anim;
+
+	ss_icon_info()
+	{
+		for (int &bmap : icon_bmaps)
+			bmap = -1;
+		generic_anim_init(&ss_anim, nullptr);
+	}
 } ss_icon_info;
 
-//ss_icon_info	Ss_icons[MAX_SHIP_CLASSES];		// holds ui info on different ship icons
 //ss_wing_info	Ss_wings[MAX_WING_BLOCKS];		// holds ui info for wings and wing slots
 
 ss_wing_info	Ss_wings_teams[MAX_TVT_TEAMS][MAX_WING_BLOCKS];
 ss_wing_info	*Ss_wings = NULL;
 
-ss_icon_info	Ss_icons_teams[MAX_TVT_TEAMS][MAX_SHIP_CLASSES];
-ss_icon_info	*Ss_icons = NULL;
+// ui info for ship icons, keyed by ship class; an absent entry means no icon data is loaded for that class
+SCP_map<int, ss_icon_info>	Ss_icons_teams[MAX_TVT_TEAMS];
+SCP_map<int, ss_icon_info>	*Ss_icons = nullptr;
 
 int Ss_mouse_down_on_region = -1;
 
@@ -196,22 +203,11 @@ int Wing_icon_coords[GR_NUM_RESOLUTIONS][MAX_WSS_SLOTS][2] = {
 };
 
 //////////////////////////////////////////////////////
-// Linked List of icons to show on ship selection list
+// List of icons to show on ship selection list
 //////////////////////////////////////////////////////
-#define SS_ACTIVE_ITEM_USED	(1<<0)
-typedef struct ss_active_item
-{
-	ss_active_item	*prev, *next;
-	int				ship_class;
-	int				flags;
-} ss_active_item;
-
-static ss_active_item	SS_active_head;
-//static ss_active_item	SS_active_items[MAX_WSS_SLOTS];//DTP commented out or else singleplayer will only have a max of MAX_WSS_SLOTS ships
-static ss_active_item	SS_active_items[MAX_SHIP_CLASSES];//DTP, now we have all ships in the TBL, as they can all be playerships
+static SCP_vector<int>	SS_active_list;		// ship classes with a positive pool count, in ascending class order
 
 static int SS_active_list_start;
-static int SS_active_list_size;
 
 //////////////////////////////////////////////////////
 // Background bitmaps data for ship_select
@@ -420,85 +416,19 @@ void ss_set_carried_icon(int from_slot, int ship_class)
 	Ship_select_buttons[gr_screen.res][SS_BUTTON_DUMMY].button.capture_mouse();
 }
 
-// clear all active list items, and reset the flags inside the SS_active_items[] array
-void clear_active_list()
-{
-	int i;
-	for ( i = 0; i < ship_info_size(); i++ ) { //DTP singleplayer ship choice fix 
-	//for ( i = 0; i < MAX_WSS_SLOTS; i++ ) { 
-		SS_active_items[i].flags = 0;
-		SS_active_items[i].ship_class = -1;
-	}
-	list_init(&SS_active_head);
-
-	SS_active_list_start = 0;
-	SS_active_list_size = 0;
-}
-
-
-// get a free element from SS_active_items[]
-ss_active_item *get_free_active_list_node()
-{
-	int i;
-	for ( i = 0; i < ship_info_size(); i++ ) { 
-	//for ( i = 0; i < MAX_WSS_SLOTS; i++ ) { //DTP, ONLY MAX_WSS_SLOTS SHIPS ???
-	if ( SS_active_items[i].flags == 0 ) {
-			SS_active_items[i].flags |= SS_ACTIVE_ITEM_USED;
-			return &SS_active_items[i];
-		}
-	}
-	return NULL;
-}
-
-
-// add a ship into the active list
-void active_list_add(int ship_class)
-{
-	ss_active_item *sai;
-
-	sai = get_free_active_list_node();
-	Assert(sai != NULL);
-	sai->ship_class = ship_class;
-	list_append(&SS_active_head, sai);
-}
-
-// remove a ship from the active list
-void active_list_remove(int ship_class)
-{
-	ss_active_item *sai, *temp;
-	
-	// next store players not assigned to wings
-	sai = GET_FIRST(&SS_active_head);
-
-	while(sai != END_OF_LIST(&SS_active_head)){
-		temp = GET_NEXT(sai);
-		if ( sai->ship_class == ship_class ) {
-			list_remove(&SS_active_head, sai);
-			sai->flags = 0;
-		}
-		sai = temp;
-	}
-}
-	
 // Build up the ship selection active list, which is a list of all ships that the player
 // can choose from.
 void init_active_list()
 {
-	ss_active_item	*sai;
-
 	Assert( Ss_pool != NULL );
 
-	clear_active_list();
+	SS_active_list.clear();
+	SS_active_list_start = 0;
 
-	// build the active list
+	// build the active list (map iteration is in ascending class order, which is the display order)
 	for ( const auto &[ship_class, count] : *Ss_pool ) {
 		if ( count > 0 ) {
-			sai = get_free_active_list_node();
-			if ( sai != NULL ) {
-				sai->ship_class = ship_class;
-				list_append(&SS_active_head, sai);
-				SS_active_list_size++;
-			}
+			SS_active_list.push_back(ship_class);
 		}
 	}
 }
@@ -600,7 +530,7 @@ void ship_select_button_do(int i)
 			if ( Current_screen != ON_SHIP_SELECT )
 				break;
 
-			if ( common_scroll_down_pressed(&SS_active_list_start, SS_active_list_size, MAX_ICONS_ON_SCREEN) ) {
+			if ( common_scroll_down_pressed(&SS_active_list_start, sz2i(SS_active_list.size()), MAX_ICONS_ON_SCREEN) ) {
 				gamesnd_play_iface(InterfaceSounds::SCROLL);
 			} else {
 				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
@@ -611,7 +541,7 @@ void ship_select_button_do(int i)
 			if ( Current_screen != ON_SHIP_SELECT )
 				break;
 
-			if ( common_scroll_up_pressed(&SS_active_list_start, SS_active_list_size, MAX_ICONS_ON_SCREEN) ) {
+			if ( common_scroll_up_pressed(&SS_active_list_start, sz2i(SS_active_list.size()), MAX_ICONS_ON_SCREEN) ) {
 				gamesnd_play_iface(InterfaceSounds::SCROLL);
 			} else {
 				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
@@ -631,8 +561,6 @@ void ship_select_button_do(int i)
 //
 void ship_select_init()
 {
-//	SS_active_items = new ss_active_item[Num_ship_classes];
-
 	common_set_interface_palette("ShipPalette");
 	common_flash_button_init();
 
@@ -741,29 +669,14 @@ void ship_select_init()
 //
 int ss_get_ship_class_from_list(int index)
 {
-	ss_active_item	*sai;
-	int				list_entry, i, count;
+	if ( index < 0 || index >= MAX_ICONS_ON_SCREEN )
+		return -1;
 
-	i = 0;
-	count = 0;
-	list_entry = -1;
-	for ( sai = GET_FIRST(&SS_active_head); sai != END_OF_LIST(&SS_active_head); sai = GET_NEXT(sai) ) {
-		count++;
-		if ( count <= SS_active_list_start )
-			continue;
+	size_t list_index = SS_active_list_start + index;
+	if ( list_index >= SS_active_list.size() )
+		return -1;
 
-		if ( i >= MAX_ICONS_ON_SCREEN )
-			break;
-
-		if ( i == index ) {
-			list_entry = sai->ship_class;
-			break;
-		}
-
-		i++;
-	}
-
-	return list_entry;
+	return SS_active_list[list_index];
 }
 
 // ---------------------------------------------------------------------
@@ -1421,11 +1334,11 @@ void ship_select_do(float frametime)
 		ship_select_redraw_pressed_buttons();
 		common_render_selected_screen_button();
 	}
-	if (!Use_3d_ship_select && ((Selected_ss_class >= 0) && (Ss_icons[Selected_ss_class].ss_anim.num_frames > 0)))
+	if (!Use_3d_ship_select && ((Selected_ss_class >= 0) && ((*Ss_icons)[Selected_ss_class].ss_anim.num_frames > 0)))
 	{
 		GR_DEBUG_SCOPE("Render ship animation");
 
-		generic_anim_render(&Ss_icons[Selected_ss_class].ss_anim, (help_overlay_active(Ship_select_overlay_id)) ? 0 : frametime, Ship_anim_coords[gr_screen.res][0], Ship_anim_coords[gr_screen.res][1], true);
+		generic_anim_render(&(*Ss_icons)[Selected_ss_class].ss_anim, (help_overlay_active(Ship_select_overlay_id)) ? 0 : frametime, Ship_anim_coords[gr_screen.res][0], Ship_anim_coords[gr_screen.res][1], true);
 	} else {
 		GR_DEBUG_SCOPE("Render ship models");
 		// The new rendering code for 3D ships courtesy your friendly UnknownPlayer :)
@@ -1493,17 +1406,17 @@ void ship_select_do(float frametime)
 		mouse_get_pos_unscaled( &mouse_x, &mouse_y );
 		sx = mouse_x + Ss_delta_x;
 		sy = mouse_y + Ss_delta_y;
-		if(Ss_icons[Carried_ss_icon.ship_class].icon_bmaps[ICON_FRAME_SELECTED] != -1)
+		if((*Ss_icons)[Carried_ss_icon.ship_class].icon_bmaps[ICON_FRAME_SELECTED] != -1)
 		{
-			gr_set_bitmap(Ss_icons[Carried_ss_icon.ship_class].icon_bmaps[ICON_FRAME_SELECTED]);
+			gr_set_bitmap((*Ss_icons)[Carried_ss_icon.ship_class].icon_bmaps[ICON_FRAME_SELECTED]);
 			gr_bitmap(sx, sy, GR_RESIZE_MENU);
 		}
 		else
 		{
 			ship_info *sip = &Ship_info[Carried_ss_icon.ship_class];
-			if(Ss_icons[Carried_ss_icon.ship_class].model_index == -1) {
-				Ss_icons[Carried_ss_icon.ship_class].model_index = model_load(sip, true);
-				mprintf(("SL WARNING: Had to attempt to page in model for %s paged in manually! Result: %d\n", sip->name, Ss_icons[Carried_ss_icon.ship_class].model_index));
+			if((*Ss_icons)[Carried_ss_icon.ship_class].model_index == -1) {
+				(*Ss_icons)[Carried_ss_icon.ship_class].model_index = model_load(sip, true);
+				mprintf(("SL WARNING: Had to attempt to page in model for %s paged in manually! Result: %d\n", sip->name, (*Ss_icons)[Carried_ss_icon.ship_class].model_index));
 			}
 			gr_set_color_fast(&Icon_colors[ICON_FRAME_SELECTED]);
 
@@ -1514,9 +1427,9 @@ void ship_select_do(float frametime)
 			draw_brackets_square(&line_draw_list, sx, sy, sx + w, sy + h, GR_RESIZE_MENU);
 			line_draw_list.flush();
 
-			if(Ss_icons[Carried_ss_icon.ship_class].model_index != -1)
+			if((*Ss_icons)[Carried_ss_icon.ship_class].model_index != -1)
 			{
-				draw_model_icon(Ss_icons[Carried_ss_icon.ship_class].model_index, MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_LIGHTING, sx, sy, w, h, sip, nullptr, 0.8f, GR_RESIZE_MENU);
+				draw_model_icon((*Ss_icons)[Carried_ss_icon.ship_class].model_index, MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_LIGHTING, sx, sy, w, h, sip, nullptr, 0.8f, GR_RESIZE_MENU);
 			}
 		}
 	}
@@ -1582,25 +1495,19 @@ void ship_select_close()
 									// select screen has been closed and memory freed.  This flag
 									// is needed so we can know if ship_select_close() needs to called if
 									// restoring a game from the Options screen invoked from ship select
-
-//	delete[] SS_active_items;
 }
 
-//	ss_unload_icons() frees the bitmaps used for ship icons 
+//	ss_unload_icons() frees the bitmaps used for ship icons
 void ss_unload_all_icons()
 {
-	int					i,j;
-	ss_icon_info		*icon;
+	if ( Ss_icons == nullptr )
+		return;
 
-	Assert( Ss_icons != NULL );
-
-	for ( i = 0; i < MAX_SHIP_CLASSES; i++ ) {
-		icon = &Ss_icons[i];
-
-		for ( j = 0; j < NUM_ICON_FRAMES; j++ ) {
-			if ( icon->icon_bmaps[j] >= 0 ) {
-				bm_release(icon->icon_bmaps[j]);
-				icon->icon_bmaps[j] = -1;
+	for ( auto &[ship_class, icon] : *Ss_icons ) {
+		for ( int j = 0; j < NUM_ICON_FRAMES; j++ ) {
+			if ( icon.icon_bmaps[j] >= 0 ) {
+				bm_release(icon.icon_bmaps[j]);
+				icon.icon_bmaps[j] = -1;
 			}
 		}
 	}
@@ -1610,21 +1517,12 @@ void ss_unload_all_icons()
 //	draw_ship_icons() will request which icons to draw on screen.
 void draw_ship_icons()
 {
-	int i;
-	int count=0;
-
-	ss_active_item	*sai;
-	i = 0;
-	for ( sai = GET_FIRST(&SS_active_head); sai != END_OF_LIST(&SS_active_head); sai = GET_NEXT(sai) ) {
-		count++;
-		if ( count <= SS_active_list_start )
-			continue;
-
-		if ( i >= MAX_ICONS_ON_SCREEN )
+	for ( int i = 0; i < MAX_ICONS_ON_SCREEN; i++ ) {
+		size_t list_index = SS_active_list_start + i;
+		if ( list_index >= SS_active_list.size() )
 			break;
 
-		draw_ship_icon_with_number(i, sai->ship_class);
-		i++;
+		draw_ship_icon_with_number(i, SS_active_list[list_index]);
 	}
 }
 
@@ -1647,7 +1545,7 @@ void draw_ship_icon_with_number(int screen_offset, int ship_class)
 	Assert( screen_offset >= 0 && screen_offset <= 3 );
 	Assert( ship_class >= 0 );
 	Assert( (Ss_pool != NULL) && (Ss_icons != NULL) );
-	ss_icon = &Ss_icons[ship_class];
+	ss_icon = &(*Ss_icons)[ship_class];
 
 	num_x = Ship_list_coords[gr_screen.res][screen_offset][2];
 	num_y = Ship_list_coords[gr_screen.res][screen_offset][3];
@@ -1748,8 +1646,8 @@ void start_ship_animation(int ship_class, int  /*play_sound*/)
 	if ( Use_3d_ship_select || !strlen(sip->anim_filename) ) {
 
 		//Unload Anim if one was playing
-		if(Ship_anim_class > 0 && Ss_icons[Ship_anim_class].ss_anim.num_frames > 0) {
-			generic_anim_unload(&Ss_icons[Ship_anim_class].ss_anim);
+		if(Ship_anim_class > 0 && (*Ss_icons)[Ship_anim_class].ss_anim.num_frames > 0) {
+			generic_anim_unload(&(*Ss_icons)[Ship_anim_class].ss_anim);
 			Ship_anim_class = -1;
 		}
 
@@ -1777,8 +1675,8 @@ void start_ship_animation(int ship_class, int  /*play_sound*/)
 		}
 
 		//unload the previous anim
-		if(Ship_anim_class > 0 && Ss_icons[Ship_anim_class].ss_anim.num_frames > 0)
-			generic_anim_unload(&Ss_icons[Ship_anim_class].ss_anim);
+		if(Ship_anim_class > 0 && (*Ss_icons)[Ship_anim_class].ss_anim.num_frames > 0)
+			generic_anim_unload(&(*Ss_icons)[Ship_anim_class].ss_anim);
 		//load animation here, we now only have one loaded
 		p = strchr(Ship_info[ship_class].anim_filename, '.' );
 		if(p)
@@ -1791,13 +1689,13 @@ void start_ship_animation(int ship_class, int  /*play_sound*/)
 			strcpy_s(animation_filename, Ship_info[ship_class].anim_filename);
 		}
 
-		generic_anim_init(&Ss_icons[ship_class].ss_anim, animation_filename);
-		Ss_icons[ship_class].ss_anim.ani.bg_type = bm_get_type(Ship_select_background_bitmap);
-		if(generic_anim_stream(&Ss_icons[ship_class].ss_anim) == -1) {
+		generic_anim_init(&(*Ss_icons)[ship_class].ss_anim, animation_filename);
+		(*Ss_icons)[ship_class].ss_anim.ani.bg_type = bm_get_type(Ship_select_background_bitmap);
+		if(generic_anim_stream(&(*Ss_icons)[ship_class].ss_anim) == -1) {
 			//we've failed to load an animation, load an image and treat it like a 1 frame animation
-			Ss_icons[ship_class].ss_anim.first_frame = bm_load(Ship_info[ship_class].anim_filename);	//if we fail here, the value is still -1
-			if(Ss_icons[ship_class].ss_anim.first_frame != -1) {
-				Ss_icons[ship_class].ss_anim.num_frames = 1;
+			(*Ss_icons)[ship_class].ss_anim.first_frame = bm_load(Ship_info[ship_class].anim_filename);	//if we fail here, the value is still -1
+			if((*Ss_icons)[ship_class].ss_anim.first_frame != -1) {
+				(*Ss_icons)[ship_class].ss_anim.num_frames = 1;
 			}
 		}
 
@@ -1811,11 +1709,12 @@ void start_ship_animation(int ship_class, int  /*play_sound*/)
 
 void ss_unload_all_anims()
 {
-	Assert( Ss_icons != NULL );
+	if ( Ss_icons == nullptr )
+		return;
 
-	for ( int i = 0; i < MAX_SHIP_CLASSES; i++ ) {
-		if ( Ss_icons[i].ss_anim.num_frames ) {
-			generic_anim_unload(&Ss_icons[i].ss_anim);
+	for ( auto &[ship_class, icon] : *Ss_icons ) {
+		if ( icon.ss_anim.num_frames ) {
+			generic_anim_unload(&icon.ss_anim);
 		}
 	}
 }
@@ -2190,7 +2089,7 @@ void draw_wing_block(int wb_num, int hot_slot, int selected_slot, int class_sele
 		slot_index = wb_num*MAX_WING_SLOTS + i;
 
 		if ( Wss_slots[slot_index].ship_class >= 0 ) {
-			icon = &Ss_icons[Wss_slots[slot_index].ship_class];
+			icon = &(*Ss_icons)[Wss_slots[slot_index].ship_class];
 		} else {
 			icon = NULL;
 		}
@@ -2368,7 +2267,7 @@ void ss_blit_ship_icon(int x,int y,int ship_class,int bmap_num)
 	{
 		Assert( Ss_icons != NULL );
 
-		ss_icon_info *icon = &Ss_icons[ship_class];
+		ss_icon_info *icon = &(*Ss_icons)[ship_class];
 		if(icon->icon_bmaps[bmap_num] != -1)
 		{
 			Assert(icon->icon_bmaps[bmap_num] != -1);	
@@ -2862,7 +2761,7 @@ void ss_load_icons(int ship_class)
 
 	Assert( Ss_icons != NULL );
 
-	icon = &Ss_icons[ship_class];
+	icon = &(*Ss_icons)[ship_class];
 	ship_info *sip = &Ship_info[ship_class];
 
 	if (!Use_3d_ship_icons && strlen(sip->icon_filename))
@@ -2891,21 +2790,14 @@ void ss_load_icons(int ship_class)
 // load all the icons for ships in the pool
 void ss_load_all_icons()
 {
-	int i, j;
-
 	Assert( (Ss_pool != NULL) && (Ss_icons != NULL) );
 
-	for ( i = 0; i < MAX_SHIP_CLASSES; i++ ) {
-		// clear out data
-		Ss_icons[i].current_icon_bitmap = -1;
-		for ( j = 0; j < NUM_ICON_FRAMES; j++ ) {
-			Ss_icons[i].icon_bmaps[j] = -1;
-		}
-		Ss_icons[i].model_index = -1;
+	// drop any icon data from a previous mission; entries are created blank on demand
+	Ss_icons->clear();
 
-		if ( Ss_pool->contains(i) ) {
-			ss_load_icons(i);
-		}
+	// note: unlike the weapon pool, all pool members get icons, including exhausted 0-count classes
+	for ( const auto &[ship_class, count] : *Ss_pool ) {
+		ss_load_icons(ship_class);
 	}
 }
 
@@ -3169,7 +3061,7 @@ void ss_set_team_pointers(int team)
 	Assert( (team >= 0) && (team < MAX_TVT_TEAMS) );
 
 	Ss_wings = Ss_wings_teams[team];
-	Ss_icons = Ss_icons_teams[team];
+	Ss_icons = &Ss_icons_teams[team];
 }
 
 // reset the necessary pointers to defaults
@@ -3181,7 +3073,7 @@ void ss_reset_team_pointers()
 		return;
 
 	Ss_wings = NULL;
-	Ss_icons = NULL;
+	Ss_icons = nullptr;
 }
 
 // initialize team specific stuff
@@ -3271,7 +3163,7 @@ void ss_synch_interface()
 	// clamp the preserved scroll offset against the largest valid offset
 	// for the new list size, so the up arrow can still reach items at the
 	// top after a swap shrinks the active list (e.g., to <= MAX_ICONS_ON_SCREEN)
-	int max_start = SS_active_list_size - MAX_ICONS_ON_SCREEN;
+	int max_start = sz2i(SS_active_list.size()) - MAX_ICONS_ON_SCREEN;
 	if ( max_start < 0 ) {
 		max_start = 0;
 	}

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -320,8 +320,6 @@ void ss_init_pool(team_data *pteam);
 commit_pressed_status create_wings();
 
 // loading/unloading
-void ss_unload_all_icons();
-void ss_unload_all_anims();
 void ss_init_units();
 anim* ss_load_individual_animation(int ship_class);
 
@@ -1497,18 +1495,21 @@ void ship_select_close()
 									// restoring a game from the Options screen invoked from ship select
 }
 
-//	ss_unload_icons() frees the bitmaps used for ship icons
-void ss_unload_all_icons()
+/**
+ * Release the bitmaps and animation held by one team's icon map, while leaving the map populated.
+ */
+static void ss_unload_team_icons(SCP_map<int, ss_icon_info> &icons)
 {
-	if ( Ss_icons == nullptr )
-		return;
-
-	for ( auto &[ship_class, icon] : *Ss_icons ) {
-		for ( int j = 0; j < NUM_ICON_FRAMES; j++ ) {
-			if ( icon.icon_bmaps[j] >= 0 ) {
-				bm_release(icon.icon_bmaps[j]);
-				icon.icon_bmaps[j] = -1;
+	for ( auto &[ship_class, icon] : icons ) {
+		for ( int &bmap : icon.icon_bmaps ) {
+			if ( bmap >= 0 ) {
+				bm_release(bmap);
+				bmap = -1;
 			}
+		}
+
+		if ( icon.ss_anim.num_frames ) {
+			generic_anim_unload(&icon.ss_anim);
 		}
 	}
 }
@@ -1705,18 +1706,6 @@ void start_ship_animation(int ship_class, int  /*play_sound*/)
 //	if ( play_sound ) {
 		gamesnd_play_iface(InterfaceSounds::SHIP_ICON_CHANGE);
 //	}
-}
-
-void ss_unload_all_anims()
-{
-	if ( Ss_icons == nullptr )
-		return;
-
-	for ( auto &[ship_class, icon] : *Ss_icons ) {
-		if ( icon.ss_anim.num_frames ) {
-			generic_anim_unload(&icon.ss_anim);
-		}
-	}
 }
 
 bool is_weapon_carried(int weapon_index)
@@ -2790,9 +2779,10 @@ void ss_load_icons(int ship_class)
 // load all the icons for ships in the pool
 void ss_load_all_icons()
 {
-	Assert( (Ss_pool != NULL) && (Ss_icons != NULL) );
+	Assert( (Ss_pool != nullptr) && (Ss_icons != nullptr) );
 
-	// drop any icon data from a previous mission; entries are created blank on demand
+	// drop any icon data from a previous load of this team
+	ss_unload_team_icons(*Ss_icons);
 	Ss_icons->clear();
 
 	// note: unlike the weapon pool, all pool members get icons, including exhausted 0-count classes
@@ -3115,22 +3105,19 @@ void ship_select_init_team_data(int team_num)
 
 // called when the briefing is entered
 void ship_select_common_init(bool API_Access)
-{		
-	// initialize team critical data for all teams
-	int idx;
-
-	if(MULTI_TEAM){		
-		// initialize for all teams in the game
-		for(idx=0;idx<MULTI_TS_MAX_TVT_TEAMS;idx++){	
-			ship_select_init_team_data(idx);
-		}		
-
-		// finally, intialize team data for myself
-		ship_select_init_team_data(Common_team);
-	} else {			
-		ship_select_init_team_data(Common_team);
+{
+	// In team-vs-team, initialize every other team first; we always initialize our own team
+	// last so that the team pointers -- which common_set_team_pointers repoints to whichever
+	// team was initialized most recently -- are left pointing at our team for the rest of the screen.
+	if(MULTI_TEAM){
+		for(int idx=0;idx<MULTI_TS_MAX_TVT_TEAMS;idx++){
+			if(idx != Common_team)
+				ship_select_init_team_data(idx);
+		}
 	}
-	
+
+	ship_select_init_team_data(Common_team);
+
 	if (!API_Access) {
 		init_active_list();
 
@@ -3144,8 +3131,11 @@ void ship_select_common_init(bool API_Access)
 
 void ship_select_common_close()
 {
-	ss_unload_all_icons();
-	ss_unload_all_anims();
+	// unload every team's icons
+	for ( auto &team_icons : Ss_icons_teams ) {
+		ss_unload_team_icons(team_icons);
+		team_icons.clear();
+	}
 }
 
 // change any interface data based on updated Wss_slots[] and Ss_pool[]

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1455,13 +1455,49 @@ void wl_load_icons(int weapon_class)
 }
 
 /**
+ * Release the bitmaps and models held by one team's weapon icon map, while leaving the map populated.
+ */
+static void wl_unload_team_icons(SCP_map<int, wl_icon_info> &icons)
+{
+	for ( auto &[weapon_class, icon] : icons ) {
+		for ( int &bmap : icon.icon_bmaps ) {
+			if ( bmap >= 0 ) {
+				bm_release(bmap);
+				bmap = -1;
+			}
+		}
+
+		if ( icon.model_index >= 0 ) {
+			model_unload(icon.model_index);
+			icon.model_index = -1;
+		}
+		if ( icon.laser_bmap >= 0 ) {
+			bm_unload(icon.laser_bmap);
+			icon.laser_bmap = -1;
+		}
+	}
+}
+
+/**
+ * Release and drop every team's weapon icon map
+ */
+static void wl_unload_all_teams_icons()
+{
+	for ( auto &team_icons : Wl_icons_teams ) {
+		wl_unload_team_icons(team_icons);
+		team_icons.clear();
+	}
+}
+
+/**
  * Load all the icons for weapons in the pool
  */
 void wl_load_all_icons()
 {
-	Assert( (Wl_icons != NULL) && (Wl_pool != NULL) );
+	Assert( (Wl_icons != nullptr) && (Wl_pool != nullptr) );
 
-	// drop any icon data from a previous mission; entries are created blank on demand
+	// drop any icon data from a previous load of this team
+	wl_unload_team_icons(*Wl_icons);
 	Wl_icons->clear();
 
 	// note: unlike the ship pool, icons are only loaded for classes with ships remaining
@@ -1470,44 +1506,6 @@ void wl_load_all_icons()
 			wl_load_icons(weapon_class);
 		}
 	}
-}
-
-/**
- * Frees the bitmaps used for weapon icons
- */
-void wl_unload_icons()
-{
-	if ( Wl_icons == nullptr )
-		return;
-
-	for ( auto &[weapon_class, icon] : *Wl_icons ) {
-		for ( int j = 0; j < NUM_ICON_FRAMES; j++ ) {
-			if ( icon.icon_bmaps[j] >= 0 ) {
-				bm_release(icon.icon_bmaps[j]);
-				icon.icon_bmaps[j] = -1;
-			}
-		}
-
-		if(icon.model_index >= 0) {
-			model_unload(icon.model_index);
-			icon.model_index = -1;
-		}
-		if(icon.laser_bmap >= 0) {
-			bm_unload(icon.laser_bmap);
-			icon.laser_bmap = -1;
-		}
-		if(Cur_Anim.num_frames > 0)
-			generic_anim_unload(&Cur_Anim);
-	}
-}
-
-/**
- * init ship-class specific data
- */
-void wl_init_ship_class_data()
-{
-	// entries are created blank on demand
-	Wl_ships.clear();
 }
 
 /**
@@ -1532,6 +1530,14 @@ void wl_free_ship_class_data()
 	}
 
 	Wl_ships.clear();
+}
+
+/**
+ * init ship-class specific data
+ */
+void wl_init_ship_class_data()
+{
+	wl_free_ship_class_data();
 }
 
 /**
@@ -2050,7 +2056,7 @@ void weapon_select_close_team()
 	if (Weapon_select_open)
 		return;
 
-	wl_unload_icons();
+	wl_unload_all_teams_icons();
 	wl_unload_all_anims();
 }
 
@@ -2060,20 +2066,17 @@ void weapon_select_close_team()
  */
 void weapon_select_common_init(bool API_Access)
 {
-	int idx;
-
+	// In team-vs-team, initialize every other team first; we always initialize our own team
+	// last so that the team pointers -- which common_set_team_pointers repoints to whichever
+	// team was initialized most recently -- are left pointing at our team for the rest of the screen.
 	if(MULTI_TEAM){
-		// initialize for all teams
-		for(idx=0;idx<MULTI_TS_MAX_TVT_TEAMS;idx++){
-			weapon_select_init_team(idx);
+		for(int idx=0;idx<MULTI_TS_MAX_TVT_TEAMS;idx++){
+			if(idx != Common_team)
+				weapon_select_init_team(idx);
 		}
-
-		// re-initialize for me specifically
-		weapon_select_init_team(Common_team);
-	} else {	
-		// initialize for my own team
-		weapon_select_init_team(Common_team);
 	}
+
+	weapon_select_init_team(Common_team);
 
 	if (!API_Access) {
 		wl_reset_selected_slot();
@@ -3011,7 +3014,7 @@ void weapon_select_close()
 	// unload bitmaps
 	bm_release(WeaponSelectMaskBitmap);
 
-	wl_unload_icons();
+	wl_unload_all_teams_icons();
 	wl_unload_all_anims();
 	// ...must be last...
 	wl_free_ship_class_data();

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -347,31 +347,45 @@ static int Wl_ship_name_coords[GR_NUM_RESOLUTIONS][2] = {
 ///////////////////////////////////////////////////////////////////////
 typedef struct wl_ship_class_info
 {
-	int				overhead_bitmap;
-	int				model_num;
+	int				overhead_bitmap = -1;
+	int				model_num = -1;
 	generic_anim	animation;
+
+	wl_ship_class_info()
+	{
+		generic_anim_init(&animation, nullptr);
+	}
 } wl_ship_class_info;
 
-wl_ship_class_info	Wl_ships[MAX_SHIP_CLASSES];
+// overhead-view data, keyed by ship class; an absent entry means nothing is loaded for that class
+SCP_map<int, wl_ship_class_info>	Wl_ships;
 
 struct wl_icon_info
 {
 	int				icon_bmaps[NUM_ICON_FRAMES];
-	int				laser_bmap;
-	int				model_index;
-	bool			can_use_for_ship;
-	TriStateBool	can_use_for_bank;
+	int				laser_bmap = -1;
+	int				model_index = -1;
+	bool			can_use_for_ship = false;
+	TriStateBool	can_use_for_bank = TriStateBool::UNKNOWN_;
 	generic_anim	animation;
+
+	wl_icon_info()
+	{
+		for (int &bmap : icon_bmaps)
+			bmap = -1;
+		generic_anim_init(&animation, nullptr);
+	}
 };
 
-wl_icon_info	Wl_icons_teams[MAX_TVT_TEAMS][MAX_WEAPON_TYPES];
-wl_icon_info	*Wl_icons = NULL;
+// ui info for weapon icons, keyed by weapon class; entries hold usability flags for all weapon classes, but icon bitmaps/models are loaded only for pool weapons
+SCP_map<int, wl_icon_info>	Wl_icons_teams[MAX_TVT_TEAMS];
+SCP_map<int, wl_icon_info>	*Wl_icons = nullptr;
 
-int Plist[MAX_WEAPON_TYPES];	// used to track scrolling of primary icon list
-int Plist_start, Plist_size;
+SCP_vector<int> Plist;	// weapon classes in the primary icon list, in pool order
+int Plist_start;			// scroll offset into Plist
 
-int Slist[MAX_WEAPON_TYPES];	// used to track scrolling of primary icon list
-int Slist_start, Slist_size;
+SCP_vector<int> Slist;	// weapon classes in the secondary icon list, in pool order
+int Slist_start;			// scroll offset into Slist
 
 static int Selected_wl_slot = -1;			// Currently selected ship slot
 static int Selected_wl_class = -1;			// Class of weapon that is selected
@@ -448,7 +462,7 @@ UI_XSTR Weapon_select_text[GR_NUM_RESOLUTIONS][WEAPON_SELECT_NUM_TEXT] = {
 ///////////////////////////////////////////////////////////////////////
 typedef struct carried_icon
 {
-	int weapon_class;		// index Wl_icons[] for carried icon (-1 if carried from bank)
+	int weapon_class;		// weapon class of the carried icon (-1 if carried from bank)
 	int num;					// number of units of weapon
 	int from_bank;			// bank index that icon came from (0..2 primary, 3..6 secondary).  -1 if from list
 	int from_slot;			// ship slot that weapon is part of 
@@ -596,7 +610,7 @@ void weapon_button_do(int i)
 {
 	switch ( i ) {
 			case WL_BUTTON_SCROLL_PRIMARY_UP:
-				if ( common_scroll_up_pressed(&Plist_start, Plist_size, NUM_PRIMARY_MASK_REGIONS) ) {
+				if ( common_scroll_up_pressed(&Plist_start, sz2i(Plist.size()), NUM_PRIMARY_MASK_REGIONS) ) {
 					gamesnd_play_iface(InterfaceSounds::SCROLL);
 				} else {
 					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
@@ -604,7 +618,7 @@ void weapon_button_do(int i)
 			break;
 
 			case WL_BUTTON_SCROLL_PRIMARY_DOWN:
-				if ( common_scroll_down_pressed(&Plist_start, Plist_size, NUM_PRIMARY_MASK_REGIONS) ) {
+				if ( common_scroll_down_pressed(&Plist_start, sz2i(Plist.size()), NUM_PRIMARY_MASK_REGIONS) ) {
 					gamesnd_play_iface(InterfaceSounds::SCROLL);
 				} else {
 					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
@@ -612,7 +626,7 @@ void weapon_button_do(int i)
 			break;
 
 			case WL_BUTTON_SCROLL_SECONDARY_UP:
-				if ( common_scroll_up_pressed(&Slist_start, Slist_size, NUM_SECONDARY_MASK_REGIONS) ) {
+				if ( common_scroll_up_pressed(&Slist_start, sz2i(Slist.size()), NUM_SECONDARY_MASK_REGIONS) ) {
 					gamesnd_play_iface(InterfaceSounds::SCROLL);
 				} else {
 					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
@@ -620,7 +634,7 @@ void weapon_button_do(int i)
 			break;
 
 			case WL_BUTTON_SCROLL_SECONDARY_DOWN:
-				if ( common_scroll_down_pressed(&Slist_start, Slist_size, NUM_SECONDARY_MASK_REGIONS) ) {
+				if ( common_scroll_down_pressed(&Slist_start, sz2i(Slist.size()), NUM_SECONDARY_MASK_REGIONS) ) {
 					gamesnd_play_iface(InterfaceSounds::SCROLL);
 				} else {
 					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
@@ -1235,6 +1249,19 @@ int eval_weapon_flag_for_game_type(int weapon_flags)
 }
 
 /**
+ * Return the weapon class shown at the given on-screen row of a scrolling icon list,
+ * or -1 if that row is past the end of the list.
+ */
+static int wl_get_weapon_class_from_list(const SCP_vector<int> &list, int list_start, int row)
+{
+	size_t list_index = list_start + row;
+	if ( list_index >= list.size() )
+		return -1;
+
+	return list[list_index];
+}
+
+/**
  * Go through the possible weapons to choose from, and flag some as disabled since
  * that ship class cannot use that kind of weapon.  The weapon filter is specified
  * in ships.tbl, where each ship has a list of all the possible weapons it can use.
@@ -1248,28 +1275,32 @@ void wl_set_disabled_weapons(int ship_class, int bank_index)
 
 	Assert(ship_class >= 0 && ship_class < ship_info_size());
 	Assert(bank_index < MAX_SHIP_PRIMARY_BANKS + MAX_SHIP_SECONDARY_BANKS);
-	Assert( Wl_icons != NULL );
+	Assert( (Wl_pool != nullptr) && (Wl_icons != nullptr) && (Wss_slots != nullptr) );
 
 	auto sip = &Ship_info[ship_class];
 
-	int i = 0;
-	for ( auto &wi: Weapon_info )
+	// Set the flags for every weapon class, not just the ones with pool or slot entries at this
+	// moment: a script may drop a weapon into a bank between calls (see the Loadout_Weapon
+	// setter), and its icon flags must already be valid when the player interacts with it.
+	// Flag-only entries in the icon map are cheap; icon bitmaps still load only for pool weapons.
+	for ( int weapon_class = 0; weapon_class < weapon_info_size(); weapon_class++ )
 	{
-		//	Determine whether weapon #i is allowed on this ship class in the current type of mission.
+		auto &wi = Weapon_info[weapon_class];
+		auto &icon = (*Wl_icons)[weapon_class];
+
+		//	Determine whether this weapon is allowed on this ship class in the current type of mission.
 		//	As of 9/6/99, the only difference is dogfight missions have a different list of legal weapons.
-		Wl_icons[i].can_use_for_ship = eval_weapon_flag_for_game_type(sip->allowed_weapons[i]);
+		icon.can_use_for_ship = eval_weapon_flag_for_game_type(sip->allowed_weapons[weapon_class]);
 
 		//	Also determine whether the weapon can be used on this bank
-		if ( bank_index < 0 || !Wl_icons[i].can_use_for_ship )
-			Wl_icons[i].can_use_for_bank = TriStateBool::UNKNOWN_;
+		if ( bank_index < 0 || !icon.can_use_for_ship )
+			icon.can_use_for_bank = TriStateBool::UNKNOWN_;
 		else if ( (wi.is_primary() && bank_index >= MAX_SHIP_PRIMARY_BANKS) || (wi.is_secondary() && bank_index < MAX_SHIP_PRIMARY_BANKS) )
-			Wl_icons[i].can_use_for_bank = TriStateBool::UNKNOWN_;
-		else if ( !eval_weapon_flag_for_game_type(sip->restricted_loadout_flag[bank_index]) || eval_weapon_flag_for_game_type(sip->allowed_bank_restricted_weapons[bank_index][i]) )
-			Wl_icons[i].can_use_for_bank = TriStateBool::TRUE_;
+			icon.can_use_for_bank = TriStateBool::UNKNOWN_;
+		else if ( !eval_weapon_flag_for_game_type(sip->restricted_loadout_flag[bank_index]) || eval_weapon_flag_for_game_type(sip->allowed_bank_restricted_weapons[bank_index][weapon_class]) )
+			icon.can_use_for_bank = TriStateBool::TRUE_;
 		else
-			Wl_icons[i].can_use_for_bank = TriStateBool::FALSE_;
-
-		++i;
+			icon.can_use_for_bank = TriStateBool::FALSE_;
 	}
 }
 
@@ -1317,9 +1348,9 @@ void maybe_select_new_weapon(int index)
 	}
 
 	if ( index < NUM_PRIMARY_MASK_REGIONS ) {
-		weapon_class = Plist[Plist_start+index];
+		weapon_class = wl_get_weapon_class_from_list(Plist, Plist_start, index);
 	} else {
-		weapon_class = Slist[Slist_start+index-NUM_PRIMARY_MASK_REGIONS];
+		weapon_class = wl_get_weapon_class_from_list(Slist, Slist_start, index - NUM_PRIMARY_MASK_REGIONS);
 	}
 
 	if ( weapon_class >= 0 ) {
@@ -1397,7 +1428,7 @@ void wl_load_icons(int weapon_class)
 
 	Assert( Wl_icons != NULL );
 
-	icon = &Wl_icons[weapon_class];
+	icon = &(*Wl_icons)[weapon_class];
 
 	if (!Use_3d_weapon_icons || (wip->render_type == WRT_LASER && !VALID_FNAME(wip->tech_model)))
 	{
@@ -1428,53 +1459,42 @@ void wl_load_icons(int weapon_class)
  */
 void wl_load_all_icons()
 {
-
-	int i, j;
-
 	Assert( (Wl_icons != NULL) && (Wl_pool != NULL) );
 
-	for ( i = 0; i < MAX_WEAPON_TYPES; i++ ) {
-		// clear out data
-		generic_anim_init(&Wl_icons[i].animation, NULL);
-		for ( j = 0; j < NUM_ICON_FRAMES; j++ ) {
-			Wl_icons[i].icon_bmaps[j] = -1;
-		}
-		Wl_icons[i].model_index = -1;
-		Wl_icons[i].laser_bmap = -1;
+	// drop any icon data from a previous mission; entries are created blank on demand
+	Wl_icons->clear();
 
-		if ( Wl_pool->value_or(i, 0) > 0 ) {
-			wl_load_icons(i);
+	// note: unlike the ship pool, icons are only loaded for classes with ships remaining
+	for ( const auto &[weapon_class, count] : *Wl_pool ) {
+		if ( count > 0 ) {
+			wl_load_icons(weapon_class);
 		}
 	}
 }
 
 /**
- * Frees the bitmaps used for weapon icons 
+ * Frees the bitmaps used for weapon icons
  */
 void wl_unload_icons()
 {
-	int					i,j;
-	wl_icon_info		*icon;
+	if ( Wl_icons == nullptr )
+		return;
 
-	Assert( Wl_icons != NULL );
-
-	for ( i = 0; i < MAX_WEAPON_TYPES; i++ ) {
-		icon = &Wl_icons[i];
-
-		for ( j = 0; j < NUM_ICON_FRAMES; j++ ) {
-			if ( icon->icon_bmaps[j] >= 0 ) {
-				bm_release(icon->icon_bmaps[j]);
-				icon->icon_bmaps[j] = -1;
+	for ( auto &[weapon_class, icon] : *Wl_icons ) {
+		for ( int j = 0; j < NUM_ICON_FRAMES; j++ ) {
+			if ( icon.icon_bmaps[j] >= 0 ) {
+				bm_release(icon.icon_bmaps[j]);
+				icon.icon_bmaps[j] = -1;
 			}
 		}
 
-		if(icon->model_index >= 0) {
-			model_unload(icon->model_index);
-			icon->model_index = -1;
+		if(icon.model_index >= 0) {
+			model_unload(icon.model_index);
+			icon.model_index = -1;
 		}
-		if(icon->laser_bmap >= 0) {
-			bm_unload(icon->laser_bmap);
-			icon->laser_bmap = -1;
+		if(icon.laser_bmap >= 0) {
+			bm_unload(icon.laser_bmap);
+			icon.laser_bmap = -1;
 		}
 		if(Cur_Anim.num_frames > 0)
 			generic_anim_unload(&Cur_Anim);
@@ -1486,15 +1506,8 @@ void wl_unload_icons()
  */
 void wl_init_ship_class_data()
 {
-	int i;
-	wl_ship_class_info	*wl_ship;
-
-	for ( i = 0; i < ship_info_size(); i++ ) {
-		wl_ship = &Wl_ships[i];
-		wl_ship->overhead_bitmap = -1;
-		wl_ship->model_num = -1;
-		generic_anim_init(&wl_ship->animation, NULL);
-	}
+	// entries are created blank on demand
+	Wl_ships.clear();
 }
 
 /**
@@ -1502,26 +1515,23 @@ void wl_init_ship_class_data()
  */
 void wl_free_ship_class_data()
 {
-	int i;
-	wl_ship_class_info	*wl_ship;
-
-	for ( i = 0; i < ship_info_size(); i++ ) {
-		wl_ship = &Wl_ships[i];
-
-		if ( wl_ship->overhead_bitmap != -1 ) {
-			bm_release(wl_ship->overhead_bitmap);
-			wl_ship->overhead_bitmap = -1;
+	for ( auto &[ship_class, wl_ship] : Wl_ships ) {
+		if ( wl_ship.overhead_bitmap != -1 ) {
+			bm_release(wl_ship.overhead_bitmap);
+			wl_ship.overhead_bitmap = -1;
 		}
 
-		if ( wl_ship->model_num != -1 ) {
+		if ( wl_ship.model_num != -1 ) {
 			// this should unload the model from memory only if it's not used in the mission
-			model_unload(wl_ship->model_num);
-			wl_ship->model_num = -1;
+			model_unload(wl_ship.model_num);
+			wl_ship.model_num = -1;
 		}
 
-		if(wl_ship->animation.num_frames)
-			generic_anim_unload(&wl_ship->animation);
+		if(wl_ship.animation.num_frames)
+			generic_anim_unload(&wl_ship.animation);
 	}
+
+	Wl_ships.clear();
 }
 
 /**
@@ -1604,19 +1614,15 @@ void wl_maybe_reset_selected_weapon_class()
 	}
 
 	// then check for a primary weapon in the pool
-	for ( i = 0; i < Plist_size; i++ ) {
-		if ( Plist[i] >= 0 ) {
-			Selected_wl_class = Plist[i];
-			return;
-		}
+	if ( !Plist.empty() ) {
+		Selected_wl_class = Plist.front();
+		return;
 	}
 
 	// finally, if no others found yet, check for a secondary weapon in the pool
-	for ( i = 0; i < Slist_size; i++ ) {
-		if ( Slist[i] >= 0 ) {
-			Selected_wl_class = Slist[i];
-			return;
-		}
+	if ( !Slist.empty() ) {
+		Selected_wl_class = Slist.front();
+		return;
 	}
 }
 
@@ -1850,25 +1856,12 @@ void wl_get_default_weapons(int ship_class, int slot_num, int *wep, int *wep_cou
  */
 void wl_add_index_to_list(int wi_index)
 {
-	int i;
 	if ( Weapon_info[wi_index].subtype == WP_MISSILE ) {
-
-		for ( i=0; i<Slist_size; i++ ) {
-			if ( Slist[i] == wi_index )
-				break;
-		}
-
-		if ( i == Slist_size ) 
-			Slist[Slist_size++] = wi_index;
-
+		if ( !Slist.contains(wi_index) )
+			Slist.push_back(wi_index);
 	} else {
-		for ( i=0; i<Plist_size; i++ ) {
-			if ( Plist[i] == wi_index )
-				break;
-		}
-
-		if ( i == Plist_size ) 
-			Plist[Plist_size++] = wi_index;
+		if ( !Plist.contains(wi_index) )
+			Plist.push_back(wi_index);
 	}
 }
 
@@ -1990,27 +1983,20 @@ void wl_fill_slots()
  */
 void wl_init_icon_lists()
 {
-	int i;
-
 	Assert( Wl_pool != NULL );
 
-	Plist_start = 0;		// offset into Plist[]
+	Plist_start = 0;
 	Slist_start = 0;
 
-	Plist_size = 0;		// number of active elements in Plist[]
-	Slist_size = 0;
-
-	for ( i = 0; i < MAX_WEAPON_TYPES; i++ ) {
-		Plist[i] = -1;
-		Slist[i] = -1;
-	}
+	Plist.clear();
+	Slist.clear();
 
 	for ( const auto &[weapon_class, count] : *Wl_pool ) {
 		if ( count > 0 ) {
 			if ( Weapon_info[weapon_class].subtype == WP_MISSILE ) {
-				Slist[Slist_size++] = weapon_class;
+				Slist.push_back(weapon_class);
 			} else {
-				Plist[Plist_size++] = weapon_class;
+				Plist.push_back(weapon_class);
 			}
 		}
 	}
@@ -2022,8 +2008,8 @@ void wl_init_icon_lists()
 void wl_set_team_pointers(int team)
 {
 	Assert( (team >= 0) && (team < MAX_TVT_TEAMS) );
-	
-	Wl_icons = Wl_icons_teams[team];
+
+	Wl_icons = &Wl_icons_teams[team];
 }
 
 /**
@@ -2032,11 +2018,11 @@ void wl_set_team_pointers(int team)
 void wl_reset_team_pointers()
 {
 	Assert( !Weapon_select_open );
-	
+
 	if ( Weapon_select_open )
 		return;
-	
-	Wl_icons = NULL;
+
+	Wl_icons = nullptr;
 }
 
 /**
@@ -2890,9 +2876,9 @@ void weapon_select_do(float frametime)
 		sx = mx + Wl_delta_x;
 		sy = my + Wl_delta_y;
 
-		if ( Wl_icons[Carried_wl_icon.weapon_class].can_use_for_ship )
+		if ( (*Wl_icons)[Carried_wl_icon.weapon_class].can_use_for_ship )
 		{
-			wl_icon_info *icon = &Wl_icons[Carried_wl_icon.weapon_class];
+			wl_icon_info *icon = &(*Wl_icons)[Carried_wl_icon.weapon_class];
 			weapon_info *wip = &Weapon_info[Carried_wl_icon.weapon_class];
 			if(icon->icon_bmaps[WEAPON_ICON_FRAME_SELECTED] != -1)
 			{
@@ -2945,7 +2931,7 @@ void weapon_select_do(float frametime)
 
 		// check so see if this is really a legal weapon to carry away
 		// (don't check can_use_for_bank here because we may drop the weapon on a bank that wasn't previously selected)
-		if ( !Wl_icons[Carried_wl_icon.weapon_class].can_use_for_ship )
+		if ( !(*Wl_icons)[Carried_wl_icon.weapon_class].can_use_for_ship )
 		{
 			int diffx, diffy;
 			diffx = abs(Carried_wl_icon.from_x-mx);
@@ -3066,7 +3052,7 @@ void wl_render_icon_count(int num, int x, int y)
 /**
  * Render icon 
  *
- * @param index             index into Wl_icons[], identifying which weapon to draw
+ * @param index             weapon class, identifying which weapon to draw
  * @param x                 x screen position to draw icon at
  * @param y                 y screen position to draw icon at
  * @param num               count for weapon
@@ -3084,7 +3070,7 @@ void wl_render_icon(int index, int x, int y, int num, int draw_num_flag, int hot
 	if ( Selected_wl_slot == -1 )
 		return;
 
-	icon = &Wl_icons[index];
+	icon = &(*Wl_icons)[index];
 
 	if ( icon->icon_bmaps[0] == -1 && icon->model_index == -1 && icon->laser_bmap == -1) {
 		wl_load_icons(index);
@@ -3235,7 +3221,7 @@ void draw_wl_icon_with_number(int list_count, int weapon_class)
 	Assert( (Wl_icons != NULL) && (Wl_pool != NULL) );
 
 
-	if ( Wl_icons[weapon_class].can_use_for_ship && Wl_icons[weapon_class].can_use_for_bank != TriStateBool::FALSE_ )
+	if ( (*Wl_icons)[weapon_class].can_use_for_ship && (*Wl_icons)[weapon_class].can_use_for_bank != TriStateBool::FALSE_ )
 	{
 		gr_set_color_fast(&Icon_colors[WEAPON_ICON_FRAME_NORMAL]);
 	}
@@ -3253,17 +3239,15 @@ void draw_wl_icon_with_number(int list_count, int weapon_class)
  */
 void draw_wl_icons()
 {
-	int i, count;
-
-	count=0;
-	for ( i = Plist_start; i < Plist_size; i++ ) {
+	int count=0;
+	for ( size_t i = Plist_start; i < Plist.size(); ++i ) {
 		draw_wl_icon_with_number(count, Plist[i]);
 		if ( ++count >= NUM_PRIMARY_MASK_REGIONS )
 			break;
 	}
 
 	count=0;
-	for ( i = Slist_start; i < Slist_size; i++ ) {
+	for ( size_t i = Slist_start; i < Slist.size(); ++i ) {
 		draw_wl_icon_with_number(count+NUM_PRIMARY_MASK_REGIONS, Slist[i]);
 		if ( ++count >= NUM_SECONDARY_MASK_REGIONS )
 			break;
@@ -3294,13 +3278,13 @@ void wl_pick_icon_from_list(int index)
 	}
 
 	if ( index < NUM_PRIMARY_MASK_REGIONS ) {
-		weapon_class = Plist[Plist_start+index];
+		weapon_class = wl_get_weapon_class_from_list(Plist, Plist_start, index);
 	} else {
-		weapon_class = Slist[Slist_start+index-NUM_PRIMARY_MASK_REGIONS];
+		weapon_class = wl_get_weapon_class_from_list(Slist, Slist_start, index - NUM_PRIMARY_MASK_REGIONS);
 	}
 
 	// there isn't a weapon there at all!
-	if ( weapon_class < 0 ) 
+	if ( weapon_class < 0 )
 		return;
 
 	Assert( Wl_pool != NULL );
@@ -3348,7 +3332,7 @@ void pick_from_ship_slot(int num)
 		return;
 	}
 
-	Assert(Wl_icons[wep[num]].can_use_for_ship);
+	Assert((*Wl_icons)[wep[num]].can_use_for_ship);
 	// we can't Assert on can_use_for_bank here because we may have clicked on a bank that isn't selected
 
 	wl_set_carried_icon(num, Selected_wl_slot, wep[num]);
@@ -3525,7 +3509,7 @@ void start_weapon_animation(int weapon_class)
 
 	Weapon_anim_class = weapon_class;
 
-	if ( Wl_icons[weapon_class].model_index >= 0 )
+	if ( (*Wl_icons)[weapon_class].model_index >= 0 )
 		return;
 }
 


### PR DESCRIPTION
Convert the mission ship/weapon select screens' per-class UI state from dense MAX_SHIP_CLASSES / MAX_WEAPON_TYPES arrays to sparse containers keyed by loadout-pool membership, matching the Ss_pool / Wl_pool maps they shadow:

  ss_icon_info Ss_icons_teams[][MAX_SHIP_CLASSES] -> SCP_map<int, ss_icon_info>[]
  wl_icon_info Wl_icons_teams[][MAX_WEAPON_TYPES] -> SCP_map<int, wl_icon_info>[]
  wl_ship_class_info Wl_ships[MAX_SHIP_CLASSES]   -> SCP_map<int, wl_ship_class_info>
  int Plist[] / Slist[] + manual size counters    -> SCP_vector<int>

The ship-select active list is replaced outright by a vector of ship classes rebuilt on each interface sync, plus the existing scroll offset.  active_list_remove() was dead code and is deleted.

Behavior fixes required by the conversion:

 * wl_set_disabled_weapons now computes usability flags for the pool
   weapons plus every weapon currently in a slot's banks, instead of all
   weapon classes.  (Bank weapons are not guaranteed pool members.)

 * The two mouse-region handlers that read Plist[Plist_start+index] for
   raw indices 0..3 now bounds-check against the list size (as does
   ss_get_ship_class_from_list).

 * wl_unload_icons and the ss unloaders early-return on a null team
   pointer instead of asserting and dereferencing.

The ship side loads icons for every pool class including exhausted 0-count entries while the weapon side loads only positive counts, preserving the existing asymmetry.

Also:

Fix bitmap and model handle leakage in the ship/weapon select screens, and make release symmetric with load:

 * Initialize each team only once in `ship_select_common_init`
 * Unload every team's map in `ss_unload_team_icons`, not just the active one.
 * Add a per-team unload helper and use it in the load-all functions

Also drop the stray per-icon Cur_Anim unload, and call `wl_free_ship_class_data` before loading in `wl_init_ship_class_data`.

~~In draft as it depends on #7737.~~