### PR TITLE
Fix a couple of oversights in prop collisions

### DIFF
--- a/code/object/collidedebrisship.cpp
+++ b/code/object/collidedebrisship.cpp
@@ -553,7 +553,7 @@ int collide_asteroid_prop(obj_pair* pair)
 			asteroid_hit_info.light = asteroid_objp;
 		}
 
-		hit = prop_check_collision(prop_objp, prop_objp, &hitpos, &asteroid_hit_info);
+		hit = prop_check_collision(prop_objp, asteroid_objp, &hitpos, &asteroid_hit_info);
 		if (hit)
 		{
 			bool ship_override = false, asteroid_override = false;

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -947,22 +947,25 @@ int collide_prop_weapon(obj_pair* pair)
 /**
  * Upper limit estimate ship speed at end of time
  */
-static float estimate_ship_speed_upper_limit( object *ship, float time ) 
+static float estimate_ship_speed_upper_limit( object *objp, float time )
 {
 	float exponent;
 	float delta_v;
 	float factor;
 
-	delta_v = Ship_info[Ships[ship->instance].ship_info_index].max_vel.xyz.z - ship->phys_info.speed;
+	if (objp->type != OBJ_SHIP)
+		return objp->phys_info.speed;
+
+	delta_v = Ship_info[Ships[objp->instance].ship_info_index].max_vel.xyz.z - objp->phys_info.speed;
 	
-	if (ship->phys_info.forward_accel_time_const == 0) {
-		return ship->phys_info.speed;
+	if (objp->phys_info.forward_accel_time_const == 0) {
+		return objp->phys_info.speed;
 	}
 	
-	exponent = time / ship->phys_info.forward_accel_time_const;
+	exponent = time / objp->phys_info.forward_accel_time_const;
 
 	factor = 1.0f - (float)exp( -exponent );
-	return ship->phys_info.speed + factor*delta_v;
+	return objp->phys_info.speed + factor*delta_v;
 }
 
 // maximum error allowed in detecting collisions between laser and big ship inside the radius

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -2089,6 +2089,10 @@ void player_generate_death_message(player *player_p)
 			sprintf(msg, XSTR( "%s was killed by a collision with an asteroid", 98), player_p->callsign);
 			break;
 
+		case OBJ_PROP:
+			sprintf(msg, XSTR( "%s was killed by a collision with an object", -1), player_p->callsign);
+			break;
+
 		case OBJ_BEAM:
 			if (strlen(player_p->killer_parent_name) <= 0)
 			{

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1223,6 +1223,8 @@ static void shiphit_record_player_killer(const object *killer_objp, player *p)
 		break;
 
 	case OBJ_PROP:
+		p->killer_objtype = OBJ_PROP;
+		p->killer_weapon_index = -1;
 		strcpy_s(p->killer_parent_name, "");
 		p->killer_species = -1;
 		p->killer_parent_name[0] = '\0';


### PR DESCRIPTION
While testing things on Solaris, I found a bug where prop objects were using a function that is only properly valid for ships, causing a crash whenever the number of props exceeds the number of ships.
I then used Claude to look for similar issues, and some were actually found; this fixes those as well.