### PR TITLE
Fix qtFRED crash when opening ship texture dialog on placeholder slot

### DIFF
--- a/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
@@ -487,6 +487,8 @@ SCP_string ShipTextureReplacementDialogModel::getDefaultName(size_t index) const
 void ShipTextureReplacementDialogModel::setMap(size_t index, const SCP_string& type, const SCP_string& newName)
 {
 	Assertion(index < _currentTextures.size(), "Texture index out of bounds");
+	if (_defaultTextures[index].empty())
+		return;
 	auto pos = _currentTextures[index].find(type);
 	if (pos == _currentTextures[index].end()) {
 		error_display(1, "Tried to set non existant map type %s. Get a programmer", type.c_str());
@@ -499,6 +501,8 @@ void ShipTextureReplacementDialogModel::setMap(size_t index, const SCP_string& t
 SCP_string ShipTextureReplacementDialogModel::getMap(size_t index, const SCP_string& type) const
 {
 	Assertion(index < _currentTextures.size(), "Texture index out of bounds");
+	if (_defaultTextures[index].empty())
+		return "";
 	auto pos = _currentTextures[index].find(type);
 	if (pos == _currentTextures[index].end()) {
 		error_display(1, "Asked for non existant map type %s. Get a programmer", type.c_str());

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipTextureReplacementDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipTextureReplacementDialog.cpp
@@ -84,7 +84,16 @@ ShipTextureReplacementDialog::ShipTextureReplacementDialog(QDialog* parent, Edit
 	ui->TexturesList->setModel(_listModel);
 	QItemSelectionModel* selectionModel = ui->TexturesList->selectionModel();
 	connect(selectionModel, &QItemSelectionModel::selectionChanged, this, &ShipTextureReplacementDialog::updateUiFull);
-	QModelIndex index = _listModel->index(0);
+	// Select the first real texture; blank/duplicate slots are placeholders that render as
+	// hidden (zero-height) rows and have no editable data.
+	int firstReal = 0;
+	for (size_t i = 0; i < _model->getSize(); i++) {
+		if (!_model->getDefaultName(i).empty()) {
+			firstReal = static_cast<int>(i);
+			break;
+		}
+	}
+	QModelIndex index = _listModel->index(firstReal);
 	ui->TexturesList->setCurrentIndex(index);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &ShipTextureReplacementDialog::updateUi);


### PR DESCRIPTION
The ship texture replacement dialog builds parallel per-slot arrays sized to pm->n_textures, but only populates the "main"/subtype map entries for real textures; blank and duplicate texture slots are left as empty-map placeholders (with an empty default name). The dialog constructor then force-selected row 0, and getMap()/setMap() raised a fatal error_display when "main" was absent, so any ship whose first texture slot is blank or a duplicate crashed the dialog on open.

getMap()/setMap() now treat an empty default name as a non-editable placeholder.  The constructor also selects the first real texture row rather than blindly row 0.