### PR TITLE
Scale font line and tab advance by the font scale factor

### DIFF
--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -556,22 +556,21 @@ struct v4 {
 };
 static v4 String_render_buff[MAX_VERTS_PER_DRAW];
 
-namespace font {
-extern int get_char_width_old(font* fnt, ubyte c1, ubyte c2, int* width, int* spacing);
-}
-
 static void gr_string_old(float sx,
 	float sy,
 	const char* s,
 	const char* end,
-	font::font* fontData,
-	float height,
-	bool canAutoScale,
-	bool canScale,
+	const font::font* fontData,
+	const font::FSFont* fontMetrics,
 	int resize_mode,
 	float scaleMultiplier)
 {
 	GR_DEBUG_SCOPE("Render VFNT string");
+
+	const float height = fontMetrics->getHeight();
+	const bool canAutoScale = fontMetrics->getAutoScaleBehavior();
+	const bool canScale = fontMetrics->getScaleBehavior();
+	const float tabWidth = fontMetrics->getTabWidth();
 
 	float x = sx;
 	float y = sy;
@@ -638,6 +637,13 @@ static void gr_string_old(float sx,
 
 		if (*s == 0) {
 			break;
+		}
+
+		// Handle tabs
+		if (*s == '\t') {
+			s++;
+			x += tabWidth * scale_factor;
+			continue;
 		}
 
 		// Get character width and spacing
@@ -822,7 +828,7 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, float scaleMu
 		VFNTFont* fnt = static_cast<VFNTFont*>(currentFont);
 		fo::font* fontData = fnt->getFontData();
 
-		gr_string_old(sx, sy, s, s + length, fontData, fnt->getHeight(), currentFont->getAutoScaleBehavior(), currentFont->getScaleBehavior(), resize_mode, scaleMultiplier);
+		gr_string_old(sx, sy, s, s + length, fontData, currentFont, resize_mode, scaleMultiplier);
 	} else if (currentFont->getType() == NVG_FONT) {
 		GR_DEBUG_SCOPE("Render TTF string");
 
@@ -878,13 +884,13 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, float scaleMu
 						case '\n':
 							doRender = false;
 
-							y += nvgFont->getHeight();
+							y += nvgFont->getHeight() * scale_factor;
 							x = 0;
 							break;
 						case '\t':
 							doRender = false;
 
-							x += nvgFont->getTabWidth();
+							x += nvgFont->getTabWidth() * scale_factor;
 							break;
 						case '\r':
 							// Ignore Carriage return chars
@@ -919,9 +925,7 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, float scaleMu
 									  text,
 									  text + 1,
 									  nvgFont->getSpecialCharacterFont(),
-									  nvgFont->getHeight(),
-							          nvgFont->getAutoScaleBehavior(),
-									  nvgFont->getScaleBehavior(),
+									  nvgFont,
 									  resize_mode,
 									  scaleMultiplier);
 					}

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -96,6 +96,17 @@ namespace font
 		return this->offsetTop;
 	}
 
