### PR TITLE
Clear bsp_data from bsp_info after it has been used

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -473,7 +473,7 @@ public:
 	matrix	frame_of_reference;		// used to be called 'orientation' - this is just used for setting the rotation axis and the animation angles
 
 	int		bsp_data_size;
-	std::shared_ptr<ubyte[]> bsp_data;
+	std::shared_ptr<ubyte[]> bsp_data; // the bsp_data loaded and then cleared after has been used in modelread
 
 	int collision_tree_index;
 
@@ -490,6 +490,7 @@ public:
 
 	int		num_live_debris;		// num live debris models assocaiated with a submodel
 	int		live_debris[MAX_LIVE_DEBRIS];	// array of live debris submodels for a submodel
+	int     num_polys = 0;          // number of tmaps & flat polys in a submodel, only loaded and used with the -pofspew cmdline
 
 	// Tree info
 	int		parent;					// what is parent for each submodel, -1 if none
@@ -1051,8 +1052,6 @@ void model_delete_instance(int model_instance_num);
 
 // Goober5000
 void model_load_texture(polymodel *pm, int i, const char *file);
-
-SCP_set<int> model_get_textures_used(const polymodel* pm, int submodel);
 
 // Returns a pointer to the polymodel structure for model 'n'
 polymodel *model_get(int model_num);

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -25,6 +25,7 @@
 #include "math/fvi.h"
 #include "math/staticrand.h"
 #include "mission/missionparse.h"
+#include "model/modelinterp.h"
 #include "model/modelrender.h"
 #include "model/modelsinc.h"
 #include "nebula/neb.h"
@@ -1245,19 +1246,19 @@ int submodel_get_num_polys_sub( ubyte *p )
 			int prelist = w(p+44);
 			int postlist = w(p+48);
 			int onlist = w(p+52);
-			n += submodel_get_num_polys_sub(p+frontlist);
-			n += submodel_get_num_polys_sub(p+backlist);
-			n += submodel_get_num_polys_sub(p+prelist);
-			n += submodel_get_num_polys_sub(p+postlist );
-			n += submodel_get_num_polys_sub(p+onlist );
+			if (frontlist) n += submodel_get_num_polys_sub(p + frontlist);
+			if (backlist) n += submodel_get_num_polys_sub(p + backlist);
+			if (prelist) n += submodel_get_num_polys_sub(p + prelist);
+			if (postlist) n += submodel_get_num_polys_sub(p + postlist);
+			if (onlist) n += submodel_get_num_polys_sub(p + onlist);
 			}
 			break;
 
 		case OP_SORTNORM2: {
 			int frontlist = w(p + 8);
 			int backlist = w(p + 12);
-			n += submodel_get_num_polys_sub(p + frontlist);
-			n += submodel_get_num_polys_sub(p + backlist);
+			if (frontlist) n += submodel_get_num_polys_sub(p + frontlist);
+			if (backlist) n += submodel_get_num_polys_sub(p + backlist);
 			}
 			end = true; // should not continue after this chunk
 			break;
@@ -1286,13 +1287,9 @@ int submodel_get_num_polys_sub( ubyte *p )
 /**
  * Returns number of tmaps & flat polys in a submodel
  */
