### PR TITLE
Allow giveOrder to specify dockpoints for ORDER_DOCK

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -911,7 +911,24 @@ void ai_add_goal_sub_scripting(ai_goal_type type, ai_goal_mode mode, int submode
 	}
 }
 
-void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, const char *shipname, ai_info *aip, int int_data, float float_data)
+// find a dockpoint on the given ship that is compatible with the specified dock-type flags (c.f. ai_goal_fixup_dockpoints)
+static int ai_goal_find_compatible_dockpoint(int shipnum, int type_flags)
+{
+	for (int i = 0; i < Num_dock_type_names; i++)
+	{
+		if (type_flags & Dock_type_names[i].def)
+		{
+			int dock_index = ai_goal_find_dockpoint(shipnum, Dock_type_names[i].def);
+			if (dock_index >= 0)
+				return dock_index;
+		}
+	}
+
+	// no compatible type-specific point found; fall back to a generic one
+	return ai_goal_find_dockpoint(shipnum, DOCK_TYPE_GENERIC);
+}
+
+void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, const char *shipname, ai_info *aip, int int_data, float float_data, int docker_index, int dockee_index)
 {
 	int empty_index;
 	ai_goal *aigp;
@@ -927,7 +944,27 @@ void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, co
 	}
 
 	if ( (mode == AI_GOAL_REARM_REPAIR) || (mode == AI_GOAL_DOCK) ) {
-		ai_goal_fixup_dockpoints( aip, aigp );
+		// if the caller specified one or both dockpoints, honor them and choose the other side to match
+		if ( mode == AI_GOAL_DOCK && (docker_index >= 0 || dockee_index >= 0) ) {
+			int dockee_shipnum = ship_name_lookup(shipname);
+			Assertion(dockee_shipnum >= 0, "Couldn't find dock target '%s'; get a coder!", shipname);
+
+			// if only one point was given, choose the other to match its dock type
+			if ( docker_index < 0 ) {
+				polymodel *dockee_pm = model_get(Ship_info[Ships[dockee_shipnum].ship_info_index].model_num);
+				docker_index = ai_goal_find_compatible_dockpoint(aip->shipnum, dockee_pm->docking_bays[dockee_index].type_flags);
+			} else if ( dockee_index < 0 ) {
+				polymodel *docker_pm = model_get(Ship_info[Ships[aip->shipnum].ship_info_index].model_num);
+				dockee_index = ai_goal_find_compatible_dockpoint(dockee_shipnum, docker_pm->docking_bays[docker_index].type_flags);
+			}
+
+			aigp->docker.index = docker_index;
+			aigp->dockee.index = dockee_index;
+			aigp->flags.set(AI::Goal_Flags::Docker_index_valid);
+			aigp->flags.set(AI::Goal_Flags::Dockee_index_valid);
+		} else {
+			ai_goal_fixup_dockpoints( aip, aigp );
+		}
 	}
 }
 

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -183,7 +183,7 @@ extern void ai_process_mission_orders( int objnum, ai_info *aip );
 extern int ai_goal_num(ai_goal *goals);
 
 // adds goals to ships/wing through sexpressions