+	float FSFont::getTabWidth() const
+	{
+		return this->tabWidth;
+	}
+
+	void FSFont::setTabWidth(float newTabWidth)
+	{
+		Assertion(newTabWidth >= 0.0f, "Invalid tab width passed!");
+		this->tabWidth = newTabWidth;
+	}
+
 	float FSFont::getHeight() const
 	{
 		return _height;

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -46,6 +46,7 @@ namespace font
 		bool canScale = false;			//!< If the font is allowed to scale with the user font multiplier
 		float offsetTop = 0.0f;			//!< The offset at the top of a line of text
 		float offsetBottom = 0.0f;		//!< The offset at the bottom of a line of text
+		float tabWidth = 20.0f;			//!< The width of a tab character in pixels (before scaling)
 
 		float _height = 0.0f;
 		float _ascender = 0.0f;
@@ -207,6 +208,13 @@ namespace font
 		float getBottomOffset() const;
 
 		/**
+		* @brief	Gets the width of a tab character for this font, in unscaled pixels
+		*
+		* @return	The tab width.
+		*/
+		float getTabWidth() const;
+
+		/**
 		* @brief    Sets the auto scaling behavior for VFNTs
 		*
 		* @date     24.1.2025
@@ -243,6 +251,13 @@ namespace font
 		* @param	newOffset The new bottom offset for this font
 		*/
 		void setBottomOffset(float newOffset);
+
+		/**
+		* @brief	Sets the tab width for this font, in unscaled pixels
+		*
+		* @param	newTabWidth The new tab width for this font
+		*/
+		void setTabWidth(float newTabWidth);
 
 		/**
 		 * @brief Recomputes the font metrics

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -1,5 +1,6 @@
 
 #include "graphics/software/NVGFont.h"
+#include "graphics/software/font_internal.h"
 #include "graphics/paths/PathRenderer.h"
 
 #include "mod_table/mod_table.h"
@@ -94,12 +95,6 @@ namespace font
 		m_letterSpacing = spacing;
 	}
 
-	void NVGFont::setTabWidth(float tabWidth)
-	{
-		Assertion(tabWidth >= 0.0f, "Invalid tab width passed!");
-		m_tabWidth = tabWidth;
-	}
-
 	void NVGFont::setSpecialCharacterFont(font* fontData)
 	{
 		Assertion(fontData != nullptr, "Invalid font data pointer passed!");
@@ -111,7 +106,6 @@ namespace font
 		return m_lineHeight;
 	}
 
-	extern int get_char_width_old(font* fnt, ubyte c1, ubyte c2, int *width, int* spacing);
 	void NVGFont::getStringSize(const char *text, size_t textLen, int resize_mode, float *width, float *height, float scaleMultiplier) const
 	{
 		using namespace graphics::paths;
@@ -140,7 +134,7 @@ namespace font
 		}
 
 		float w = 0.0f;
-		float h = this->getHeight();
+		float h = this->getHeight() * scale_factor;
 
 		size_t tokenLength;
 
@@ -163,13 +157,13 @@ namespace font
 				case '\n':
 					specialChar = true;
 
-					h += this->getHeight();
+					h += this->getHeight() * scale_factor;
 					lineWidth = 0.0f;
 					break;
 				case '\t':
 					specialChar = true;
 
-					lineWidth += this->getTabWidth();
+					lineWidth += this->getTabWidth() * scale_factor;
 					break;
 				default:
 					if (!Unicode_text_mode) {

--- a/code/graphics/software/NVGFont.h
+++ b/code/graphics/software/NVGFont.h
@@ -12,7 +12,6 @@ namespace font
 		int m_handle = -1;
 		float m_letterSpacing = 0.0f;
 		float m_size = 12.0f;
-		float m_tabWidth = 20.0f;
 
 		font* m_specialCharacters = nullptr;
 
@@ -25,13 +24,11 @@ namespace font
 		int getHandle() const { return m_handle; }
 		float getSize() const { return m_size; }
 		float getLetterSpacing() const { return m_letterSpacing; }
-		float getTabWidth() const { return m_tabWidth; }
 		font* getSpecialCharacterFont() const { return m_specialCharacters; }
 
 		void setHandle(int handle);
 		void setSize(float size);
 		void setLetterSpacing(float spacing);
-		void setTabWidth(float tabWidth);
 		void setSpecialCharacterFont(font* fontData);
 
 		FontType getType() const override { return NVG_FONT; };

--- a/code/graphics/software/VFNTFont.cpp
+++ b/code/graphics/software/VFNTFont.cpp
@@ -39,7 +39,6 @@ namespace font
 		return volitionFontName;
 	}
 
-	extern int get_char_width_old(font* fnt, ubyte c1, ubyte c2, int *width, int* spacing);
 	void VFNTFont::getStringSize(const char *text, size_t textSize, int /* resize_mode */, float *w1, float *h1, float scaleMultiplier) const
 	{
 		int longest_width;
@@ -82,6 +81,24 @@ namespace font
 				if (*text == 0)
 				{
 					break;
+				}
+
+				// Handle tabs to match the VFNT render path
+				if (*text == '\t')
+				{
+					w += fl2i(this->getTabWidth());
+					if (w > longest_width)
+						longest_width = w;
+
+					text++;
+
+					if (checkLength)
+					{
+						textLen--;
+						if (textLen <= 0)
+							break;
+					}
+					continue;
 				}
 
 				get_char_width_old(fontPtr, text[0], text[1], &width, &spacing);

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -176,7 +176,7 @@ namespace
 
 			if (temp < 0.0f)
 			{
-				error_display(0, "Invalid tab spacing %f. Has to be greater or equal to zero.", temp);
+				error_display(0, "Invalid tab width %f! Has to be greater than or equal to zero.", temp);
 			}
 			else
 			{
@@ -191,7 +191,7 @@ namespace
 
 			if (temp < 0.0f)
 			{
-				error_display(0, "Invalid letter spacing %f! Has to be greater or equal to zero.", temp);
+				error_display(0, "Invalid letter spacing %f! Has to be greater than or equal to zero.", temp);
 			}
 			else
 			{
@@ -424,6 +424,21 @@ namespace
 			font->setBottomOffset(temp);
 		}
 
+		if (optional_string("+Tab width:"))
+		{
+			float temp;
+			stuff_float(&temp);
+
+			if (temp < 0.0f)
+			{
+				error_display(0, "Invalid tab width %f! Has to be greater than or equal to zero.", temp);
+			}
+			else
+			{
+				font->setTabWidth(temp);
+			}
+		}
+
 		// Make sure that the height is not invalid
 		font->computeFontMetrics();
 
@@ -651,7 +666,7 @@ namespace font
 		{
 			if (fontNum < 0 || fontNum >= FontManager::numberOfFonts())
 			{
-				error_display(0, "Invalid font number %d! must be greater or equal to zero and smaller than %d.", fontNum, FontManager::numberOfFonts());
+				error_display(0, "Invalid font number %d! Must be greater than or equal to zero and smaller than %d.", fontNum, FontManager::numberOfFonts());
 				font_idx = -1;
 			}
 			else
@@ -693,7 +708,7 @@ namespace font
 	*
 	* @return	The character width.
 	*/
-	int get_char_width_old(fo::font* fnt, ubyte c1, ubyte c2, int *width, int* spacing)
+	int get_char_width_old(const fo::font* fnt, ubyte c1, ubyte c2, int *width, int* spacing)
 	{
 		int i, letter;
 

--- a/code/graphics/software/font_internal.h
+++ b/code/graphics/software/font_internal.h
@@ -45,6 +45,11 @@ namespace font
 		font();
 		~font();
 	} font_data;
+
+	// Looks up the width and spacing of character c1 in the given bitmap font, taking
+	// kerning against the following character c2 into account.  Returns the glyph index,
+	// or -1 if c1 is not present in the font.
+	int get_char_width_old(const font* fnt, ubyte c1, ubyte c2, int* width, int* spacing);
 }
 
 #endif // FONT_INTERNAL_H


### PR DESCRIPTION
Multi-line and tabbed strings drawn with a scaleMultiplier != 1 overlapped or misaligned because the font code advanced newlines and tabs by the unscaled font height/tab width -- most visible in FRED's viewport labels now that they honor an adjustable font scale.

Scale the newline and tab advance in both the rendering and measurement paths of each backend: the NVG path (gr_string and NVGFont::getStringSize) and the VFNT path (gr_string_old and VFNTFont::getStringSize), which also gains tab handling.  The tab width is hoisted onto the shared FSFont base so both backends share it.

While here, pass the FSFont wrapper to gr_string_old instead of a bag of scalars, make its font pointer const, and consolidate the get_char_width_old externs into a single declaration in font_internal.h.

Fixes an engine bug that #7745 uncovered.  Tested in FRED and QtFRED with both VFNT and NVG fonts at different scaling settings.