### PR TITLE
Remove the weapon class limit

### DIFF
--- a/code/globalincs/globals.h
+++ b/code/globalincs/globals.h
@@ -36,7 +36,7 @@
 #define MAX_SHIPS					500		// max number of ship instances there can be.DTP; bumped from 200 to 400, then to 500 in 2022
 #define SHIPS_LIMIT					500		// what MAX_SHIPS will be at release time (for error checking in debug mode); dtp Bumped from 200 to 400, then to 500 in 2022
 
-// MAX_SHIP_CLASSES is no longer needed!  The effective ceiling on ship classes is now 32767, which is determined by the signed SHORT fields in multiplayer loadout sync packets.
+// MAX_SHIP_CLASSES and MAX_WEAPON_TYPES are no longer needed!  The effective ceiling on both ship and weapon classes is now 32767, which is determined by the signed SHORT fields in multiplayer loadout sync packets.
 
 #define MAX_WINGS				75
 
@@ -60,8 +60,6 @@
 
 // from weapon.h
 #define MAX_WEAPONS	3000		//Increased from 2000 to 3000 in 2022
-
-#define MAX_WEAPON_TYPES				500
 
 // from model.h
 #define MAX_MODEL_TEXTURES	64

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -90,7 +90,7 @@ void pilotfile::csg_read_info()
 		ship_list.push_back(ilist);
 	}
 
-	// weapon list (NOTE: may contain more than MAX_WEAPON_TYPES)
+	// weapon list (NOTE: may contain more weapon classes than this mod defines)
 	list_size = cfread_int(cfp);
 
 	for (idx = 0; idx < list_size; idx++) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -854,11 +854,6 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			return -1;
 		}
 
-		// Check if there are too many weapon classes
-		if (Weapon_info.size() >= MAX_WEAPON_TYPES) {
-			Error(LOCATION, "Too many weapon classes before '%s'; maximum is %d.\n", fname, MAX_WEAPON_TYPES);
-		}
-
 		w_id = weapon_info_size();
 		Weapon_info.push_back(weapon_info());
 		wip = &Weapon_info.back();


### PR DESCRIPTION
With every fixed-size weapon-class-indexed structure now converted to dynamic containers, we can finally remove the `MAX_WEAPON_TYPES` limit!

~~This depends on PR #7758 and is in draft until that is merged.~~