### PR TITLE
Remove the ship class limit

### DIFF
--- a/code/globalincs/globals.h
+++ b/code/globalincs/globals.h
@@ -9,7 +9,6 @@
 #ifndef _GLOBALS_H
 #define _GLOBALS_H
 
-
 // from parselo.h
 #define	PATHNAME_LENGTH			192
 #define	NAME_LENGTH				32
@@ -23,6 +22,9 @@
 #define TRAINING_MESSAGE_LENGTH	512
 #define CONDITION_LENGTH		64
 
+// from missionparse.h and then redefined to the same value in sexp.h
+#define TOKEN_LENGTH	32
+
 // from missionparse.h
 #define MISSION_DESC_LENGTH		512
 
@@ -34,10 +36,7 @@
 #define MAX_SHIPS					500		// max number of ship instances there can be.DTP; bumped from 200 to 400, then to 500 in 2022
 #define SHIPS_LIMIT					500		// what MAX_SHIPS will be at release time (for error checking in debug mode); dtp Bumped from 200 to 400, then to 500 in 2022
 
-// from missionparse.h and then redefined to the same value in sexp.h
-#define TOKEN_LENGTH	32
-
-#define MAX_SHIP_CLASSES		500
+// MAX_SHIP_CLASSES is no longer needed!  The effective ceiling on ship classes is now 32767, which is determined by the signed SHORT fields in multiplayer loadout sync packets.
 
 #define MAX_WINGS				75
 
@@ -58,17 +57,14 @@
 // Goober5000 - moved from hudescort.cpp
 // size of complete escort list, including all those wanting to get onto list but without space
 #define MAX_COMPLETE_ESCORT_LIST	20
-             
+
 // from weapon.h
 #define MAX_WEAPONS	3000		//Increased from 2000 to 3000 in 2022
 
 #define MAX_WEAPON_TYPES				500
 
-
 // from model.h
-
 #define MAX_MODEL_TEXTURES	64
-
 #define MAX_POLYGON_MODELS  300
 
 // object.h

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -7507,8 +7507,6 @@ bool parse_main(const char *mission_name, int flags)
 {
 	bool rval;
 
-	Assert(Ship_info.size() <= MAX_SHIP_CLASSES);
-
 	Parsing_mission = true;
 
 	do {

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -78,7 +78,7 @@ void pilotfile::csg_read_info()
 	//       this is not necessarily fatal
 	//
 
-	// ship list (NOTE: may contain more than MAX_SHIP_CLASSES)
+	// ship list (NOTE: may contain more ship classes than this mod defines)
 	list_size = cfread_int(cfp);
 
 	for (idx = 0; idx < list_size; idx++) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1998,11 +1998,6 @@ static void parse_ship(const char *filename, bool replace)
 			return;
 		}
 
-		// Check if there are too many ship classes
-		if (Ship_info.size() >= MAX_SHIP_CLASSES) {
-			Error(LOCATION, "Too many ship classes before '%s'; maximum is %d.\n", fname, MAX_SHIP_CLASSES);
-		}
-
 		Ship_info.push_back(ship_info());
 		sip = &Ship_info.back();
 		first_time = true;


### PR DESCRIPTION
With every fixed-size ship-class-indexed structure now converted to dynamic containers, we can finally remove the `MAX_SHIP_CLASSES` limit!

~~This depends on PRs #7737, #7739, #7742, and #7743.  It is in draft until they are merged.~~