### PR TITLE
Store the shield-system editor types in a map

### DIFF
--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -574,7 +574,7 @@ int create_ship(matrix *orient, vec3d *pos, int ship_type)
 	// default shield setting
 	shipp->special_shield = -1;
 	z1 = Shield_sys_teams[shipp->team];
-	z2 = Shield_sys_types[ship_type];
+	z2 = Shield_sys_types.value_or(ship_type, 0);
     if (((z1 == 1) && z2) || (z2 == 1))
         Objects[obj].flags.set(Object::Object_Flags::No_shields);
 
@@ -915,9 +915,7 @@ void clear_mission(bool fast_reload)
 	Shield_sys_teams.clear();
 	Shield_sys_teams.resize(Iff_info.size(), 0);
 
-	for (i=0; i<MAX_SHIP_CLASSES; i++){
-		Shield_sys_types[i] = 0;
-	}
+	Shield_sys_types.clear();
 
 	set_cur_indices(-1);
 

--- a/fred2/shieldsysdlg.cpp
+++ b/fred2/shieldsysdlg.cpp
@@ -22,7 +22,7 @@ static char THIS_FILE[] = __FILE__;
 #endif
 
 SCP_vector<int> Shield_sys_teams;
-int Shield_sys_types[MAX_SHIP_CLASSES] = {0};
+SCP_map<int, int> Shield_sys_types;	// ship class -> shield status (0=has, 1=none, 2=mixed); absent = 0
 
 /////////////////////////////////////////////////////////////////////////////
 // shield_sys_dlg dialog