-extern void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, const char *shipname, ai_info *aip, int int_data, float float_data);
+extern void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, const char *shipname, ai_info *aip, int int_data, float float_data, int docker_index = -1, int dockee_index = -1);
 extern void ai_add_ship_goal_sexp(int sexp, ai_goal_type type, ai_info *aip);
 extern void ai_add_wing_goal_sexp(int sexp, ai_goal_type type, wing *wingp);
 extern void ai_add_goal_sub_sexp(int sexp, ai_goal_type type, ai_info *aip, ai_goal *aigp, const char *actor_name);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1695,7 +1695,7 @@ ADE_FUNC(clearOrders, l_Ship, NULL, "Clears a ship's orders list", "boolean", "T
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(giveOrder, l_Ship, "enumeration Order /* ORDER_* */, [object Target=nil, subsystem TargetSubsystem=nil, number Priority=1.0, shipclass TargetShipclass=nil, shiptype TargetShiptype=nil]", "Uses the goal code to execute orders.  NOTE: This function uses a scale from 0.0-1.0 (up to 2.0) rather than the usual 0-100 (up to 200)", "boolean", "True if order was given, otherwise false or nil")
+ADE_FUNC(giveOrder, l_Ship, "enumeration Order /* ORDER_* */, [object Target=nil, subsystem TargetSubsystem=nil, number Priority=1.0, shipclass TargetShipclass=nil, shiptype TargetShiptype=nil, string|number DockerPoint=nil, string|number DockeePoint=nil]", "Uses the goal code to execute orders.  NOTE: This function uses a scale from 0.0-1.0 (up to 2.0) rather than the usual 0-100 (up to 200).  DockerPoint and DockeePoint only apply to ORDER_DOCK.", "boolean", "True if order was given, otherwise false or nil")
 {
 	object_h *objh = NULL;
 	enum_h *eh = NULL;
@@ -1704,6 +1704,8 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order /* ORDER_* */, [object Target=nil
 	int stype = -1;
 	object_h *tgh = NULL;
 	ship_subsys_h *tgsh = NULL;
+	int docker_index = -1;
+	int dockee_index = -1;
 	int n_args = ade_get_args(L, "oo|oofoo", l_Object.GetPtr(&objh), l_Enum.GetPtr(&eh), l_Object.GetPtr(&tgh), l_Subsystem.GetPtr(&tgsh), &priority, l_Shipclass.Get(&sclass), l_Shiptype.Get(&stype));
 	if (n_args < 2)
 		return ADE_RETURN_NIL;
@@ -1757,6 +1759,52 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order /* ORDER_* */, [object Target=nil
 			ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			ai_mode = AI_GOAL_DOCK;
 			ai_submode = AIS_DOCK_0;
+
+			polymodel *docker_pm = model_get(Ship_info[Ships[objh->objp()->instance].ship_info_index].model_num);
+			polymodel *dockee_pm = model_get(Ship_info[Ships[tgh->objp()->instance].ship_info_index].model_num);
+
+			if (!lua_isnoneornil(L, 8))
+			{
+				if (lua_isnumber(L, 8))
+				{
+					ade_get_args(L, "*******i", &docker_index);
+					docker_index--;	// Lua --> C/C++
+				}
+				else
+				{
+					const char *name = nullptr;
+					ade_get_args(L, "*******s", &name);
+					docker_index = model_find_dock_name_index(docker_pm, name);
+				}
+
+				if (docker_index < 0 || docker_index >= docker_pm->n_docks)
+				{
+					LuaError(L, "Invalid docker point specified for ship '%s'", Ships[objh->objp()->instance].ship_name);
+					return ade_set_error(L, "b", false);
+				}
+			}
+
+			if (!lua_isnoneornil(L, 9))
+			{
+				if (lua_isnumber(L, 9))
+				{
+					ade_get_args(L, "********i", &dockee_index);
+					dockee_index--;	// Lua --> C/C++
+				}
+				else
+				{
+					const char *name = nullptr;
+					ade_get_args(L, "********s", &name);
+					dockee_index = model_find_dock_name_index(dockee_pm, name);
+				}
+
+				if (dockee_index < 0 || dockee_index >= dockee_pm->n_docks)
+				{
+					LuaError(L, "Invalid dockee point specified for ship '%s'", Ships[tgh->objp()->instance].ship_name);
+					return ade_set_error(L, "b", false);
+				}
+			}
+
 			break;
 		}
 		case LE_ORDER_WAYPOINTS:
@@ -1979,7 +2027,7 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order /* ORDER_* */, [object Target=nil
 		return ade_set_error(L, "b", false);
 
 	//Fire off the goal
-	ai_add_ship_goal_scripting(ai_mode, ai_submode, fl2i(priority*100.0f), ai_shipname, &Ai_info[Ships[objh->objp()->instance].ai_index], int_data, float_data);
+	ai_add_ship_goal_scripting(ai_mode, ai_submode, fl2i(priority*100.0f), ai_shipname, &Ai_info[Ships[objh->objp()->instance].ai_index], int_data, float_data, docker_index, dockee_index);
 
 	return ADE_RETURN_TRUE;
 }


### PR DESCRIPTION
The giveOrder scripting function now accepts optional DockerPoint and DockeePoint arguments for ORDER_DOCK, each given as a dockpoint name or one-based index (matching the setDocked convention).  DockerPoint refers to a dockpoint on the ordering ship and DockeePoint to one on the target.

If only one point is specified, a compatible point is chosen automatically on the other ship using the same dock-type precedence as the existing automatic dockpoint negotiation.  When neither is specified, behavior is unchanged.

Fixes #7119.  ~~In draft pending testing.~~