-int submodel_get_num_polys(int model_num, int submodel_num )
+int submodel_get_num_polys(int model_num, int submodel_num)
 {
-	polymodel * pm;
-
-	pm = model_get(model_num);
-
-	return submodel_get_num_polys_sub( pm->submodel[submodel_num].bsp_data.get() );
+	return model_get(model_num)->submodel[submodel_num].num_polys;
 }
 
 /**

--- a/code/model/modelinterp.h
+++ b/code/model/modelinterp.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+class polymodel;
+
+// Internal BSP helpers shared by the model loader and virtual POF processing.
+int submodel_get_num_polys_sub(ubyte* bsp_data);
+SCP_set<int> model_get_textures_used(const polymodel* pm, int submodel);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3509,15 +3509,10 @@ int model_load(const  char* filename, ship_info* sip, ErrorType error_type, bool
 		auto* sm = &pm->submodel[i];
 		sm->collision_tree_index = model_create_bsp_collision_tree();
 
-		if (sm->bsp_data == nullptr) {
-			sm->num_polys = 0;
-			continue;
-		}
-
 		auto* bsp_data = sm->bsp_data.get();
 		Macro_ubyte_bounds = bsp_data + sm->bsp_data_size;
 		if (Cmdline_spew_pof_info) {
-			sm->num_polys = submodel_get_num_polys_sub(bsp_data);
+			sm->num_polys = bsp_data != nullptr ? submodel_get_num_polys_sub(bsp_data) : 0;
 		}
 		auto* tree = model_get_bsp_collision_tree(sm->collision_tree_index);
 		model_collide_parse_bsp(tree, bsp_data, pm->version);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3504,7 +3504,6 @@ int model_load(const  char* filename, ship_info* sip, ErrorType error_type, bool
 #endif
 
 	TRACE_SCOPE(tracing::ModelParseAllBSPTrees);
-	extern int Cmdline_spew_pof_info;
 
 	for (i = 0; i < pm->n_models; ++i) {
 		auto* sm = &pm->submodel[i];

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -31,6 +31,7 @@
 #include "math/fvi.h"
 #include "math/vecmat.h"
 #include "model/model.h"
+#include "model/modelinterp.h"
 #include "model/modelrender.h"
 #include "model/modelreplace.h"
 #include "model/modelsinc.h"
@@ -3503,14 +3504,31 @@ int model_load(const  char* filename, ship_info* sip, ErrorType error_type, bool
 #endif
 
 	TRACE_SCOPE(tracing::ModelParseAllBSPTrees);
+	extern int Cmdline_spew_pof_info;
 
 	for (i = 0; i < pm->n_models; ++i) {
-		pm->submodel[i].collision_tree_index = model_create_bsp_collision_tree();
-		bsp_collision_tree* tree             = model_get_bsp_collision_tree(pm->submodel[i].collision_tree_index);
+		auto* sm = &pm->submodel[i];
+		sm->collision_tree_index = model_create_bsp_collision_tree();
 
-		Macro_ubyte_bounds = pm->submodel[i].bsp_data.get() + pm->submodel[i].bsp_data_size;
-		model_collide_parse_bsp(tree, pm->submodel[i].bsp_data.get(), pm->version);
+		if (sm->bsp_data == nullptr) {
+			sm->num_polys = 0;
+			continue;
+		}
+
+		auto* bsp_data = sm->bsp_data.get();
+		Macro_ubyte_bounds = bsp_data + sm->bsp_data_size;
+		if (Cmdline_spew_pof_info) {
+			sm->num_polys = submodel_get_num_polys_sub(bsp_data);
+		}
+		auto* tree = model_get_bsp_collision_tree(sm->collision_tree_index);
+		model_collide_parse_bsp(tree, bsp_data, pm->version);
 		Macro_ubyte_bounds = nullptr;
+	}
+
+	// clear bsp_data cache
+	for (i = 0; i < pm->n_models; ++i) {
+		pm->submodel[i].bsp_data.reset();
+		pm->submodel[i].bsp_data_size = 0;
 	}
 
 	// Find the core_radius... the minimum of 

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -1,6 +1,7 @@
 #include "modelreplace.h"
 
 #include "model/model.h"
+#include "model/modelinterp.h"
 
 #include "cfile/cfile.h"
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -968,6 +968,7 @@ add_file_folder("Model"
 	model/model.h
 	model/modelcollide.cpp
 	model/modelinterp.cpp
+	model/modelinterp.h
 	model/modelread.cpp
 	model/modelrender.h
 	model/modelrender.cpp


### PR DESCRIPTION
After taking a look at were bsp_data is used, i noticed that only submodel_get_num_polys() used it after it had completed model_load(), and this function was called only from freespace2.cpp when the -pofspew was used.

So i changed it to save the result of submodel_get_num_polys_sub() that submodel_get_num_polys() used when the -pofspew cmdline is used. Then i reseted the buffer.

Then i noticed -pofspew was causing an abort because submodel_get_num_polys_sub() had an infinite recursion bug when one of the list had a value of 0 and called submodel_get_num_polys_sub() again.
I confirmed this by running -pofspew on the current nightly and it crashes before exporting all models on BP 3.3.3 dataset, so this was probably broken for like, forever. I added a check to avoid this and how it works again.

As for the results of clearing the bsp_data cache:
On Icarus (with a dgpu)

Before:
<img width="727" height="52" alt="with-bsp" src="https://github.com/user-attachments/assets/1229fa92-b69d-4f03-8375-04e0d441c520" />

After:
<img width="742" height="56" alt="clear-bsp" src="https://github.com/user-attachments/assets/d1f59d60-3107-4d2a-a54d-5429b87ee583" />

Im not noticing any problems with this change, but ill recommend someone who knows more about the model system (and virtual pof) might want to check it out first.


P.D. i moved model_get_textures_used() declaration from models.h to modelinterp.h i just added because it seems cleaner since i was adding a new header.