@@ -59,14 +59,11 @@ BOOL shield_sys_dlg::OnInitDialog()
 {
 	int i, z;
 	int* teams = new int[Iff_info.size()]();
-	int types[MAX_SHIP_CLASSES];
+	SCP_set<int> types_seen;		// which ship classes we've encountered this pass
 	CComboBox *box;
 
 	for (i=0; i< (int)Iff_info.size(); i++)
 		teams[i] = 0;
-
-	for (i=0; i<MAX_SHIP_CLASSES; i++)
-		types[i] = 0;
 
 	for (i=0; i<MAX_SHIPS; i++)
 		if (Ships[i].objnum >= 0) {
@@ -76,13 +73,12 @@ BOOL shield_sys_dlg::OnInitDialog()
 			else if (Shield_sys_teams[Ships[i].team] != z)
 				Shield_sys_teams[Ships[i].team] = 2;
 
-			if (!types[Ships[i].ship_info_index])
+			if (types_seen.insert(Ships[i].ship_info_index).second)
 				Shield_sys_types[Ships[i].ship_info_index] = z;
 			else if (Shield_sys_types[Ships[i].ship_info_index] != z)
 				Shield_sys_types[Ships[i].ship_info_index] = 2;
 
 			teams[Ships[i].team]++;
-			types[Ships[i].ship_info_index]++;
 		}
 
 	delete[] teams;
@@ -112,9 +108,10 @@ void shield_sys_dlg::OnOK()
 	for (i=0; i<MAX_SHIPS; i++)
 		if (Ships[i].objnum >= 0) {
 			z = Shield_sys_teams[Ships[i].team];
-			if (!Shield_sys_types[Ships[i].ship_info_index])
+			int type_z = Shield_sys_types.value_or(Ships[i].ship_info_index, 0);
+			if (!type_z)
 				z = 0;
-			else if (Shield_sys_types[Ships[i].ship_info_index] == 1)
+			else if (type_z == 1)
 				z = 1;
 
 			if (!z)
@@ -165,12 +162,14 @@ void shield_sys_dlg::OnSelchangeType()
 
 void shield_sys_dlg::set_type()
 {
-	if (!Shield_sys_types[m_type])
+	int type_z = Shield_sys_types.value_or(m_type, 0);
+
+	if (!type_z)
 		((CButton *) GetDlgItem(IDC_TYPE_YES))->SetCheck(TRUE);
 	else
 		((CButton *) GetDlgItem(IDC_TYPE_YES))->SetCheck(FALSE);
 
-	if (Shield_sys_types[m_type] == 1)
+	if (type_z == 1)
 		((CButton *) GetDlgItem(IDC_TYPE_NO))->SetCheck(TRUE);
 	else
 		((CButton *) GetDlgItem(IDC_TYPE_NO))->SetCheck(FALSE);

--- a/fred2/shieldsysdlg.h
+++ b/fred2/shieldsysdlg.h
@@ -10,7 +10,7 @@
 
 
 extern SCP_vector<int> Shield_sys_teams;
-extern int Shield_sys_types[MAX_SHIP_CLASSES];
+extern SCP_map<int, int> Shield_sys_types;	// ship class -> shield status (0=has, 1=none, 2=mixed); absent = 0
 
 /////////////////////////////////////////////////////////////////////////////
 // shield_sys_dlg dialog

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -112,7 +112,7 @@ extern void allocate_parse_text(size_t size);
 namespace fso {
 namespace fred {
 	
-Editor::Editor() : currentObject{ -1 }, Shield_sys_teams(Iff_info.size(), GlobalShieldStatus::HasShields), Shield_sys_types(MAX_SHIP_CLASSES, GlobalShieldStatus::HasShields) {
+Editor::Editor() : currentObject{ -1 }, Shield_sys_teams(Iff_info.size(), GlobalShieldStatus::HasShields) {
 	connect(fredApp, &FredApplication::onIdle, this, &Editor::update);
 
 	// When the mission changes we need to update all renderers
@@ -525,9 +525,7 @@ void Editor::clearMission(bool fast_reload) {
 	Shield_sys_teams.clear();
 	Shield_sys_teams.resize(Iff_info.size(), GlobalShieldStatus::HasShields);
 
-	for (int i = 0; i < MAX_SHIP_CLASSES; i++) {
-		Shield_sys_types[i] = GlobalShieldStatus::HasShields;
-	}
+	Shield_sys_types.clear();
 
 	setupCurrentObjectIndices(-1);
 
@@ -734,7 +732,7 @@ int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type) {
 	shipp->special_shield = -1;
 
 	auto z1 = Shield_sys_teams[shipp->team];
-	auto z2 = Shield_sys_types[ship_type];
+	auto z2 = Shield_sys_types.value_or(ship_type, GlobalShieldStatus::HasShields);
 	if (((z1 == GlobalShieldStatus::NoShields) && z2 != GlobalShieldStatus::HasShields) || (z2 == GlobalShieldStatus::NoShields)) {
 		Objects[obj].flags.set(Object::Object_Flags::No_shields);
 	}
@@ -1929,14 +1927,13 @@ SCP_vector<SCP_string> Editor::get_docking_list(int model_index) {
 	return out;
 }
 
-void Editor::exportShieldSysData(SCP_vector<GlobalShieldStatus>& teams, SCP_vector<GlobalShieldStatus>& types) const {
+void Editor::exportShieldSysData(SCP_vector<GlobalShieldStatus>& teams, SCP_map<int, GlobalShieldStatus>& types) const {
 	teams = Shield_sys_teams;
 	types = Shield_sys_types;
 }
 
-void Editor::importShieldSysData(const SCP_vector<GlobalShieldStatus>& teams, const SCP_vector<GlobalShieldStatus>& types) {
+void Editor::importShieldSysData(const SCP_vector<GlobalShieldStatus>& teams, const SCP_map<int, GlobalShieldStatus>& types) {
 	Assertion(Shield_sys_teams.size() == teams.size(), "Mismatched shield data from global shield dialog!");
-	Assertion(Shield_sys_types.size() == types.size(), "Mismatched shield data from global shield dialog!");
 
 	Shield_sys_teams = teams;
 	Shield_sys_types = types;
@@ -1944,9 +1941,10 @@ void Editor::importShieldSysData(const SCP_vector<GlobalShieldStatus>& teams, co
 	for (int i = 0; i < MAX_SHIPS; i++) {
 		if (Ships[i].objnum >= 0) {
 			auto z = Shield_sys_teams[Ships[i].team];
-			if (Shield_sys_types[Ships[i].ship_info_index] == GlobalShieldStatus::HasShields)
+			auto type_z = Shield_sys_types.value_or(Ships[i].ship_info_index, GlobalShieldStatus::HasShields);
+			if (type_z == GlobalShieldStatus::HasShields)
 				z = GlobalShieldStatus::HasShields;
-			else if (Shield_sys_types[Ships[i].ship_info_index] == GlobalShieldStatus::NoShields)
+			else if (type_z == GlobalShieldStatus::NoShields)
 				z = GlobalShieldStatus::NoShields;
 
 			if (z == GlobalShieldStatus::HasShields)
@@ -1960,7 +1958,7 @@ void Editor::importShieldSysData(const SCP_vector<GlobalShieldStatus>& teams, co
 // adapted from shield_sys_dlg OnInitDialog()
 void Editor::normalizeShieldSysData() {
 	std::vector<int> teams(Iff_info.size(), 0);
-	std::vector<int> types(MAX_SHIP_CLASSES, 0);
+	SCP_set<int> types_seen;		// which ship classes we've encountered this pass
 
 	for (int i = 0; i < MAX_SHIPS; i++) {
 		if (Ships[i].objnum >= 0) {
@@ -1970,13 +1968,12 @@ void Editor::normalizeShieldSysData() {
 			else if (Shield_sys_teams[Ships[i].team] != z)
 				Shield_sys_teams[Ships[i].team] = GlobalShieldStatus::MixedShields;
 
-			if (!types[Ships[i].ship_info_index])
+			if (types_seen.insert(Ships[i].ship_info_index).second)
 				Shield_sys_types[Ships[i].ship_info_index] = z;
 			else if (Shield_sys_types[Ships[i].ship_info_index] != z)
 				Shield_sys_types[Ships[i].ship_info_index] = GlobalShieldStatus::MixedShields;
 
 			teams[Ships[i].team]++;
-			types[Ships[i].ship_info_index]++;
 		}
 	}
 }

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -243,8 +243,8 @@ class Editor : public QObject {
 
 	static SCP_vector<SCP_string> get_docking_list(int model_index);
 
-	void exportShieldSysData(SCP_vector<GlobalShieldStatus>& teams, SCP_vector<GlobalShieldStatus>& types) const;
-	void importShieldSysData(const SCP_vector<GlobalShieldStatus>& teams, const SCP_vector<GlobalShieldStatus>& types);
+	void exportShieldSysData(SCP_vector<GlobalShieldStatus>& teams, SCP_map<int, GlobalShieldStatus>& types) const;
+	void importShieldSysData(const SCP_vector<GlobalShieldStatus>& teams, const SCP_map<int, GlobalShieldStatus>& types);
 	void normalizeShieldSysData();
 
 	static void strip_quotation_marks(SCP_string& str);
@@ -278,7 +278,7 @@ class Editor : public QObject {
 	int numMarked = 0;
 
 	SCP_vector<GlobalShieldStatus> Shield_sys_teams;
-	SCP_vector<GlobalShieldStatus> Shield_sys_types;
+	SCP_map<int, GlobalShieldStatus> Shield_sys_types;	// ship class -> shield status; absent = HasShields
 
 	bool already_deleting_wing = false;
 

--- a/qtfred/src/mission/dialogs/ShieldSystemDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShieldSystemDialogModel.cpp
@@ -6,7 +6,7 @@
 namespace fso::fred::dialogs {
 
 ShieldSystemDialogModel::ShieldSystemDialogModel(QObject* parent, EditorViewport* viewport) :
-	AbstractDialogModel(parent, viewport), _teams(Iff_info.size(), GlobalShieldStatus::HasShields), _types(MAX_SHIP_CLASSES, GlobalShieldStatus::HasShields) {
+	AbstractDialogModel(parent, viewport), _teams(Iff_info.size(), GlobalShieldStatus::HasShields) {
 
 	initializeData();
 }
@@ -51,12 +51,12 @@ int ShieldSystemDialogModel::getCurrentShipType() const
 }
 void ShieldSystemDialogModel::setCurrentTeam(int team)
 {
-	Assertion(SCP_vector_inbounds(Iff_info, team), "Team index %d out of bounds (size: %d)", team, static_cast<int>(Iff_info.size()));
+	Assertion(Iff_info.in_bounds(team), "Team index %d out of bounds (size: %d)", team, static_cast<int>(Iff_info.size()));
 	_currTeam = team;
 }
 void ShieldSystemDialogModel::setCurrentShipType(int type)
 {
-	Assertion(type >= 0 && type < MAX_SHIP_CLASSES, "Ship class index %d is invalid!", type); // NOLINT(readability-simplify-boolean-expr)
+	Assertion(Ship_info.in_bounds(type), "Ship class index %d is invalid!", type);
 	_currType = type;
 }
 
@@ -66,7 +66,7 @@ GlobalShieldStatus ShieldSystemDialogModel::getCurrentTeamShieldSys() const
 }
 GlobalShieldStatus ShieldSystemDialogModel::getCurrentTypeShieldSys() const
 {
-	return _types[_currType];
+	return _types.value_or(_currType, GlobalShieldStatus::HasShields);
 }
 
 void ShieldSystemDialogModel::applyTeam(bool hasShields)

--- a/qtfred/src/mission/dialogs/ShieldSystemDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShieldSystemDialogModel.h
@@ -38,7 +38,7 @@ class ShieldSystemDialogModel: public AbstractDialogModel {
 	SCP_vector<SCP_string> _shipTypeOptions;
 	SCP_vector<SCP_string> _teamOptions;
 	SCP_vector<GlobalShieldStatus> _teams;
-	SCP_vector<GlobalShieldStatus> _types;
+	SCP_map<int, GlobalShieldStatus> _types;	// ship class -> shield status; absent = HasShields
 	int	_currTeam;
 	int	_currType;
 };


### PR DESCRIPTION
Shield_sys_types (the per-ship-class shield status in the FRED2/qtFRED Shield System dialog) was a dense array/vector sized to MAX_SHIP_CLASSES, one of the last cap-blocking structures.  It is a poor fit for a dense container: it is derived, ephemeral editor state, and sparse in practice, since only the ship classes present in the mission ever get a meaningful value.  Its default (HasShields) is exactly the "absent" case.

Convert it to a map keyed by ship class:

  FRED2:  int Shield_sys_types[MAX_SHIP_CLASSES]            -> SCP_map<int, int>
  qtFRED: SCP_vector<GlobalShieldStatus> Shield_sys_types   -> SCP_map<int, GlobalShieldStatus>
          (and the ShieldSystemDialogModel::_types copy likewise)

No file-format or behavior change: shield status is still derived from and applied to the same ship flags.