### PR TITLE
hold bitmap references for replacement and script-set textures

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -81,6 +81,13 @@ SCP_vector<std::array<bitmap_slot, BM_BLOCK_SIZE>> bm_blocks;
 // --------------------------------------------------------------------------------------------------------------------
 // Definition of private variables at file scope (static).
 static bool bm_inited = false;
+
+// Some objects with static storage duration (e.g. model_texture_replace held by a global shared_ptr) release bitmaps
+// in their destructors.  If the program exits without bm_close(), bm_blocks may be destroyed before they are, so this
+// guard, which is destroyed before bm_blocks because it is defined after it, marks bmpman as uninitialized first.
+static struct bm_static_destruction_guard {
+	~bm_static_destruction_guard() { bm_inited = false; }
+} Bm_static_destruction_guard;
 static uint Bm_next_signature = 0x1234;
 static int Bm_low_mem = 0;
 
@@ -2920,6 +2927,9 @@ void bm_print_bitmaps() {
 int bm_release(int handle, int clear_render_targets) {
 	Assert(handle >= 0);
 
+	if (!bm_inited)
+		return 0;
+
 	bitmap_entry *be;
 
 	be = bm_get_entry(handle);
@@ -3017,6 +3027,45 @@ int bm_release(int handle, int clear_render_targets) {
 	}
 
 	return 1;
+}
+
+int bm_add_ref(int handle) {
+	if (!bm_is_valid(handle))
+		return -1;
+
+	// render targets are not counted, because bm_release() will not release them anyway
+	if (bm_is_render_target(handle))
+		return handle;
+
+	// animations are counted on their first frame
+	int first_frame = bm_get_info(handle);
+	if (first_frame < 0)
+		return -1;
+
+	bm_get_entry(first_frame)->load_count++;
+
+	return first_frame;
+}
+
+int bm_release_ref(int handle) {
+	if (!bm_is_valid(handle))
+		return 0;
+
+	// animations are counted on their first frame
+	int first_frame = bm_get_info(handle);
+	if (first_frame < 0)
+		return 0;
+
+	// a locked bitmap can't be freed right now, but our reference can still be given up; the data is then freed by a
+	// later release (render targets are never counted, see bm_add_ref())
+	auto be = bm_get_entry(first_frame);
+	if (be->ref_count != 0 && !bm_is_render_target(first_frame)) {
+		if (be->load_count > 0)
+			be->load_count--;
+		return 0;
+	}
+
+	return bm_release(first_frame);
 }
 
 bool bm_release_rendertarget(int handle) {
@@ -3202,13 +3251,16 @@ bool bm_set_render_target(int handle, int face) {
 	return false;
 }
 
-int bm_unload(int handle, int clear_render_targets, bool nodebug) {
+int bm_unload(int handle, int clear_render_targets, bool nodebug, bool keep_reference) {
 	bitmap_entry *be;
 	bitmap *bmp;
 
 	if (handle == -1) {
 		return -1;
 	}
+
+	if (!bm_inited)
+		return -1;
 
 	be = bm_get_entry(handle);
 	bmp = &be->bm;
@@ -3232,7 +3284,7 @@ int bm_unload(int handle, int clear_render_targets, bool nodebug) {
 	// kind of like ref_count except it gets around the lock/unlock usage problem
 	// this gets set for each bm_load() call so we can make sure and not unload it
 	// from memory, even if we *can*, until it's really not needed anymore
-	if (!Bm_ignore_load_count) {
+	if (!Bm_ignore_load_count && !keep_reference) {
 		if (be->load_count > 0)
 			be->load_count--;
 
@@ -3241,6 +3293,9 @@ int bm_unload(int handle, int clear_render_targets, bool nodebug) {
 			return 0;
 		}
 	}
+
+	// freeing the data resets the load count, but paging out gives up no references, so remember it
+	int saved_load_count = be->load_count;
 
 	// be sure that all frames of an ani are unloaded - taylor
 	if (bm_is_anim(be) == true) {
@@ -3264,7 +3319,22 @@ int bm_unload(int handle, int clear_render_targets, bool nodebug) {
 		bm_free_data(bm_get_slot(handle));		// clears flags, bbp, data, etc
 	}
 
+	if (keep_reference)
+		be->load_count = saved_load_count;
+
 	return 1;
+}
+
+int bm_page_out(int handle) {
+	if (!bm_is_valid(handle))
+		return 0;
+
+	// animations are counted on their first frame
+	int first_frame = bm_get_info(handle);
+	if (first_frame < 0)
+		return 0;
+
+	return (bm_unload(first_frame, 0, false, true) == 1) ? 1 : 0;
 }
 
 void bm_unload_all() {

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -257,11 +257,17 @@ int bm_create_3d(int bpp, int w, int h, int d, void* data = nullptr);
  * @param handle                The index number of the bitmap to free
  * @param clear_render_targets  If true, release a render target
  * @param nodebug               If true, exclude certain debug messages
+ * @param keep_reference        If true, no load-count reference is given up: the data is freed, but every reference to
+ *                              the bitmap is preserved, so it is simply reloaded the next time it is locked.  For
+ *                              animations, pass the first frame, since that is where the references are counted.
+ *                              See bm_page_out()
  *
- * @returns 0 if not successful,
- * @returns 1 if successful
+ * @returns 1 if the data was freed,
+ * @returns 0 if it was not (e.g. the bitmap is locked, or another holder still needs it), or
+ * @returns -1 if the handle is invalid, bmpman is not initialized, or the bitmap is a render target and
+ *   clear_render_targets is not set
  */
-int bm_unload(int handle, int clear_render_targets = 0, bool nodebug = false);
+int bm_unload(int handle, int clear_render_targets = 0, bool nodebug = false, bool keep_reference = false);
 
 /**
  * @brief Quickly unloads a bitmap's data, ignoring the load_count
@@ -275,6 +281,20 @@ int bm_unload(int handle, int clear_render_targets = 0, bool nodebug = false);
  * @note bm_free_data_fast() is used here and NOT bm_free_data()
  */
 int bm_unload_fast(int handle, int clear_render_targets = 0);
+
+/**
+ * @brief Frees a bitmap's data without giving up the caller's load-count reference
+ *
+ * @details Use this to page out a bitmap that will be needed again later: the slot and every reference to the bitmap are
+ *   kept, and the data is reloaded the next time it is locked.  Unlike bm_unload(), this never consumes a reference, so
+ *   it works no matter how many holders the bitmap has.  A bitmap that is currently locked is left alone.
+ *
+ * @param handle  The bitmap handle.  For animations, any frame may be passed; the whole animation is paged out.
+ *
+ * @returns 1 if the data was freed,
+ * @returns 0 otherwise
+ */
+int bm_page_out(int handle);
 
 /**
  * @brief Frees both a bitmap's data and it's associated slot.
@@ -292,6 +312,36 @@ int bm_unload_fast(int handle, int clear_render_targets = 0);
  * @todo upgrade return type and clear_render_targets type to bools
  */
 int bm_release(int handle, int clear_render_targets = 0);
+
+/**
+ * @brief Takes an additional load-count reference on a bitmap that is already loaded
+ *
+ * @details This is the equivalent of loading the bitmap a second time: the bitmap will not be freed until every
+ *   reference has been released.  Use it when storing a handle that was loaded by someone else, so that the stored
+ *   handle stays valid even after the original loader releases it.  Every call must be balanced by a call to
+ *   bm_release_ref().
+ *
+ * @param handle  The bitmap handle.  For animations, any frame may be passed; the reference is taken on the first frame.
+ *   Render targets are not counted, since bm_release() will not release them without being explicitly asked to.
+ *
+ * @returns the handle the reference was taken on (the first frame for animations), or the handle itself for a render
+ *   target, on which no reference is taken, or
+ * @returns -1 if the handle is not a valid bitmap
+ */
+int bm_add_ref(int handle);
+
+/**
+ * @brief Releases a load-count reference taken by bm_add_ref() or by loading the bitmap
+ *
+ * @details Same as bm_release(), except that any frame of an animation may be passed, and that if the bitmap is
+ *   currently locked the reference is still given up; the bitmap is then freed by a later release, or at shutdown.
+ *
+ * @param handle  The bitmap handle.  For animations, any frame may be passed; the reference is released on the first frame.
+ *
+ * @returns 1 if the bitmap was freed,
+ * @returns 0 otherwise
+ */
+int bm_release_ref(int handle);
 
 /**
  * @brief Detaches the render target of a bitmap if it exists

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -856,22 +856,7 @@ void LabManager::changeShipInternal() {
 	ship_objp->special_exp_damage = -1;
 
 	// If the ship class defines replacement textures, load them and apply them to the ship
-	// load the texture
-	auto replacements = ship_infop->replacement_textures;
-	for (auto& tr : replacements) {
-		if (!stricmp(tr.new_texture, "invisible"))
-		{
-			// invisible is a special case
-			tr.new_texture_id = REPLACE_WITH_INVISIBLE;
-		}
-		else
-		{
-			// try to load texture or anim as normal
-			tr.new_texture_id = bm_load_either(tr.new_texture);
-		}
-	}
-
-	ship_objp->apply_replacement_textures(replacements);
+	ship_objp->load_and_apply_replacement_textures(ship_infop->replacement_textures);
 	ship_page_in_textures(ship_objp->ship_info_index);
 
 	if (!ship_infop->default_team_name.empty())

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -537,10 +537,6 @@ void techroom_ships_render(float frametime)
 		closeup_pos = sip->closeup_pos;
 		closeup_zoom = sip->closeup_zoom;
 
-		if (!sip->replacement_textures.empty()) {
-			render_info.set_replacement_textures(Techroom_modelnum, sip->replacement_textures);
-		}
-
 		if (sip->flags[Ship::Info_Flags::No_lighting])
 			noLighting = true;
 
@@ -600,13 +596,7 @@ void techroom_ships_render(float frametime)
 	render_info.set_detail_level_lock(0);
 
 	int model_instance = -1;
-	auto cache_result = model_get_cached_ui_render_instance(Techroom_modelnum, &model_instance);
-	// Only set up the instance when it was freshly created; the cached instance persists across
-	// frames, so re-running this every frame would re-apply initial animations on top of the
-	// already-animated pose and make animated submodels (e.g. turrets) flip/jitter.
-	if (Tab == SHIPS_DATA_TAB && cache_result == TriStateBool::TRUE_) {
-		model_set_up_techroom_instance(&Ship_info[Cur_entry_index], model_instance);
-	}
+	model_get_cached_ui_render_instance_for_class(render_info, Techroom_modelnum, (Tab == SHIPS_DATA_TAB) ? &Ship_info[Cur_entry_index] : nullptr, &model_instance);
 
     if(shadow_maybe_start_frame(Shadow_disable_overrides.disable_techroom))
     {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5561,6 +5561,41 @@ void post_process_mission_props()
 	}
 }
 
+// Loads the bitmaps for a parse object's replacement textures.  The parse object holds a reference to each one for the
+// lifetime of the mission, so that every ship created from it (e.g. each wave of a wing) can share them.
+static void mission_load_replacement_textures(p_object &p_obj)
+{
+	for (auto &tr : p_obj.replacement_textures)
+	{
+		if (!stricmp(tr.new_texture, "invisible"))
+		{
+			// invisible is a special case
+			tr.new_texture_id = REPLACE_WITH_INVISIBLE;
+		}
+		else
+		{
+			// try to load texture or anim as normal
+			tr.new_texture_id = bm_load_either(tr.new_texture);
+		}
+
+		// not found?
+		if (tr.new_texture_id == -1)
+			mprintf(("Could not load replacement texture %s for ship %s\n", tr.new_texture, p_obj.name));
+	}
+}
+
+// Releases the references taken by mission_load_replacement_textures()
+static void mission_release_replacement_textures(p_object &p_obj)
+{
+	for (auto &tr : p_obj.replacement_textures)
+	{
+		// the check skips REPLACE_WITH_INVISIBLE
+		if (tr.new_texture_id >= 0)
+			bm_release_ref(tr.new_texture_id);
+		tr.new_texture_id = -1;
+	}
+}
+
 // Goober5000
 void post_process_ships_wings()
 {
@@ -5628,28 +5663,14 @@ void post_process_ships_wings()
 		}
 
 		// also load any replacement textures (do this outside the parse loop because we may have ship class replacements too)
-		for (SCP_vector<texture_replace>::iterator tr = p_obj.replacement_textures.begin(); tr != p_obj.replacement_textures.end(); ++tr)
+		mission_load_replacement_textures(p_obj);
+
+		// account for FRED
+		if (Fred_running)
 		{
-			// load the texture
-			if (!stricmp(tr->new_texture, "invisible"))
+			for (const auto &tr : p_obj.replacement_textures)
 			{
-				// invisible is a special case
-				tr->new_texture_id = REPLACE_WITH_INVISIBLE;
-			}
-			else
-			{
-				// try to load texture or anim as normal
-				tr->new_texture_id = bm_load_either(tr->new_texture);
-			}
-
-			// not found?
-			if (tr->new_texture_id < 0)
-				mprintf(("Could not load replacement texture %s for ship %s\n", tr->new_texture, p_obj.name));
-
-			// account for FRED
-			if (Fred_running)
-			{
-				Fred_texture_replacements.push_back(*tr);
+				Fred_texture_replacements.push_back(tr);
 				Fred_texture_replacements.back().new_texture_id = -1;
 			}
 		}
@@ -7399,6 +7420,24 @@ void support_ship_info::reset()
 	}
 }
 
+// Releases the references to the replacement textures of every parse object (see mission_load_replacement_textures());
+// ships created from those objects hold their own.
+static void mission_release_replacement_textures()
+{
+	for (auto &p_obj : Parse_objects)
+		mission_release_replacement_textures(p_obj);
+
+	mission_release_replacement_textures(Support_ship_pobj);
+}
+
+void mission_parse_level_close()
+{
+	// The parse objects themselves are kept until the next mission is parsed, since the debriefing and red alert code
+	// still consult them, but nothing needs their replacement textures once the mission's ships are gone.  (This is
+	// also done in mission_init(), for the paths that never reach a level close, such as loading a mission in FRED.)
+	mission_release_replacement_textures();
+}
+
 /**
  * Initialize the mission and related data structures.
  */
@@ -7459,6 +7498,7 @@ void mission_init(mission *pm, bool quick_init)
 	}
 	Total_initially_docked = 0;
 
+	mission_release_replacement_textures();
 	Parse_objects.clear();
 	list_init(&Ship_arrival_list);	// init list for arrival ships
 
@@ -7577,6 +7617,7 @@ void mission_parse_close()
 	}
 
 	// the destructor for each p_object will clear its dock list
+	mission_release_replacement_textures();
 	Parse_objects.clear();
 }
 
@@ -9248,6 +9289,9 @@ void mission_bring_in_support_ship( object *requester_objp )
 	// object since I'm no longer working with a mission file.  These exceptions will be noted with
 	// comments
 
+	// the previous support ship's parse object may still hold replacement texture references
+	mission_release_replacement_textures(Support_ship_pobj);
+
 	Support_ship_pobj = p_object();		// get a fresh p_object with default fields
 	Arriving_support_ship = &Support_ship_pobj;
 	pobj = Arriving_support_ship;
@@ -9263,6 +9307,7 @@ void mission_bring_in_support_ship( object *requester_objp )
 	Assert(pobj->ship_max_hull_strength > 0.0f);	// Goober5000: div-0 check (not shield because we might not have one)
 	pobj->max_shield_recharge = sip->max_shield_recharge;
 	pobj->replacement_textures = sip->replacement_textures;	// initialize our set with the ship class set, which may be empty
+	mission_load_replacement_textures(*pobj);
 	pobj->score = sip->score;
 
 	// get average position of all ships

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -625,6 +625,9 @@ void resolve_parse_flags(object *objp, flagset<Mission::Parse_Object_Flags> &par
 
 void mission_parse_close();
 
+// Frees the mission parsing resources that are only needed while a mission is being played; called from game_level_close()
+void mission_parse_level_close();
+
 // used in fred management.cpp when creating a new mission
 void apply_default_custom_data(mission* pm);
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -706,15 +706,25 @@ brief_icon *brief_get_closeup_icon()
 	return Closeup_icon;
 }
 
+// deletes the model instance an icon was set up with for a closeup, if any
+static void brief_delete_closeup_instance(brief_icon *bi)
+{
+	if (bi == nullptr)
+		return;
+
+	// the instance may already be gone, e.g. if all models were freed in the meantime
+	if (model_instance_exists(bi->model_instance_num))
+		model_delete_instance(bi->model_instance_num);
+
+	bi->model_instance_num = -1;
+}
+
 // stop showing the closeup view of an icon
 void brief_turn_off_closeup_icon(bool api_access)
 {
 	// turn off closeup
 	if ( Closeup_icon != NULL ) {
-		if (Closeup_icon->model_instance_num >= 0) {
-			model_delete_instance(Closeup_icon->model_instance_num);
-			Closeup_icon->model_instance_num = -1;
-		}
+		brief_delete_closeup_instance(Closeup_icon);
 
 		if (!api_access) {
 			gamesnd_play_iface(InterfaceSounds::BRIEF_ICON_SELECT);
@@ -768,11 +778,13 @@ void brief_set_default_closeup()
 	bs = &Briefing->stages[0];
 
 	if ( Briefing->num_stages <= 0 ) {
+		brief_delete_closeup_instance(Closeup_icon);
 		Closeup_icon = NULL;
 		return;
 	}
 
 	if ( bs->num_icons <= 0 ) {
+		brief_delete_closeup_instance(Closeup_icon);
 		Closeup_icon = NULL;
 		return;
 	}
@@ -1105,9 +1117,9 @@ void brief_render_closeup(int ship_class, float frametime)
 			gr_set_clip(Closeup_region[gr_screen.res][0], Closeup_region[gr_screen.res][1], w, h, GR_RESIZE_MENU);
 		}
 
-		auto sip = &Ship_info[ship_class];
-		if (!sip->replacement_textures.empty())
-			render_info.set_replacement_textures(Closeup_icon->modelnum, sip->replacement_textures);
+		// the instance carries the ship class's replacement textures, if any
+		if (Closeup_icon->model_instance_num >= 0)
+			render_info.set_replacement_textures(model_get_instance(Closeup_icon->model_instance_num)->texture_replace);
 
 		render_info.set_flags(MR_AUTOCENTER);
 	}
@@ -1277,6 +1289,9 @@ int brief_setup_closeup(brief_icon *bi, bool api_access)
 	ship_info		*sip=NULL;
 	vec3d			tvec;
 
+	// only the current closeup icon should own a model instance, so let go of the previous one's before switching
+	brief_delete_closeup_instance(Closeup_icon);
+
 	Closeup_icon = bi;
 	Closeup_icon->modelnum = -1;
 	Closeup_icon->model_instance_num = -1;
@@ -1425,6 +1440,7 @@ void brief_update_closeup_icon(int mode)
 		brief_setup_closeup(bi);
 	}
 	else {
+		brief_delete_closeup_instance(Closeup_icon);
 		Closeup_icon = NULL;
 	}
 }
@@ -1941,6 +1957,15 @@ void brief_close(bool api_access)
 
 		// unload the bitmaps
 		brief_unload_bitmaps();
+
+		// delete the model instances of every icon that was set up for a closeup, in case any were orphaned
+		if (Briefing != nullptr) {
+			for (int i = 0; i < Briefing->num_stages; i++) {
+				brief_stage *bs = &Briefing->stages[i];
+				for (int j = 0; j < bs->num_icons; j++)
+					brief_delete_closeup_instance(&bs->icons[j]);
+			}
+		}
 
 		brief_common_close();
 	}

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1657,19 +1657,10 @@ void draw_model_icon(int model_id, uint64_t flags, int x, int y, int w, int h, s
 		common_setup_room_lights();
 	}
 
-	if (sip != NULL && sip->replacement_textures.size() > 0) 
-	{
-		render_info.set_replacement_textures(model_id, sip->replacement_textures);
-	}
-
 	Glowpoint_override = true;
 	model_clear_instance(model_id);
 	int model_instance = -1;
-	auto cache_result = model_get_cached_ui_render_instance(model_id, &model_instance);
-	// Only set up the instance when it was freshly created; the cached instance persists across frames.
-	if (sip != nullptr && cache_result == TriStateBool::TRUE_) {
-		model_set_up_techroom_instance(sip, model_instance);
-	}
+	model_get_cached_ui_render_instance_for_class(render_info, model_id, sip, &model_instance);
 
 	render_info.set_flags(flags);
 	model_render_immediate(&render_info, model_id, model_instance, &object_orient, &vmd_zero_vector);
@@ -1688,12 +1679,10 @@ void draw_model_rotating(model_render_params *render_info, int ship_class, int m
 	if (model_id < 0)
 		return;
 
+	bool is_ship = !(flags & MR_IS_MISSILE) && Ship_info.in_bounds(ship_class);
+
 	int model_instance = -1;
-	auto cache_result = model_get_cached_ui_render_instance(model_id, &model_instance);
-	// Only set up the instance when it was freshly created; the cached instance persists across frames.
-	if (!(flags & MR_IS_MISSILE) && SCP_vector_inbounds(Ship_info, ship_class) && cache_result == TriStateBool::TRUE_) {
-		model_set_up_techroom_instance(&Ship_info[ship_class], model_instance);
-	}
+	model_get_cached_ui_render_instance_for_class(*render_info, model_id, is_ship ? &Ship_info[ship_class] : nullptr, &model_instance);
 
 	lighting_profiles::set_non_mission_profile non_mission_lighting_profile;
 

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1359,11 +1359,6 @@ void ship_select_do(float frametime)
 				render_info.set_team_color(sip->default_team_name, "none", 0, 0);
 			}
 
-			if (sip->replacement_textures.size() > 0)
-			{
-				render_info.set_replacement_textures(ShipSelectModelNum, sip->replacement_textures);
-			}
-
 			select_effect_params params;
 			params.effect = sip->selection_effect;
 			params.fs2_grid_color = sip->fs2_effect_grid_color;

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -842,16 +842,8 @@ void draw_3d_overhead_view(int model_num,
 
 		model_clear_instance(model_num);
 		int model_instance = -1;
-		auto cache_result = model_get_cached_ui_render_instance(model_num, &model_instance);
-		// Only set up the instance when it was freshly created; the cached instance persists across frames.
-		if (cache_result == TriStateBool::TRUE_) {
-			model_set_up_techroom_instance(sip, model_instance);
-		}
+		model_get_cached_ui_render_instance_for_class(render_info, model_num, sip, &model_instance);
 		polymodel* pm = model_get(model_num);
-
-		if (sip->replacement_textures.size() > 0) {
-			render_info.set_replacement_textures(model_num, sip->replacement_textures);
-		}
 
 		if (shadow_maybe_start_frame(Shadow_disable_overrides.disable_mission_select_weapons)) {
 			gr_reset_clip();

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -163,8 +163,10 @@ struct submodel_instance
 #define TM_SPEC_GLOSS_TYPE	6		// optional reflectance map (specular and gloss)
 #define TM_AMBIENT_TYPE		7		// optional ambient occlusion map with ambient occlusion and cavity occlusion factors for red and green channels.
 #define TM_NUM_TYPES		8		//WMC - Number of texture_info objects in texture_map
-									//Used by scripting - if you change this, do a search
-									//to update switch() statement in lua.cpp
+									//Used by scripting: the "textures" and "modelinstancetextures" Lua handles expose
+									//a flat array with TM_NUM_TYPES entries per texture_map, in the order listed above.
+									//If you add or reorder a type, update the docs for those handles in
+									//scripting/api/objs/model.cpp and scripting/api/objs/modelinstance.cpp.
 
 inline const SCP_map<int, SCP_string> MODEL_TEXTURE_SUFFIXES = {
 	{ TM_GLOW_TYPE,       "-glow" },
@@ -191,12 +193,35 @@ inline const SCP_string& model_texture_longest_suffix() {
 // Goober5000 - since we need something < 0
 #define REPLACE_WITH_INVISIBLE	-47
 
-class model_texture_replace : public std::array<int, MAX_REPLACEMENT_TEXTURES> {
+// Per-instance texture replacements, indexed by (texture_map index * TM_NUM_TYPES + TM_*_TYPE).  Each entry is a bitmap
+// handle, -1 for no replacement, or REPLACE_WITH_INVISIBLE.  The array owns one load-count reference on every bitmap
+// handle it holds and releases them all when it is destroyed, so entries can only be written through adopt(),
+// reference(), or clear().  The exception is render targets, which bm_release() will not free unless explicitly asked;
+// the cockpit display code stores those here, and they are left alone when the array is destroyed, as before.
+class model_texture_replace
+{
+	std::array<int, MAX_REPLACEMENT_TEXTURES> m_handles;
+
 public:
-	model_texture_replace() : std::array<int, MAX_REPLACEMENT_TEXTURES>() {
-		for (int& tex : *this)
-			tex = -1;
-	}
+	model_texture_replace();
+	~model_texture_replace();
+
+	model_texture_replace(const model_texture_replace&) = delete;
+	model_texture_replace& operator=(const model_texture_replace&) = delete;
+
+	int operator[](int index) const { return m_handles[index]; }
+	auto begin() const { return m_handles.begin(); }
+	auto end() const { return m_handles.end(); }
+
+	// Stores a handle whose load-count reference (e.g. from bm_load) the array takes over from the caller.
+	void adopt(int index, int handle);
+
+	// Stores a handle that someone else owns; the array takes its own load-count reference on it.  REPLACE_WITH_INVISIBLE is
+	// stored as-is; any other invalid handle clears the slot.
+	void reference(int index, int handle);
+
+	// Removes any replacement in this slot.
+	void clear(int index);
 };
 
 // Data specific to a particular instance of a model.
@@ -789,6 +814,7 @@ class texture_info
 private:
 	int original_texture;	// what gets read in from file
 	int texture;			// what texture you draw with; reset to original_textures by model_set_instance
+	int held_texture;		// texture (if any) on which this object holds its own load-count reference; see SetTexture
 
 	//WMC - Removed unneeded struct and is_anim to clean this up.
 	//If num_frames is < 2, it doesn't need to be treated like an animation.
@@ -810,8 +836,14 @@ public:
 	void PageIn();
 	void PageOut(bool release);
 
+	// Resets the texture to the original one, releasing any reference taken by SetTexture(..., true).
 	int ResetTexture();
-	int SetTexture(int n_tex);
+
+	// Sets the texture to draw with.  If take_reference is true, this object takes its own load-count reference on
+	// the new texture and keeps it until ResetTexture(), PageOut(true), or a later SetTexture() with take_reference
+	// releases it.  Use this when the handle comes from somewhere the model does not control, such as a script, so
+	// that the texture cannot be freed out from under the model.
+	int SetTexture(int n_tex, bool take_reference = false);
 };
 
 // taylor
@@ -1266,6 +1298,15 @@ extern void model_set_submodel_instance_motion_info(bsp_info *sm, submodel_insta
 
 // Sets the submodel instance data in a submodel
 extern void model_set_up_techroom_instance(ship_info *sip, int model_instance_num);
+
+// Returns whether a model instance with this number currently exists.  Use this before acting on an instance number that
+// was stored earlier, since instances can be deleted (and their numbers reused) at any time.
+extern bool model_instance_exists(int model_instance_num);
+
+// Loads the given replacement textures (e.g. a ship class's table entry, which has filenames only) for a model instance,
+// discarding any replacement textures the instance already had.  The instance owns the loaded bitmaps.
+struct texture_replace;
+extern void model_instance_load_replacement_textures(polymodel_instance *pmi, const SCP_vector<texture_replace> &replacements);
 
 void model_replicate_submodel_instance(polymodel *pm, polymodel_instance *pmi, int submodel_num, flagset<Ship::Subsystem_Flags>& flags);
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1454,29 +1454,18 @@ void model_page_out_textures(polymodel* pm, bool release, const SCP_set<int>& sk
 		pm->maps[i].PageOut(release);
 	}
 
-	// NOTE: "release" doesn't work here for some, as of yet unknown, reason - taylor
+	// NOTE: these can only be paged out, not released, because a virtual POF copies glow point banks from its source
+	// models without taking a reference per copy, so two banks can share one handle and releasing would over-release.
 	for (j = 0; j < pm->n_glow_point_banks; j++) {
 		if(skipGlowBanks.contains(j))
 			continue;
 		glow_point_bank* bank = &pm->glow_point_banks[j];
 
-		if (bank->glow_bitmap >= 0) {
-		//	if (release) {
-		//		bm_release(bank->glow_bitmap);
-		//		bank->glow_bitmap = -1;
-		//	} else {
-				bm_unload(bank->glow_bitmap);
-		//	}
-		}
+		if (bank->glow_bitmap >= 0)
+			bm_page_out(bank->glow_bitmap);
 
-		if (bank->glow_neb_bitmap >= 0) {
-		//	if (release) {
-		//		bm_release(bank->glow_neb_bitmap);
-		//		bank->glow_neb_bitmap = -1;
-		//	} else {
-				bm_unload(bank->glow_neb_bitmap);
-		//	}
-		}
+		if (bank->glow_neb_bitmap >= 0)
+			bm_page_out(bank->glow_neb_bitmap);
 	}
 }
 
@@ -2670,18 +2659,17 @@ texture_info::texture_info()
 }
 texture_info::texture_info(int bm_handle)
 {
+	clear();
+
 	if(!bm_is_valid(bm_handle))
-	{
-		clear();
 		return;
-	}
 
 	this->original_texture = bm_handle;
 	this->ResetTexture();
 }
 void texture_info::clear()
 {
-	texture = original_texture = -1;
+	texture = original_texture = held_texture = -1;
 	num_frames = 0;
 	total_time = 1.0f;
 }
@@ -2722,25 +2710,47 @@ void texture_info::PageIn()
 
 void texture_info::PageOut(bool release)
 {
-	if (texture >= 0) {
-		if (release) {
-			bm_release(texture);
-			texture = -1;
-			num_frames = 0;
-			total_time = 1.0f;
-		} else {
-			bm_unload(texture);
-		}
+	if (release) {
+		// release our own reference to a texture that was set from outside, if any
+		if (held_texture >= 0)
+			bm_release_ref(held_texture);
+
+		// release the texture we loaded; note that this is not necessarily the texture currently being drawn with
+		if (original_texture >= 0)
+			bm_release_ref(original_texture);
+
+		clear();
+	} else if (original_texture >= 0) {
+		// page out the texture we loaded, keeping our reference so that it can be paged back in; a texture set from
+		// outside is left alone, since whoever set it may still be using it
+		bm_page_out(original_texture);
 	}
 }
 int texture_info::ResetTexture()
 {
-	return this->SetTexture(original_texture);
+	int result = this->SetTexture(original_texture);
+
+	// drop the held reference once we are back on the original
+	if (held_texture >= 0 && texture == original_texture) {
+		bm_release_ref(held_texture);
+		held_texture = -1;
+	}
+
+	return result;
 }
-int texture_info::SetTexture(int n_tex)
+int texture_info::SetTexture(int n_tex, bool take_reference)
 {
 	if(n_tex != -1 && !bm_is_valid(n_tex))
 		return texture;
+
+	if (take_reference) {
+		// take the new reference before releasing the old one, in case they are the same texture
+		if (n_tex != -1)
+			bm_add_ref(n_tex);
+		if (held_texture >= 0)
+			bm_release_ref(held_texture);
+		held_texture = n_tex;
+	}
 
 	//Set the new texture
 	texture = n_tex;
@@ -2819,6 +2829,56 @@ void texture_map::ResetToOriginal()
 {
 	for(int i = 0; i < TM_NUM_TYPES; i++)
 		this->textures[i].ResetTexture();
+}
+
+//********************-----CLASS: model_texture_replace-----********************//
+model_texture_replace::model_texture_replace()
+{
+	m_handles.fill(-1);
+}
+
+model_texture_replace::~model_texture_replace()
+{
+	for (int tex : m_handles)
+		if (tex >= 0)
+			bm_release_ref(tex);
+}
+
+static bool valid_replacement_index(int index)
+{
+	Assertion(index >= 0 && index < MAX_REPLACEMENT_TEXTURES, "Replacement texture index %d is out of range!", index);
+	return index >= 0 && index < MAX_REPLACEMENT_TEXTURES;
+}
+
+void model_texture_replace::adopt(int index, int handle)
+{
+	if (!valid_replacement_index(index))
+		return;
+
+	int& slot = m_handles[index];
+
+	if (slot >= 0)
+		bm_release_ref(slot);
+
+	slot = handle;
+}
+
+void model_texture_replace::reference(int index, int handle)
+{
+	// check this before taking the reference, since adopt() would refuse it without releasing
+	if (!valid_replacement_index(index))
+		return;
+
+	// REPLACE_WITH_INVISIBLE is stored as-is; anything else must be a valid bitmap, or the slot is cleared
+	if (handle != REPLACE_WITH_INVISIBLE && bm_add_ref(handle) < 0)
+		handle = -1;
+
+	adopt(index, handle);
+}
+
+void model_texture_replace::clear(int index)
+{
+	adopt(index, -1);
 }
 
 bsp_polygon_data::bsp_polygon_data(ubyte* _bsp_data, int _bsp_data_size)

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2415,7 +2415,9 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 
 							if (bank->glow_neb_bitmap < 0)
 							{
-								bank->glow_neb_bitmap = bank->glow_bitmap;
+								// leave it invalid; the renderer falls back to the normal glowpoint texture.  (Aliasing the
+								// two handles here would mean one bitmap owned by two fields, which the paging code can't tell
+								// apart from two separate textures.)
 								nprintf(( "Model", "Glow point bank nebula texture not found for '%s', using normal glowpoint texture instead\n", pm->filename));
 							//	Error( LOCATION, "Couldn't open texture '%s'\nreferenced by model '%s'\n", glow_texture_name, pm->filename );
 							}
@@ -3841,6 +3843,11 @@ int num_model_instances()
 	return static_cast<int>(Polygon_model_instances.size());
 }
 
+bool model_instance_exists(int model_instance_num)
+{
+	return (model_instance_num >= 0) && (model_instance_num < num_model_instances()) && (Polygon_model_instances[model_instance_num] != nullptr);
+}
+
 polymodel_instance* model_get_instance(int model_instance_num)
 {
 	Assert( model_instance_num >= 0 );
@@ -5018,6 +5025,50 @@ void model_set_submodel_instance_motion_info(bsp_info *sm, submodel_instance *sm
 	smi->shift_accel = sm->default_shift_accel;
 }
 
+void model_instance_load_replacement_textures(polymodel_instance *pmi, const SCP_vector<texture_replace> &replacements)
+{
+	// discard whatever the instance had, because the new positions may be different
+	pmi->texture_replace = nullptr;
+
+	if (replacements.empty())
+		return;
+
+	auto pm = model_get(pmi->model_num);
+	pmi->texture_replace = std::make_shared<model_texture_replace>();
+
+	// now fill them in according to texture name
+	for (const auto &tr : replacements)
+	{
+		int new_tex = -1;
+
+		// look for textures
+		for (int j = 0; j < pm->n_textures; j++)
+		{
+			int tnum = pm->maps[j].FindTexture(tr.old_texture);
+			if (tnum < 0)
+				continue;
+
+			// load the replacement the first time it is actually needed, and only once; each slot takes its own reference
+			if (new_tex == -1)
+			{
+				if (!stricmp(tr.new_texture, "invisible"))
+					new_tex = REPLACE_WITH_INVISIBLE;
+				else
+					new_tex = bm_load_either(tr.new_texture);
+
+				if (new_tex == -1)
+					break;
+			}
+
+			pmi->texture_replace->reference(j * TM_NUM_TYPES + tnum, new_tex);
+		}
+
+		// and the reference from loading is no longer needed (the check skips REPLACE_WITH_INVISIBLE)
+		if (new_tex >= 0)
+			bm_release_ref(new_tex);
+	}
+}
+
 // Sets the submodel instance data when a tech room model instance is created.
 // This only needs to be done at creation, not every frame.
 void model_set_up_techroom_instance(ship_info *sip, int model_instance_num)
@@ -5025,6 +5076,9 @@ void model_set_up_techroom_instance(ship_info *sip, int model_instance_num)
 	auto pmi = model_get_instance(model_instance_num);
 	auto pm = model_get(pmi->model_num);
 	flagset<Ship::Subsystem_Flags> empty;
+
+	// the instance carries the class's replacement textures, so that screens rendering it don't have to load them themselves
+	model_instance_load_replacement_textures(pmi, sip->replacement_textures);
 
 	sip->animations.clearShipData(pmi);
 	sip->animations.getAll(pmi, animation::ModelAnimationTriggerType::Initial).start(animation::ModelAnimationDirection::FWD, true, true);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -88,7 +88,7 @@ size_t model_hash_subsystem_name_list_for_cache(const SCP_vector<SCP_string>& su
 
 // Returns TriStateBool::TRUE_ if a new instance was created, TriStateBool::FALSE_ if an existing instance was returned,
 // or TriStateBool::UNKNOWN_ if there was an error (and model_instance_out will be set to -1 in this case)
-TriStateBool model_get_cached_ui_render_instance(int model_num, int* model_instance_out, size_t instance_data_hash)
+static TriStateBool model_get_cached_ui_render_instance(int model_num, int* model_instance_out, size_t instance_data_hash = 0)
 {
 	Assertion(model_instance_out != nullptr, "model_instance_out must not be null!");
 	if (model_instance_out == nullptr) {
@@ -118,6 +118,29 @@ TriStateBool model_get_cached_ui_render_instance(int model_num, int* model_insta
 	entry.last_used_framecount = Framecount;
 	*model_instance_out = entry.model_instance;
 	return created_new ? TriStateBool::TRUE_ : TriStateBool::FALSE_;
+}
+
+TriStateBool model_get_cached_ui_render_instance_for_class(model_render_params& render_info, int model_num, ship_info* sip, int* model_instance_out, size_t instance_data_hash)
+{
+	// key the instance by ship class as well, since classes sharing a model may differ in replacement textures
+	if (sip != nullptr)
+		boost::hash_combine(instance_data_hash, static_cast<size_t>(sip - Ship_info.data()));
+
+	auto cache_result = model_get_cached_ui_render_instance(model_num, model_instance_out, instance_data_hash);
+	if (cache_result == TriStateBool::UNKNOWN_)
+		return cache_result;
+
+	// only set up the instance when it was freshly created; the cached instance persists across frames, so re-running
+	// this every frame would re-apply initial animations on top of the already-animated pose
+	if (sip != nullptr && cache_result == TriStateBool::TRUE_)
+		model_set_up_techroom_instance(sip, *model_instance_out);
+
+	// the instance carries the ship class's replacement textures, if any; a bare model has none, and the caller may
+	// have set some of its own
+	if (sip != nullptr)
+		render_info.set_replacement_textures(model_get_instance(*model_instance_out)->texture_replace);
+
+	return cache_result;
 }
 
 void model_process_cached_ui_render_instances()
@@ -327,27 +350,6 @@ bool model_render_params::is_team_color_set() const
 
 void model_render_params::set_replacement_textures(std::shared_ptr<const model_texture_replace> textures)
 {
-	Replacement_textures = std::move(textures);
-}
-
-void model_render_params::set_replacement_textures(int modelnum, const SCP_vector<texture_replace>& replacement_textures)
-{
-	auto textures = std::make_shared<model_texture_replace>();
-
-	polymodel* pm = model_get(modelnum);
-
-	for (const auto& tr : replacement_textures) 
-	{
-		for (int i = 0; i < pm->n_textures; ++i) 
-		{
-			texture_map *tmap = &pm->maps[i];
-
-			int tnum = tmap->FindTexture(tr.old_texture);
-			if (tnum > -1)
-				(*textures)[i * TM_NUM_TYPES + tnum] = bm_load(tr.new_texture);
-		}
-	}
-
 	Replacement_textures = std::move(textures);
 }
 
@@ -1774,7 +1776,7 @@ void model_render_glowpoint_bitmap(int point_num, const vec3d *pos, const matrix
 			vm_vec_sub(&tempv,&View_position,&loc_offset);
 			vm_vec_normalize(&tempv);
 
-			if ( The_mission.flags[Mission::Mission_Flags::Fullneb] ) {
+			if ( The_mission.flags[Mission::Mission_Flags::Fullneb] && bank->glow_neb_bitmap >= 0 ) {
 				batching_add_quad(bank->glow_neb_bitmap, verts);
 			} else {
 				batching_add_quad(bank->glow_bitmap, verts);
@@ -3115,7 +3117,7 @@ void modelinstance_replace_active_texture(polymodel_instance* pmi, const char* o
 			pmi->texture_replace = std::make_shared<model_texture_replace>();
 		}
 
-		(*pmi->texture_replace)[final_index] = texture;
+		pmi->texture_replace->adopt(final_index, texture);
 	} else
 		Warning(LOCATION, "Invalid texture '%s' used for replacement texture", old_name);
 }
@@ -3152,7 +3154,6 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 
 			// Make sure model is loaded
 			model_num = model_load(sip, true);
-			render_info.set_replacement_textures(model_num, sip->replacement_textures);
 
 			break;
 
@@ -3240,29 +3241,26 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 	if (model_type == TECH_SHIP) {
 		auto sip = &Ship_info[class_idx];
 		const auto subsystem_hash = model_hash_subsystem_name_list_for_cache(destroyed_subsystems);
-		const auto cache_result = model_get_cached_ui_render_instance(model_num, &model_instance, subsystem_hash);
-		if (cache_result == TriStateBool::TRUE_) {
-			model_set_up_techroom_instance(sip, model_instance);
-			if (!destroyed_subsystems.empty()) {
-				auto pm = model_get(model_num);
-				auto pmi = model_get_instance(model_instance);
-				flagset<Ship::Subsystem_Flags> empty;
+		const auto cache_result = model_get_cached_ui_render_instance_for_class(render_info, model_num, sip, &model_instance, subsystem_hash);
+		if (cache_result == TriStateBool::TRUE_ && !destroyed_subsystems.empty()) {
+			auto pm = model_get(model_num);
+			auto pmi = model_get_instance(model_instance);
+			flagset<Ship::Subsystem_Flags> empty;
 
-				for (int idx = 0; idx < sip->n_subsystems; ++idx) {
-					auto& subsystem = sip->subsystems[idx];
+			for (int idx = 0; idx < sip->n_subsystems; ++idx) {
+				auto& subsystem = sip->subsystems[idx];
 
-					if (subsystem.subobj_num < 0 || subsystem.subobj_num >= pm->n_models ||
-						subsystem.model_num != model_num) {
-						continue;
-					}
+				if (subsystem.subobj_num < 0 || subsystem.subobj_num >= pm->n_models ||
+					subsystem.model_num != model_num) {
+					continue;
+				}
 
-					for (auto& destroyed_name : destroyed_subsystems) {
-						if (!stricmp(subsystem.subobj_name, destroyed_name.c_str()) ||
-							!stricmp(subsystem.name, destroyed_name.c_str())) {
-							pmi->submodel[subsystem.subobj_num].blown_off = true;
-							model_replicate_submodel_instance(pm, pmi, subsystem.subobj_num, empty);
-							break;
-						}
+				for (auto& destroyed_name : destroyed_subsystems) {
+					if (!stricmp(subsystem.subobj_name, destroyed_name.c_str()) ||
+						!stricmp(subsystem.name, destroyed_name.c_str())) {
+						pmi->submodel[subsystem.subobj_num].blown_off = true;
+						model_replicate_submodel_instance(pm, pmi, subsystem.subobj_num, empty);
+						break;
 					}
 				}
 			}

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -127,7 +127,6 @@ public:
 	void set_forced_bitmap(int bitmap);
 	void set_insignia_bitmap(int bitmap);
 	void set_replacement_textures(std::shared_ptr<const model_texture_replace> textures);
-	void set_replacement_textures(int modelnum, const SCP_vector<texture_replace>& replacement_textures);
 	void set_team_color(const team_color &clr);
 	void set_team_color(const SCP_string &team, const SCP_string &secondaryteam, fix timestamp, int fadetime);
 	void set_clip_plane(const vec3d &pos, const vec3d &normal);
@@ -317,7 +316,10 @@ int model_render_determine_detail(float depth, int model_num, int detail_level_l
 bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, const matrix* orient, const SCP_string& pof_filename = "", float closeup_zoom = 0, const vec3d* closeup_pos = &vmd_zero_vector, const SCP_string& tcolor = "", const SCP_vector<SCP_string>& destroyed_subsystems = SCP_vector<SCP_string>());
 
 size_t model_hash_subsystem_name_list_for_cache(const SCP_vector<SCP_string>& subsystem_names);
-TriStateBool model_get_cached_ui_render_instance(int model_num, int* model_instance_out, size_t instance_data_hash = 0);
+// Fetches the cached model instance used to render a ship class (or a bare model, if sip is null) without an object: the
+// cache key includes the class, the instance is set up for the class when it is freshly created, and render_info is
+// pointed at the instance's replacement textures.
+TriStateBool model_get_cached_ui_render_instance_for_class(model_render_params& render_info, int model_num, ship_info* sip, int* model_instance_out, size_t instance_data_hash = 0);
 void model_clear_cached_ui_render_instances();
 void model_process_cached_ui_render_instances();
 

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -26,8 +26,7 @@
 #include "mod_table/mod_table.h"
 #include "tracing/categories.h"
 #include "tracing/tracing.h"
-#define BMPMAN_INTERNAL
-#include "bmpman/bm_internal.h"
+#include "bmpman/bmpman.h"
 
 using namespace Rocket::Core;
 
@@ -169,11 +168,8 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 		else if (submode.Find("bmpman,") == 0) {
 			int handle = std::atoi(submode.Substring(7).CString());
 
-			auto* entry = bm_get_entry(handle);
-			if (entry->handle != handle)
+			if (bm_add_ref(handle) < 0)
 				return false;
-
-			entry->load_count++;
 
 			bm_get_info(handle, &texture_dimensions.x, &texture_dimensions.y);
 
@@ -261,7 +257,8 @@ void RocketRenderingInterface::ReleaseTexture(TextureHandle texture)
 	if (tex->is_animation) {
 		generic_anim_unload(&tex->animation);
 	} else {
-		bm_release(tex->bm_handle);
+		// the reference was taken with bm_add_ref(), which counts on the first frame of an animation
+		bm_release_ref(tex->bm_handle);
 	}
 	delete tex;
 }

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1676,8 +1676,9 @@ ADE_FUNC(createTexture, l_Graphics, "[number Width=512, number Height=512, enume
 ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, boolean NoDropFrames]",
 		 "Gets a handle to a texture. If second argument is set to true, animations will also be loaded."
 			 "If third argument is set to true, every other animation frame will not be loaded if system has less than 48 MB memory."
-			 "<br><strong>IMPORTANT:</strong> Textures will not be unload themselves unless you explicitly tell them to do so."
-			 "When you are done with a texture, call the unload() function to free up memory.",
+			 "<br>The texture stays loaded for as long as any Lua reference to the handle exists; its reference is released automatically once the handle is garbage collected.  "
+			 "Anything the texture is assigned to, such as a model or ship texture slot, takes its own reference, so the script does not need to keep the handle alive after assigning it.  "
+			 "Call unload() to release the texture sooner.",
 		 "texture",
 		 "Texture handle, or invalid texture handle if texture couldn't be loaded")
 {

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -590,9 +590,9 @@ ADE_INDEXER(l_ModelSubmodels, "submodel", "number|string IndexOrName", "submodel
 
 
 //**********HANDLE: modeltextures
-ADE_OBJ(l_ModelTextures, model_h, "textures", "Array of textures");
+ADE_OBJ(l_ModelTextures, model_h, "textures", "Flat array of model textures.  Each material (texture_map) on the model contributes " SCP_TOKEN_TO_STR(TM_NUM_TYPES) " consecutive entries, in this order: base, glow, specular, normal, height, misc, reflectance, ambient occlusion.  So for material N (1-based), the base map is at index (N-1)*" SCP_TOKEN_TO_STR(TM_NUM_TYPES) "+1, the glow map at (N-1)*" SCP_TOKEN_TO_STR(TM_NUM_TYPES) "+2, and so on.  Slots that the material does not use hold invalid texture handles.");
 
-ADE_FUNC(__len, l_ModelTextures, NULL, "Number of textures on model", "number", "Number of model textures")
+ADE_FUNC(__len, l_ModelTextures, nullptr, "Number of texture slots on the model, i.e. the number of materials multiplied by " SCP_TOKEN_TO_STR(TM_NUM_TYPES), "number", "Number of texture slots, or 0 if handle is invalid")
 {
 	model_h *mth;
 	if (!ade_get_args(L, "o", l_ModelTextures.GetPtr(&mth)))
@@ -605,7 +605,7 @@ ADE_FUNC(__len, l_ModelTextures, NULL, "Number of textures on model", "number", 
 	return ade_set_args(L, "i", TM_NUM_TYPES * pm->n_textures);
 }
 
-ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "texture", "Model textures, or invalid modeltextures handle if model handle is invalid")
+ADE_INDEXER(l_ModelTextures, "number/string IndexOrTextureFilename", "Gets or sets a texture slot.  A number is a 1-based index into the flat array (see the \"textures\" handle description for the layout); a string is matched against the filename of every slot on every material.  Setting a slot changes the shared model, and so affects every object using it.  The model takes its own reference to the texture, so the script does not need to keep the handle alive.", "texture", "Texture, or invalid texture handle if the model handle is invalid or the index/name does not match")
 {
 	model_h *mth = NULL;
 	texture_h* new_tex   = nullptr;
@@ -649,7 +649,7 @@ ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "text
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (ADE_SETTING_VAR && new_tex != nullptr) {
-		tinfo->SetTexture(new_tex->handle);
+		tinfo->SetTexture(new_tex->handle, true);
 	}
 
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(tinfo->GetTexture())));

--- a/code/scripting/api/objs/modelinstance.cpp
+++ b/code/scripting/api/objs/modelinstance.cpp
@@ -11,9 +11,9 @@ namespace scripting {
 namespace api {
 
 //**********HANDLE: modelinstancetextures (compatible with preceding shiptextures)
-ADE_OBJ(l_ModelInstanceTextures, modelinstance_h, "modelinstancetextures", "Model instance textures handle");
+ADE_OBJ(l_ModelInstanceTextures, modelinstance_h, "modelinstancetextures", "Flat array of textures for one model instance.  It has the same layout as the model's \"textures\" handle: each material (texture_map) contributes " SCP_TOKEN_TO_STR(TM_NUM_TYPES) " consecutive entries, in this order: base, glow, specular, normal, height, misc, reflectance, ambient occlusion.  So for material N (1-based), the base map is at index (N-1)*" SCP_TOKEN_TO_STR(TM_NUM_TYPES) "+1, the glow map at (N-1)*" SCP_TOKEN_TO_STR(TM_NUM_TYPES) "+2, and so on.  Reads return the instance's replacement texture for that slot if one is set, otherwise the model's texture.  Writes set a replacement texture on this instance only.");
 
-ADE_FUNC(__len, l_ModelInstanceTextures, nullptr, "Number of textures on a model instance", "number", "Number of textures on the model instance, or 0 if handle is invalid")
+ADE_FUNC(__len, l_ModelInstanceTextures, nullptr, "Number of texture slots on the model instance, i.e. the number of materials multiplied by " SCP_TOKEN_TO_STR(TM_NUM_TYPES), "number", "Number of texture slots, or 0 if handle is invalid")
 {
 	modelinstance_h *mih;
 	if(!ade_get_args(L, "o", l_ModelInstanceTextures.GetPtr(&mih)))
@@ -30,7 +30,7 @@ ADE_FUNC(__len, l_ModelInstanceTextures, nullptr, "Number of textures on a model
 	return ade_set_args(L, "i", pm->n_textures*TM_NUM_TYPES);
 }
 
-ADE_INDEXER(l_ModelInstanceTextures, "number/string IndexOrTextureFilename", "Array of model instance textures", "texture", "Texture, or invalid texture handle on failure")
+ADE_INDEXER(l_ModelInstanceTextures, "number/string IndexOrTextureFilename", "Gets or sets a texture slot.  A number is a 1-based index into the flat array (see the \"modelinstancetextures\" handle description for the layout).  A string is matched first against the filenames of this instance's replacement textures, then against the filename of every slot on every material of the model.  Setting a slot sets a replacement texture on this instance only; set it to an invalid texture handle to clear the replacement.  The instance takes its own reference to the texture, so the script does not need to keep the handle alive.", "texture", "Texture, or invalid texture handle if the handle is invalid or the index/name does not match")
 {
 	modelinstance_h *mih;
 	const char* s;
@@ -86,9 +86,9 @@ ADE_INDEXER(l_ModelInstanceTextures, "number/string IndexOrTextureFilename", "Ar
 			pmi->texture_replace = std::make_shared<model_texture_replace>();
 		}
 
-		if (tdx != nullptr) {
-			(*pmi->texture_replace)[final_index] = tdx->isValid() ? tdx->handle : -1;
-		}
+		// an invalid texture handle clears the replacement
+		if (tdx != nullptr)
+			pmi->texture_replace->reference(final_index, tdx->handle);
 	}
 
 	if (pmi->texture_replace != nullptr && (*pmi->texture_replace)[final_index] >= 0)

--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -1320,10 +1320,6 @@ ADE_FUNC(renderSelectModel,
 		render_info.set_team_color(tcolor, "none", 0, 0);
 	}
 
-	if (sip->replacement_textures.size() > 0) {
-		render_info.set_replacement_textures(modelNum, sip->replacement_textures);
-	}
-
 	select_effect_params params;
 	params.effect = effect;
 	params.fs2_grid_color = sip->fs2_effect_grid_color;

--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -3,16 +3,14 @@
 
 #include "texture.h"
 #include "bmpman/bmpman.h"
-#define BMPMAN_INTERNAL
-#include "bmpman/bm_internal.h"
 
 namespace scripting {
 namespace api {
 
 texture_h::texture_h() = default;
-texture_h::texture_h(int bm, bool refcount, int parent_bm) : handle(bm), parent_handle(parent_bm) {
+texture_h::texture_h(int bm, bool refcount) : handle(bm) {
 	if (refcount && isValid())
-		bm_get_entry(parent_bm != -1 ? parent_bm : bm)->load_count++;
+		bm_add_ref(bm);
 }
 texture_h::~texture_h()
 {
@@ -31,7 +29,8 @@ texture_h::~texture_h()
 	//Otherwise it is possible (and has been observed in practice) that the parent texture get's deleted before all dependent objects,
 	//causing this release of the dependent object to clear unrelated textures that were assigned the previously freed spots.
 	//So instead, both lock and later unlock the parent texture rather than this child texture. -Lafiel
-	bm_release(parent_handle != -1 ? parent_handle : handle);
+	//(bm_add_ref() and bm_release_ref() take care of that: both count on the first frame of an animation.)
+	bm_release_ref(handle);
 }
 bool texture_h::isValid() const { return bm_is_valid(handle) != 0; }
 
@@ -41,7 +40,6 @@ texture_h::texture_h(texture_h&& other) noexcept {
 texture_h& texture_h::operator=(texture_h&& other) noexcept {
 	if (this != &other) {
 		std::swap(handle, other.handle);
-		std::swap(parent_handle, other.parent_handle);
 	}
 	return *this;
 }
@@ -98,7 +96,7 @@ ADE_INDEXER(l_Texture, "number",
 	//Get actual texture handle
 	frame = first + frame;
 
-	return ade_set_args(L, "o", l_Texture.Set(texture_h(frame, true, first)));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(frame)));
 }
 
 ADE_FUNC(unload, l_Texture, NULL, "Unloads a texture from memory", NULL, NULL)
@@ -111,7 +109,7 @@ ADE_FUNC(unload, l_Texture, NULL, "Unloads a texture from memory", NULL, NULL)
 	if (!th->isValid())
 		return ADE_RETURN_NIL;
 
-	bm_release(th->handle);
+	bm_release_ref(th->handle);
 
 	//WMC - invalidate this handle
 	th->handle = -1;

--- a/code/scripting/api/objs/texture.h
+++ b/code/scripting/api/objs/texture.h
@@ -9,10 +9,9 @@ namespace api {
 
 struct texture_h {
 	int handle = -1;
-	int parent_handle = -1;
 
 	texture_h();
-	explicit texture_h(int bm, bool refcount = true, int parent_handle = -1);
+	explicit texture_h(int bm, bool refcount = true);
 
 	~texture_h();
 

--- a/code/scripting/api/objs/texturemap.cpp
+++ b/code/scripting/api/objs/texturemap.cpp
@@ -78,7 +78,7 @@ ADE_VIRTVAR(BaseMap, l_TextureMap, "texture", "Base texture", "texture", "Base t
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (ADE_SETTING_VAR && new_tex != nullptr && new_tex->isValid()) {
-		tmap->textures[TM_BASE_TYPE].SetTexture(new_tex->handle);
+		tmap->textures[TM_BASE_TYPE].SetTexture(new_tex->handle, true);
 	}
 
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(tmap->textures[TM_BASE_TYPE].GetTexture())));
@@ -96,7 +96,7 @@ ADE_VIRTVAR(GlowMap, l_TextureMap, "texture", "Glow texture", "texture", "Glow t
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (ADE_SETTING_VAR && new_tex != nullptr && new_tex->isValid()) {
-		tmap->textures[TM_GLOW_TYPE].SetTexture(new_tex->handle);
+		tmap->textures[TM_GLOW_TYPE].SetTexture(new_tex->handle, true);
 	}
 
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(tmap->textures[TM_GLOW_TYPE].GetTexture())));
@@ -114,7 +114,7 @@ ADE_VIRTVAR(SpecularMap, l_TextureMap, "texture", "Specular texture", "texture",
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (ADE_SETTING_VAR && new_tex != nullptr && new_tex->isValid()) {
-		tmap->textures[TM_SPECULAR_TYPE].SetTexture(new_tex->handle);
+		tmap->textures[TM_SPECULAR_TYPE].SetTexture(new_tex->handle, true);
 	}
 
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(tmap->textures[TM_SPECULAR_TYPE].GetTexture())));

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7157,9 +7157,14 @@ void ship::apply_replacement_textures(const SCP_vector<texture_replace> &replace
 
 			int tnum = tmap->FindTexture(tr.old_texture);
 			if (tnum > -1)
-				(*pmi->texture_replace)[j * TM_NUM_TYPES + tnum] = tr.new_texture_id;
+				pmi->texture_replace->reference(j * TM_NUM_TYPES + tnum, tr.new_texture_id);
 		}
 	}
+}
+
+void ship::load_and_apply_replacement_textures(const SCP_vector<texture_replace> &replacements) const
+{
+	model_instance_load_replacement_textures(model_get_instance(model_instance_num), replacements);
 }
 
 void ship_weapon::clear() 
@@ -8449,9 +8454,7 @@ void ship_close_cockpit_displays(ship* shipp)
 			bm_release(Player_displays[i].foreground);
 		}
 
-		if ( Player_displays[i].target >= 0 ) {
-			bm_release(Player_displays[i].target);
-		}
+		// the render target is owned by Player_cockpit_textures, not by the display
 	}
 
 	Player_displays.clear();
@@ -8487,8 +8490,14 @@ static void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_
 		}
 	}
 
+	// if the texture isn't on the model, there is nothing to draw to
+	if ( glow_target < 0 ) {
+		Warning(LOCATION, "Cockpit display '%s' draws to texture '%s', which is not on cockpit model '%s'.  The display will not be created.", display->name, display->filename, pm->filename);
+		return;
+	}
+
 	// create a render target for this cockpit texture
-	auto& glow_texture = (*Player_cockpit_textures)[glow_target];
+	int glow_texture = (*Player_cockpit_textures)[glow_target];
 	if ( glow_texture == -1) {
 		bm_get_info(diffuse_handle, &w, &h);
 		glow_texture = bm_make_render_target(w, h, BMP_FLAG_RENDER_TARGET_DYNAMIC | BMP_FLAG_RENDER_TARGET_DEPTH_ATTACHMENT);
@@ -8497,6 +8506,8 @@ static void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_
 		if ( glow_texture < 0 ) {
 			return;
 		}
+
+		Player_cockpit_textures->adopt(glow_target, glow_texture);
 	}
 
 	new_display.background = -1;
@@ -11595,14 +11606,12 @@ static void ship_model_change(int n, int ship_type)
 	ship_info	*sip;
 	ship			*sp;
 	polymodel * pm;
-	polymodel_instance * pmi;
 	object *objp;
 
 	Assert( n >= 0 && n < MAX_SHIPS );
 	sp = &Ships[n];
 	sip = &(Ship_info[ship_type]);
 	objp = &Objects[sp->objnum];
-	pmi = model_get_instance(sp->model_instance_num);
 
 	// get new model
 	if (sip->model_num == -1) {
@@ -11699,36 +11708,11 @@ static void ship_model_change(int n, int ship_type)
 		sp->cockpit_model_instance = model_create_instance(model_objnum_special::OBJNUM_COCKPIT, sip->cockpit_model_num);
 	else
 		sp->cockpit_model_instance = -1;
-	
-	pmi = model_get_instance(sp->model_instance_num);
 
 	// Goober5000 - deal with texture replacement by re-applying the same code we used during parsing
 	// wookieejedi - replacement textures are loaded in mission parse, so need to load any new textures here
 	// Lafiel - this now has to happen last, as the texture replacement stuff is stored in the pmi
-	if ( !sip->replacement_textures.empty() ) {
-
-		// clear and reset replacement textures because the new positions may be different
-		pmi->texture_replace = std::make_shared<model_texture_replace>();
-		auto& texture_replace_deref = *pmi->texture_replace;
-
-		// now fill them in according to texture name
-		for (const auto& tr : sip->replacement_textures) {
-			// look for textures
-			for (auto j = 0; j < pm->n_textures; j++) {
-
-				texture_map* tmap = &pm->maps[j];
-				int tnum = tmap->FindTexture(tr.old_texture);
-
-				if (tnum > -1) {
-					// load new texture
-					int new_tex = bm_load_either(tr.new_texture);
-					if (new_tex > -1) {
-						texture_replace_deref[j * TM_NUM_TYPES + tnum] = new_tex;
-					}
-				}
-			}
-		}
-	}
+	sp->load_and_apply_replacement_textures(sip->replacement_textures);
 }
 
 /**

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -959,7 +959,11 @@ public:
 	const char* get_display_name() const;
 	bool has_display_name() const;
 
+	// Applies replacement textures whose bitmaps have already been loaded (new_texture_id is set); the model instance takes its own references
 	void apply_replacement_textures(const SCP_vector<texture_replace> &replacements);
+
+	// Applies replacement textures given by filename only (e.g. a ship class's table entry), loading the bitmaps for the model instance
+	void load_and_apply_replacement_textures(const SCP_vector<texture_replace> &replacements) const;
 };
 
 struct ai_target_priority {

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -650,17 +650,7 @@ int create_ship(matrix *orient, vec3d *pos, int ship_type)
 	}
 
 	Ai_info[shipp->ai_index].kamikaze_damage = (int) std::min(1000.0f, 200.0f + (temp_max_hull_strength / 4.0f));
-	auto replacements = sip->replacement_textures;
-	for (auto& tr : replacements) {
-		if (!stricmp(tr.new_texture, "invisible")) {
-			// invisible is a special case
-			tr.new_texture_id = REPLACE_WITH_INVISIBLE;
-		} else {
-			// try to load texture or anim as normal
-			tr.new_texture_id = bm_load_either(tr.new_texture);
-		}
-	}
-	shipp->apply_replacement_textures(replacements);
+	shipp->load_and_apply_replacement_textures(sip->replacement_textures);
 	return obj;
 }
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -977,6 +977,7 @@ void game_level_close()
 		ct_level_close();
 		beam_level_close();
 		mission_brief_common_reset();		// close out parsed briefing/mission stuff
+		mission_parse_level_close();		// let go of the replacement textures the parse objects were holding
 		photo_mode_set_active(false);
 		cam_close();
 		subtitles_close();

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -755,17 +755,7 @@ int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type) {
 	}
 
 	Ai_info[shipp->ai_index].kamikaze_damage = (int) std::min(1000.0f, 200.0f + (temp_max_hull_strength / 4.0f));
-	auto replacements = sip->replacement_textures;
-	for (auto& tr : replacements) {
-		if (!stricmp(tr.new_texture, "invisible")) {
-			// invisible is a special case
-			tr.new_texture_id = REPLACE_WITH_INVISIBLE;
-		} else {
-			// try to load texture or anim as normal
-			tr.new_texture_id = bm_load_either(tr.new_texture);
-		}
-	}
-	shipp->apply_replacement_textures(replacements);
+	shipp->load_and_apply_replacement_textures(sip->replacement_textures);
 	missionChanged();
 
 	return obj;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
@@ -333,7 +333,7 @@ bool ShipTextureReplacementDialogModel::apply()
 					if (!mainName.empty() && !lcase_equal(mainName, _defaultTextures[i])) {
 						int id = load_tex(mainName);
 						if (id != -1)
-							(*pmi->texture_replace)[groupIdx * TM_NUM_TYPES + TM_BASE_TYPE] = id;
+							pmi->texture_replace->adopt(groupIdx * TM_NUM_TYPES + TM_BASE_TYPE, id);
 					}
 
 					// Sub-type slots.
@@ -356,7 +356,7 @@ bool ShipTextureReplacementDialogModel::apply()
 
 						int id = load_tex(fullName);
 						if (id != -1)
-							(*pmi->texture_replace)[groupIdx * TM_NUM_TYPES + tmType] = id;
+							pmi->texture_replace->adopt(groupIdx * TM_NUM_TYPES + tmType, id);
 					}
 				}
 			}
@@ -368,14 +368,19 @@ bool ShipTextureReplacementDialogModel::apply()
 					continue;
 				if (stricmp(tr.ship_name, shipp.ship_name) != 0)
 					continue;
-				int id = (tr.new_texture_id != -1) ? tr.new_texture_id : load_tex(tr.new_texture);
+				// FRED entries never carry a loaded bitmap, so load it here
+				int id = load_tex(tr.new_texture);
 				if (id == -1)
 					continue;
+				// one bitmap may go into several slots, so each slot takes its own reference
 				for (int j = 0; j < pm->n_textures; j++) {
 					int tnum = pm->maps[j].FindTexture(tr.old_texture);
 					if (tnum >= 0)
-						(*pmi->texture_replace)[j * TM_NUM_TYPES + tnum] = id;
+						pmi->texture_replace->reference(j * TM_NUM_TYPES + tnum, id);
 				}
+				// and the reference from loading is no longer needed (the check skips REPLACE_WITH_INVISIBLE)
+				if (id >= 0)
+					bm_release_ref(id);
 			}
 		};
 


### PR DESCRIPTION
Model instance replacement arrays and script-set model textures stored raw
bitmap handles without taking a load-count reference.  A script doing
ship.Textures["foo"] = gr.loadTexture("bar") therefore left the ship pointing
at a bitmap slot that was freed as soon as Lua collected the temporary
texture handle, and reused by whatever bitmap loaded next.

- Add bm_add_ref() / bm_release_ref() to bmpman so callers no longer need
  BMPMAN_INTERNAL to take a reference.  Both count on the first frame of an
  animation, so any frame may be passed and the release always hits the
  same entry as the add; neither counts render targets, since bm_release()
  will not release those anyway.  Use them in the scripting texture handle
  and the librocket rendering interface, which previously counted on
  whatever frame they were handed.
- Add bm_page_out() (bm_unload() with a new keep_reference option) for
  dropping a bitmap's data without giving up the caller's reference, and use
  it when paging out model textures and glow bank bitmaps.  The plain
  bm_unload() call used before consumed one reference without freeing when
  another holder remained, which was harmless while nothing ever released
  but would now leave the model with a dangling handle once the other
  holder did.
- Make model_texture_replace own its entries: the array is now private, is
  written only through adopt() / reference() / clear(), and releases every
  handle it holds when destroyed.  Convert every writer (mission and SEXP
  replacements, cockpit displays, scripting, qtFRED).  Render targets are
  the documented exception; the cockpit display code no longer pretends to
  release its target separately.
- Release the references that mission parsing and the texture replacement
  SEXPs take on replacement bitmaps when the parse objects are discarded;
  ships created from those objects hold their own.  Previously those
  references were never released.
- Add model_instance_load_replacement_textures() to load a table's
  replacement list into an instance by filename, and use it from
  ship_model_change, the lab, FRED, and qtFRED, which each had their own
  copy of that loop (and which each leaked the loader's references).
- Give texture_info an optional held reference so script-set model textures
  stay alive until reset, replaced, or paged out.  PageOut() now pages out
  or releases the texture the model loaded rather than whatever is
  currently drawn, which also stops the debris species swap from releasing
  a texture it does not own.
- Have the cached UI render instances carry their ship class's replacement
  textures, loaded once in model_set_up_techroom_instance(), and add
  model_get_cached_ui_render_instance_for_class() so that the tech room,
  ship and weapon select, loadout icons, and tech model rendering fetch the
  instance and its replacements with one call instead of each building a
  fresh array with bm_load() every frame, which leaked one load count per
  frame.  The instance cache is now keyed by ship class as well, since
  classes sharing a model may differ in replacement textures.  As a side
  effect, those screens and the briefing closeup now load table replacement
  textures the same way missions do, so "invisible" and animated
  replacements are honored in previews where they were previously ignored.
- Delete the briefing closeup's model instance when its icon is set up
  again or the briefing closes; previously every revisited icon leaked its
  instance, which now also pinned its replacement bitmaps.
- Skip a cockpit display whose texture is not on the cockpit model, with a
  warning; previously this indexed the replacement array with -1.
- Guard bmpman against static destructors that release bitmaps after an
  exit that skipped bm_close().
- Document the texture slot layout of the "textures" and
  "modelinstancetextures" Lua handles, fix the stale TM_NUM_TYPES comment,
  and correct the gr.loadTexture docs on texture lifetime.
- Glow bank bitmaps are now released when a model is unloaded, and support
  ships receive their class's replacement textures.

~~Depends on #7761; in draft until that is merged.~~