### PR TITLE
fix weapon substitution bank attribution and turret ammo accounting

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -350,6 +350,18 @@ const weapon_info *get_turret_weapon_wip(const ship_weapon *swp, int weapon_num)
 		return &Weapon_info[wi_index];
 }
 
+// similar to the above, since "weapon_num" is a bank index over multiple banks
+static std::pair<int, int> get_turret_weapon_bank(int weapon_num)
+{
+	int pbank = -1;
+	int sbank = -1;
+	if (weapon_num >= MAX_SHIP_PRIMARY_BANKS)
+		sbank = weapon_num - MAX_SHIP_PRIMARY_BANKS;
+	else
+		pbank = weapon_num;
+	return { pbank, sbank };
+}
+
 int get_turret_weapon_next_fire_stamp(const ship_weapon *swp, int weapon_num)
 {
 	Assert(weapon_num < MAX_SHIP_WEAPONS);
@@ -1729,6 +1741,7 @@ bool turret_fire_weapon(int weapon_num,
 	auto wip = get_turret_weapon_wip(&turret->weapons, weapon_num);
 	if (!wip)
 		return false;
+	auto [turret_pbank, turret_sbank] = get_turret_weapon_bank(weapon_num);
 
 	bool in_lab = (gameseq_get_state() == GS_STATE_LAB);
 
@@ -1839,6 +1852,7 @@ bool turret_fire_weapon(int weapon_num,
 				else
 					fire_info.target_subsys = nullptr;
 				fire_info.turret = turret;
+				fire_info.bank = turret_pbank;
 				fire_info.burst_seed = old_burst_seed;
 				fire_info.fire_method = BFM_TURRET_FIRED;
 				fire_info.per_burst_rotation = swp->per_burst_rot;
@@ -1850,7 +1864,6 @@ bool turret_fire_weapon(int weapon_num,
 					fire_info.bfi_flags |= BFIF_TARGETING_COORDS;
 					fire_info.target_pos1 = turret->last_aim_enemy_pos;
 				}
-
 
 				// fire a beam weapon
 				weapon_objnum = beam_fire(&fire_info);
@@ -1877,113 +1890,53 @@ bool turret_fire_weapon(int weapon_num,
 		}
 		// don't fire swam, but set up swarm info instead
 		else if ((wip->wi_flags[Weapon::Info_Flags::Swarm]) || (wip->wi_flags[Weapon::Info_Flags::Corkscrew])) {
-			if (swp->current_secondary_bank < 0) {
-				swp->current_secondary_bank = 0;
+			// swarm and corkscrew are not restricted to missiles, so check whichever bank is actually firing
+			if (!in_lab && (turret->system_info->flags[Model::Subsystem_Flags::Turret_use_ammo])) {
+				bool has_ammo = (turret_pbank >= 0)
+					? swp->primary_bank_ammo[turret_pbank] > 0
+					: ship_secondary_has_ammo(swp, turret_sbank);
+				if (!has_ammo)
+					return false;
 			}
-			int bank_to_fire = swp->current_secondary_bank;
-			if (!in_lab && (turret->system_info->flags[Model::Subsystem_Flags::Turret_use_ammo]) && !ship_secondary_has_ammo(swp, bank_to_fire)) {
-				if (!(turret->system_info->flags[Model::Subsystem_Flags::Use_multiple_guns])) {
-					swp->current_secondary_bank++;
-					if (swp->current_secondary_bank >= swp->num_secondary_banks) {
-						swp->current_secondary_bank = 0;
-					}
-					return false;
-				} else {
-					return false;
-				}
-			} else {
-				turret_swarm_set_up_info(parent_objnum, turret, wip, turret->turret_next_fire_pos, in_lab);
 
-				turret->flags.set(Ship::Subsystem_Flags::Has_fired);	//set fired flag for scripting -nike
-				return true;
-			}
+			turret_swarm_set_up_info(parent_objnum, turret, wip, turret->turret_next_fire_pos, turret_pbank, turret_sbank, in_lab);
+			turret->flags.set(Ship::Subsystem_Flags::Has_fired);	//set fired flag for scripting -nike
+			return true;
 		}
 		// now do anything else
 		else {
 			float shots_mult = wip->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::SHOTS_MULT, launch_curve_data);
 			int shots = fl2i(i2fl(wip->shots) * shots_mult);
+
+			// note that wip is reassigned to the created weapon's class inside the loop, so any
+			// property of the bank's own weapon must be read before we get there
+			bool no_ammo_needed = (turret_sbank >= 0) && Weapon_info[swp->secondary_bank_weapons[turret_sbank]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo];
 			for (int i = 0; i < shots; i++) {
 				if (!in_lab && turret->system_info->flags[Model::Subsystem_Flags::Turret_use_ammo]) {
-					int bank_to_fire, num_slots = turret->system_info->turret_num_firing_points;
-					if (wip->subtype == WP_LASER) {
+					if (turret_pbank >= 0) {
 						int points;
-						if (swp->num_primary_banks <= 0) {
-							return false;
-						}
-
-						if (swp->current_primary_bank < 0){
-							swp->current_primary_bank = 0;
-							return false;
-						}
-
-						int	num_primary_banks = swp->num_primary_banks;
-
-						Assert(num_primary_banks > 0);
-						if (num_primary_banks < 1){
-							return false;
-						}
-
-						bank_to_fire = swp->current_primary_bank;
-
 						if (turret->system_info->flags[Model::Subsystem_Flags::Turret_salvo]) {
-							points = num_slots;
+							points = turret->system_info->turret_num_firing_points;
 						} else {
 							points = 1;
 						}
 
-						if (swp->primary_bank_ammo[bank_to_fire] >= points) {
-							swp->primary_bank_ammo[bank_to_fire] -= points;
-						} else if ((swp->primary_bank_ammo[bank_to_fire] >= 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
+						if (swp->primary_bank_ammo[turret_pbank] >= points) {
+							swp->primary_bank_ammo[turret_pbank] -= points;
+						} else if ((swp->primary_bank_ammo[turret_pbank] >= 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
 							// default behavior allowed ammo to be negative
-							swp->primary_bank_ammo[bank_to_fire] -= points;
-						} else if (!(turret->system_info->flags[Model::Subsystem_Flags::Use_multiple_guns]) && (swp->primary_bank_ammo[bank_to_fire] < 0)) {
-							swp->current_primary_bank++;
-							if (swp->current_primary_bank >= swp->num_primary_banks) {
-								swp->current_primary_bank = 0;
-							}
-							return false;
+							swp->primary_bank_ammo[turret_pbank] -= points;
 						} else {
 							return false;
 						}
 					}
-					else if (wip->subtype == WP_MISSILE) {
-						if (swp->num_secondary_banks <= 0) {
-							return false;
-						}
-
-						if (swp->current_secondary_bank < 0){
-							swp->current_secondary_bank = 0;
-							return false;
-						}
-
-						bank_to_fire = swp->current_secondary_bank;
-
-						int start_slot, end_slot;
-
-						start_slot = swp->secondary_next_slot[bank_to_fire];
-						end_slot = start_slot;
-
-						for (int j = start_slot; j <= end_slot; j++) {
-							swp->secondary_next_slot[bank_to_fire]++;
-
-							if (Weapon_info[swp->secondary_bank_weapons[bank_to_fire]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo])
-								continue;
-
-							if (swp->secondary_next_slot[bank_to_fire] > (num_slots - 1)){
-								swp->secondary_next_slot[bank_to_fire] = 0;
-							}
-
-							if (swp->secondary_bank_ammo[bank_to_fire] > 0) {
-								swp->secondary_bank_ammo[bank_to_fire]--;
-							} else if ((swp->secondary_bank_ammo[bank_to_fire] == 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
+					else if (turret_sbank >= 0) {
+						if (!no_ammo_needed) {
+							if (swp->secondary_bank_ammo[turret_sbank] > 0) {
+								swp->secondary_bank_ammo[turret_sbank]--;
+							} else if ((swp->secondary_bank_ammo[turret_sbank] == 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
 								// default behavior allowed ammo to be negative
-								swp->secondary_bank_ammo[bank_to_fire]--;
-							} else if (!(turret->system_info->flags[Model::Subsystem_Flags::Use_multiple_guns]) && (swp->secondary_bank_ammo[bank_to_fire] < 0)) {
-								swp->current_secondary_bank++;
-								if (swp->current_secondary_bank >= swp->num_secondary_banks) {
-									swp->current_secondary_bank = 0;
-								}
-								return false;
+								swp->secondary_bank_ammo[turret_sbank]--;
 							} else {
 								return false;
 							}
@@ -1998,7 +1951,7 @@ bool turret_fire_weapon(int weapon_num,
 				// so we need to get the position info separately for each shot
 				ship_get_global_turret_gun_info(&Objects[parent_objnum], turret, &firing_pos_buf, false, nullptr, true, nullptr);
 
-				weapon_objnum = weapon_create(firing_pos, &firing_orient, turret_weapon_class, parent_objnum, -1, true, false, 0.0f, turret, launch_curve_data);
+				weapon_objnum = weapon_create(firing_pos, &firing_orient, turret_weapon_class, parent_objnum, -1, true, false, swp, turret_pbank, turret_sbank, launch_curve_data);
 				weapon_set_tracking_info(weapon_objnum, parent_objnum, turret->turret_enemy_objnum, 1, turret->targeted_subsys);		
 			
 				//nprintf(("AI", "Turret_time_enemy_in_range = %7.3f\n", ss->turret_time_enemy_in_range));		
@@ -2142,7 +2095,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 	};
 
 	// create weapon and homing info
-	weapon_objnum = weapon_create(&turret_pos, &firing_orient, tsi->weapon_class, tsi->parent_objnum, -1, true, false, 0.0f, tsi->turret, launch_curve_data);
+	weapon_objnum = weapon_create(&turret_pos, &firing_orient, tsi->weapon_class, tsi->parent_objnum, -1, true, false, &tsi->turret->weapons, tsi->swp_pbank, tsi->swp_sbank, launch_curve_data);
 	weapon_set_tracking_info(weapon_objnum, tsi->parent_objnum, tsi->target_objnum, 1, tsi->target_subsys);
 
 	// do other cool stuff if weapon is created.

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3475,7 +3475,7 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 		multi_set_network_signature( wnet_signature, MULTI_SIG_NON_PERMANENT );
 	}
 
-	weapon_objnum = weapon_create( &pos, &orient, wid, OBJ_INDEX(objp), -1, true, false, 0.0f, ssp, launch_curve_data);
+	weapon_objnum = weapon_create( &pos, &orient, wid, OBJ_INDEX(objp), -1, true, false, nullptr, -1, -1, launch_curve_data);
 
 	if (weapon_objnum != -1) {
 		if ( Weapon_info[wid].launch_snd.isValid() ) {
@@ -8382,6 +8382,12 @@ void process_beam_fired_packet(ubyte *data, header *hinfo)
 	fire_info.target = multi_get_network_object(target_sig);
 	fire_info.burst_index = 0;
 
+	// the weapon class arrives over the network, so validate it before using it to index Weapon_info
+	if (!Weapon_info.in_bounds(fire_info.beam_info_index)) {
+		nprintf(("Network", "Received invalid weapon class %d for BEAM weapon!\n", fire_info.beam_info_index));
+		return;
+	}
+
 	if ( fire_info.target && (target_subsys_index >= 0) ) {
 		ship *targetp = &Ships[fire_info.target->instance];
 		fire_info.target_subsys = ship_get_indexed_subsys(targetp, target_subsys_index);
@@ -8394,12 +8400,14 @@ void process_beam_fired_packet(ubyte *data, header *hinfo)
 			Assertion(bank >= 0, "Fighter BEAM bank is invalid!");
 			Assertion(point >= 0, "Fighter BEAM point is invalid!");
 
-			if ( (bank < 0) || (point < 0) ) {
+			polymodel *pm = model_get( Ship_info[shipp->ship_info_index].model_num );
+
+			// the bank and point also arrive over the network, so validate them against the model
+			if ( (bank < 0) || (bank >= pm->n_guns) || (point < 0) || (point >= pm->gun_banks[bank].num_slots) ) {
 				nprintf(("Network", "Couldn't get firing point for fighter BEAM weapon!\n"));
 				return;
 			}
 
-			polymodel *pm = model_get( Ship_info[shipp->ship_info_index].model_num );
 			float field_of_fire = Weapon_info[fire_info.beam_info_index].field_of_fire;
 
 			fire_info.local_fire_postion = pm->gun_banks[bank].pnt[point];
@@ -8779,7 +8787,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	};
 
 	// create the weapon object	
-	weapon_objnum = weapon_create( &pos, &orient, wid, OBJ_INDEX(objp), -1, true, false, 0.0f, ssp, launch_curve_data);
+	weapon_objnum = weapon_create( &pos, &orient, wid, OBJ_INDEX(objp), -1, true, false, nullptr, -1, -1, launch_curve_data);
 	if (weapon_objnum != -1) {
 		const weapon_info& wip = Weapon_info[wid];
 		if ( wip.launch_snd.isValid() ) {

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -22259,6 +22259,7 @@ void sexp_beam_fire(int node, bool at_coords)
 		// store the weapon info index
 		if (Weapon_info[fire_info.turret->weapons.primary_bank_weapons[idx]].wi_flags[Weapon::Info_Flags::Beam]) {
 			fire_info.beam_info_index = fire_info.turret->weapons.primary_bank_weapons[idx];
+			fire_info.bank = idx;
 		}
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13643,7 +13643,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 							// create the weapon -- the network signature for multiplayer is created inside
 							// of weapon_create							
 							weapon_objnum = weapon_create( &firing_pos, &firing_orient, weapon_idx, OBJ_INDEX(obj), new_group_id,
-								false, false, swp->primary_bank_fof_cooldown[bank_to_fire], nullptr, launch_curve_data );
+								false, false, swp, bank_to_fire, -1, launch_curve_data );
 
 							if (weapon_objnum == -1) {
 								// Weapon most likely failed to fire
@@ -14026,7 +14026,8 @@ bool ship_secondary_bank_can_dual_fire(const ship *shipp, int bank)
 	if (Weapon_info[weapon_class].wi_flags[Weapon::Info_Flags::No_doublefire])
 		return false;
 
-	if (shipp->objnum == OBJ_INDEX(Player_obj))
+	// use the flag, not Player_obj, for multiplayer correctness
+	if (shipp->objnum >= 0 && Objects[shipp->objnum].flags[Object::Object_Flags::Player_ship])
 	{
 		if (The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire])
 			return false;
@@ -14481,7 +14482,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 
 			// create the weapon -- for multiplayer, the net_signature is assigned inside
 			// of weapon_create
-			weapon_num = weapon_create( &firing_pos, &firing_orient, weapon_idx, OBJ_INDEX(obj), -1, tinfo.locked, false, 0.f, nullptr, launch_curve_data);
+			weapon_num = weapon_create( &firing_pos, &firing_orient, weapon_idx, OBJ_INDEX(obj), -1, tinfo.locked, false, swp, -1, bank, launch_curve_data);
 
 			if (weapon_num == -1) {
 				// Weapon most likely failed to fire
@@ -22378,7 +22379,7 @@ bool ship_stop_secondary_fire(object* objp)
 }
 
 bool ship_secondary_has_ammo(ship_weapon* swp, int bank_index) {
-	return swp->secondary_bank_ammo[bank_index] > 0 || Weapon_info[swp->secondary_bank_weapons[bank_index]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo];
+	return bank_index >= 0 && (swp->secondary_bank_ammo[bank_index] > 0 || Weapon_info[swp->secondary_bank_weapons[bank_index]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo]);
 }
 
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -364,33 +364,30 @@ int beam_fire(beam_fire_info *fire_info)
 	wip = &Weapon_info[fire_info->beam_info_index];	
 
 	// copied from weapon_create()
-	if ((wip->num_substitution_patterns > 0) && (fire_info->shooter != nullptr)) {
+	// (a beam whose info was dictated by the server has already had its substitution resolved there)
+	if ((wip->num_substitution_patterns > 0) && (fire_info->shooter != nullptr) && (fire_info->beam_info_override == nullptr)) {
 		// using substitution
 
-		// get to the instance of the gun
-		Assertion(fire_info->shooter->type == OBJ_SHIP, "Expected type OBJ_SHIP, got %d", fire_info->shooter->type);
-		Assertion((fire_info->shooter->instance < MAX_SHIPS) && (fire_info->shooter->instance >= 0),
-			"Ship index is %d, which is out of range [%d,%d)", fire_info->shooter->instance, 0, MAX_SHIPS);
-		ship* parent_shipp = &(Ships[fire_info->shooter->instance]);
-		Assert(parent_shipp != nullptr);
-
-		size_t* position = get_pointer_to_weapon_fire_pattern_index(fire_info->beam_info_index, fire_info->shooter->instance, fire_info->turret);
-		Assertion(position != nullptr, "'%s' is trying to fire a weapon that is not selected", Ships[fire_info->shooter->instance].ship_name);
-
-		size_t curr_pos = *position;
-		if ((parent_shipp->flags[Ship::Ship_Flags::Primary_linked]) && curr_pos > 0) {
-			curr_pos--;
+		// the turret and fighter firing code both tell us which bank the beam is in
+		int pbank = fire_info->bank;
+		ship *parent_shipp = nullptr;
+		ship_weapon* swp = nullptr;
+		if (fire_info->fire_method == BFM_TURRET_FIRED || fire_info->fire_method == BFM_TURRET_FORCE_FIRED) {
+			// the fire method and the turret are set independently, so the turret can be null here
+			if (fire_info->turret != nullptr)
+				swp = &fire_info->turret->weapons;
+		} else if (fire_info->fire_method == BFM_FIGHTER_FIRED && fire_info->shooter->type == OBJ_SHIP) {
+			parent_shipp = &Ships[fire_info->shooter->instance];
+			swp = &parent_shipp->weapons;
 		}
-		++(*position);
-		*position = (*position) % wip->num_substitution_patterns;
 
-		if (wip->weapon_substitution_pattern[curr_pos] == -1) {
-			// weapon doesn't want any sub
-			return -1;
-		}
-		else if (wip->weapon_substitution_pattern[curr_pos] != fire_info->beam_info_index) {
-			fire_info->beam_info_index = wip->weapon_substitution_pattern[curr_pos];
-			// weapon wants to sub with weapon other than me
+		auto [use_substitution, substituted_weapon_info_index] = get_weapon_substitution_tuple(fire_info->beam_info_index, swp, pbank, -1, parent_shipp);
+
+		if (use_substitution) {
+			if (substituted_weapon_info_index < 0)
+				return -1;
+
+			fire_info->beam_info_index = substituted_weapon_info_index;
 			return beam_fire(fire_info);
 		}
 	}

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -102,7 +102,7 @@ typedef struct beam_fire_info {
 	vec3d			starting_pos;							// starting positiong for floating beams -MageKing17
 	beam_info		*beam_info_override;			// (optional), pass this in to override all beam movement info (for multiplayer)
 	int				num_shots;						// (optional), only used for type D weapons
-	int bank;									// for fighters, which bank of the primary weapons are they in
+	int bank;									// which primary bank the beam is in (for fighters and turrets)
 	int point;									// for fighters, which point on the bank it is from
 	int bfi_flags;
 	char team;									// for floating beams, determines which team the beam is on

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -63,6 +63,8 @@ void swarm_level_init()
 		tswarmp->turret		  = NULL;
 		tswarmp->target_subsys = NULL;
 		tswarmp->time_to_fire  = 0;
+		tswarmp->swp_pbank = -1;
+		tswarmp->swp_sbank = -1;
 	}
 
 	Turret_swarm_validity_next_check_time = timestamp(TURRET_SWARM_VALIDITY_CHECKTIME);
@@ -286,6 +288,8 @@ int turret_swarm_create()
 	tswarmp->turret = NULL;
 	tswarmp->target_subsys = NULL;
 	tswarmp->time_to_fire = 0;
+	tswarmp->swp_pbank = -1;
+	tswarmp->swp_sbank = -1;
 
 	tswarmp->flags |= SWARM_USED;
 	return i;
@@ -309,7 +313,7 @@ void turret_swarm_delete(int i)
 }
 
 // Set up turret swarm info struct
-void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weapon_info *wip, int weapon_num, bool no_tracking_object)
+void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weapon_info *wip, int weapon_num, int swp_pbank, int swp_sbank, bool no_tracking_object)
 {
 	turret_swarm_info	*tsi;
 	object *parent_obj;
@@ -404,6 +408,8 @@ void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weap
 	tsi->target_subsys = turret->targeted_subsys;
 	tsi->time_to_fire = 1;	// first missile next frame
 	tsi->weapon_num = weapon_num;
+	tsi->swp_pbank = swp_pbank;
+	tsi->swp_sbank = swp_sbank;
 }
 
 void turret_swarm_fire_from_turret(turret_swarm_info *tsi);

--- a/code/weapon/swarm.h
+++ b/code/weapon/swarm.h
@@ -30,6 +30,8 @@ typedef struct turret_swarm_info {
 	ship_subsys*	target_subsys;
 	int				time_to_fire;
 	int				weapon_num;
+	int				swp_pbank;
+	int				swp_sbank;
 } turret_swarm_info;
 
 struct swarm_info {
@@ -52,7 +54,7 @@ void	swarm_maybe_fire_missile(int shipnum);
 
 int	turret_swarm_create();
 void	turret_swarm_delete(int i);
-void	turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weapon_info *wip, int weapon_num, bool no_tracking_object = false);
+void	turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weapon_info *wip, int weapon_num, int swp_pbank, int swp_sbank, bool no_tracking_object = false);
 void	turret_swarm_check_validity();
 
 #endif /* __FREESPACE_SWARM_H__ */

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -36,8 +36,11 @@
 #include "utils/modular_curves.h"
 
 #include <optional>
+#include <tuple>
 
 class object;
+class ship;
+class ship_weapon;
 class ship_subsys;
 
 #define WP_UNUSED    -1
@@ -1030,8 +1033,9 @@ int weapon_create( const vec3d *pos,
 	int group_id=-1,
 	bool is_locked = false,
 	bool is_spawned = false,
-	float fof_cooldown = 0.0f,
-	ship_subsys *src_turret = nullptr,
+	ship_weapon *src_swp = nullptr,
+	int src_pbank = -1,
+	int src_sbank = -1,
 	const WeaponLaunchCurveData& launch_curve_data = WeaponLaunchCurveData {
 		0,
 		0.f,
@@ -1046,8 +1050,8 @@ inline void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, track
 }
 
 // gets the substitution pattern pointer for a given weapon
-// src_turret may be null
-size_t* get_pointer_to_weapon_fire_pattern_index(int weapon_type, int ship_idx, ship_subsys* src_turret);
+// returns [use_substitution, substituted_weapon_info_index]
+std::tuple<bool, int> get_weapon_substitution_tuple(int weapon_info_index, ship_weapon *swp, int pbank, int sbank, ship *shipp_to_check);
 
 bool weapon_armed(weapon *wp, bool hit_target);
 void maybe_play_conditional_impacts(const std::array<std::optional<ConditionData>, NumHitTypes>& impact_data, const object* weapon_objp, const object* impacted_objp, bool armed_weapon, int submodel, const vec3d* hitpos, const vec3d* local_hitpos = nullptr, const vec3d* hit_normal = nullptr);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7046,31 +7046,69 @@ void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, int target_o
 	}
 }
 
-size_t* get_pointer_to_weapon_fire_pattern_index(int weapon_type, int ship_idx, ship_subsys * src_turret)
+static size_t *get_pointer_to_weapon_fire_pattern_index(ship_weapon *ship_weapon_p, int swp_pbank, int swp_sbank)
 {
-	Assertion(ship_idx >= 0 && ship_idx < MAX_SHIPS, "Invalid ship index in get_pointer_to_weapon_fire_pattern_index()");
-	ship* shipp = &Ships[ship_idx];
-	ship_weapon* ship_weapon_p = &(shipp->weapons);
-	if(src_turret)
+	if (ship_weapon_p)
 	{
-		ship_weapon_p = &src_turret->weapons;
+		if (swp_pbank >= 0)
+		{
+			Assertion(swp_pbank < MAX_SHIP_PRIMARY_BANKS, "swp_pbank is %d, which is out of range [0,%d)", swp_pbank, MAX_SHIP_PRIMARY_BANKS);
+			return &(ship_weapon_p->primary_bank_substitution_pattern_index[swp_pbank]);
+		}
+		if (swp_sbank >= 0)
+		{
+			Assertion(swp_sbank < MAX_SHIP_SECONDARY_BANKS, "swp_sbank is %d, which is out of range [0,%d)", swp_sbank, MAX_SHIP_SECONDARY_BANKS);
+			return &(ship_weapon_p->secondary_bank_substitution_pattern_index[swp_sbank]);
+		}
 	}
-	Assert( ship_weapon_p != NULL );
+	return nullptr;
+}
 
-	// search for the corresponding bank pattern index for the weapon_type that is being fired.
-	// Note: Because a weapon_type may not be unique to a weapon bank per ship this search may attribute
-	// the weapon to the wrong bank.  Hopefully this isn't a problem.
-	for ( int pi = 0; pi < MAX_SHIP_PRIMARY_BANKS; pi++ ) {
-		if ( ship_weapon_p->primary_bank_weapons[pi] == weapon_type ) {
-			return &(ship_weapon_p->primary_bank_substitution_pattern_index[pi]);
+// gets the substitution pattern pointer for a given weapon
+// returns [use_substitution, substituted_weapon_info_index]
+std::tuple<bool, int> get_weapon_substitution_tuple(int weapon_info_index, ship_weapon *swp, int pbank, int sbank, ship *shipp_to_check)
+{
+	auto wip = &Weapon_info[weapon_info_index];
+	if (wip->num_substitution_patterns == 0)
+		return { false, -1 };
+
+	bool paired_shot = false;
+	if (shipp_to_check)
+	{
+		// only advance the pattern once per linked/paired shot rather than once per projectile
+		if (wip->subtype == WP_LASER)
+		{
+			paired_shot = shipp_to_check->flags[Ship::Ship_Flags::Primary_linked];
+		}
+		else if (wip->subtype == WP_MISSILE && shipp_to_check->flags[Ship::Ship_Flags::Secondary_dual_fire])
+		{
+			// for dual fire, also check whether the armed bank can actually use it, since the flag is ignored rather than cleared for banks that can't
+			paired_shot = ship_secondary_bank_can_dual_fire(shipp_to_check, sbank);
 		}
 	}
-	for ( int si = 0; si < MAX_SHIP_SECONDARY_BANKS; si++ ) {
-		if ( ship_weapon_p->secondary_bank_weapons[si] == weapon_type ) {
-			return &(ship_weapon_p->secondary_bank_substitution_pattern_index[si]);
+
+	auto position = get_pointer_to_weapon_fire_pattern_index(swp, pbank, sbank);
+	if (position)
+	{
+		size_t curr_pos = *position;
+		if (paired_shot && curr_pos > 0)
+			curr_pos--;
+		++(*position);
+		*position = (*position) % wip->num_substitution_patterns;
+
+		if (wip->weapon_substitution_pattern[curr_pos] == -1)
+		{
+			// weapon doesn't want any sub
+			return { true, -1 };
+		}
+		else if (wip->weapon_substitution_pattern[curr_pos] != weapon_info_index)
+		{
+			// weapon wants to sub with weapon other than me
+			return { true, wip->weapon_substitution_pattern[curr_pos] };
 		}
 	}
-	return NULL;
+
+	return { false, -1 };
 }
 
 /**
@@ -7079,7 +7117,7 @@ size_t* get_pointer_to_weapon_fire_pattern_index(int weapon_type, int ship_idx, 
  * @return Index of weapon in the Objects[] array, -1 if the weapon object was not created
  */
 int Weapons_created = 0;
-int weapon_create( const vec3d *pos, const matrix *porient, int weapon_type, int parent_objnum, int group_id, bool is_locked, bool is_spawned, float fof_cooldown, ship_subsys *src_turret, const WeaponLaunchCurveData& launch_curve_data )
+int weapon_create( const vec3d *pos, const matrix *porient, int weapon_type, int parent_objnum, int group_id, bool is_locked, bool is_spawned, ship_weapon *src_swp, int src_pbank, int src_sbank, const WeaponLaunchCurveData& launch_curve_data )
 {
 	int			n, objnum;
 	object		*objp, *parent_objp=NULL;
@@ -7104,38 +7142,17 @@ int weapon_create( const vec3d *pos, const matrix *porient, int weapon_type, int
 
 	if ( (wip->num_substitution_patterns > 0) && (parent_objp != NULL)) {
 		// using substitution
+		// linked/dual fire pairing only applies to ship-level fire, not to turrets or non-ship parents
+		ship *parent_shipp = nullptr;
+		if (parent_objp->type == OBJ_SHIP && src_swp == &Ships[parent_objp->instance].weapons)
+			parent_shipp = &Ships[parent_objp->instance];
+		auto [use_substitution, substituted_weapon_info_index] = get_weapon_substitution_tuple(weapon_type, src_swp, src_pbank, src_sbank, parent_shipp);
 
-		// get to the instance of the gun
-		Assertion( parent_objp->type == OBJ_SHIP, "Expected type OBJ_SHIP, got %d", parent_objp->type );
-		Assertion( (parent_objp->instance < MAX_SHIPS) && (parent_objp->instance >= 0),
-			"Ship index is %d, which is out of range [%d,%d)", parent_objp->instance, 0, MAX_SHIPS);
-		ship* parent_shipp = &(Ships[parent_objp->instance]);
-		Assert( parent_shipp != NULL );
+		if (use_substitution) {
+			if (substituted_weapon_info_index < 0)
+				return -1;
 
-		size_t *position = get_pointer_to_weapon_fire_pattern_index(weapon_type, parent_objp->instance, src_turret);
-		Assertion( position != NULL, "'%s' is trying to fire a weapon that is not selected", Ships[parent_objp->instance].ship_name );
-
-		size_t curr_pos = *position;
-		// only advance the pattern once per linked/paired shot rather than once per projectile
-		bool paired_shot = false;
-		if (Weapon_info[weapon_type].subtype == WP_LASER) {
-			paired_shot = parent_shipp->flags[Ship::Ship_Flags::Primary_linked];
-		} else if (Weapon_info[weapon_type].subtype == WP_MISSILE && !src_turret && parent_shipp->flags[Ship::Ship_Flags::Secondary_dual_fire]) {
-			// for dual fire, also check whether the armed bank can actually use it, since the flag is ignored rather than cleared for banks that can't
-			paired_shot = ship_secondary_bank_can_dual_fire(parent_shipp, parent_shipp->weapons.current_secondary_bank);
-		}
-		if (paired_shot && (curr_pos > 0)) {
-			curr_pos--;
-		}
-		++(*position);
-		*position = (*position) % wip->num_substitution_patterns;
-
-		if ( wip->weapon_substitution_pattern[curr_pos] == -1 ) {
-			// weapon doesn't want any sub
-			return -1;
-		} else if ( wip->weapon_substitution_pattern[curr_pos] != weapon_type ) {
-			// weapon wants to sub with weapon other than me
-			return weapon_create(pos, porient, wip->weapon_substitution_pattern[curr_pos], parent_objnum, group_id, is_locked, is_spawned, fof_cooldown, nullptr, launch_curve_data);
+			return weapon_create(pos, porient, substituted_weapon_info_index, parent_objnum, group_id, is_locked, is_spawned, src_swp, src_pbank, src_sbank, launch_curve_data);
 		}
 	}
 
@@ -7147,7 +7164,7 @@ int weapon_create( const vec3d *pos, const matrix *porient, int weapon_type, int
 		float test = rng.next();
 		if (test < failure_rate) {
 			if (wip->failure_sub != -1) {
-				return weapon_create(pos, porient, wip->failure_sub, parent_objnum, group_id, is_locked, is_spawned, fof_cooldown, nullptr, launch_curve_data);
+				return weapon_create(pos, porient, wip->failure_sub, parent_objnum, group_id, is_locked, is_spawned, src_swp, src_pbank, src_sbank, launch_curve_data);
 			} else {
 				return -1;
 			}
@@ -7200,9 +7217,15 @@ int weapon_create( const vec3d *pos, const matrix *porient, int weapon_type, int
 	orient = &morient;
 
 	float combined_fof = wip->field_of_fire * wip->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::FOF_MULT, launch_curve_data);
-	// If there is a fof_cooldown value, increase the spread linearly
-	if (fof_cooldown != 0.0f) {
-		combined_fof = wip->field_of_fire + (fof_cooldown * wip->max_fof_spread);
+	{
+		// If there is a fof_cooldown value, increase the spread linearly
+		float fof_cooldown = 0.0f;
+		if (src_swp && src_pbank >= 0)
+			fof_cooldown = src_swp->primary_bank_fof_cooldown[src_pbank];
+//		if (src_swp && src_sbank >= 0)
+//			fof_cooldown = src_swp->secondary_bank_fof_cooldown[src_sbank];
+		if (fof_cooldown != 0.0f)
+			combined_fof = wip->field_of_fire + (fof_cooldown * wip->max_fof_spread);
 	}
 
 	if(combined_fof > 0.0f){


### PR DESCRIPTION
Follow-up to #7635.

Pass the firing bank explicitly through weapon_create() and beam_fire() instead of searching the ship's banks by weapon class, which could attribute substitution patterns to the wrong bank.  Factor the substitution logic into get_weapon_substitution_tuple() and only apply linked/dual-fire pairing to ship-level fire, not turret fire.  Skip substitution on multiplayer clients, since the server already resolved it.

Derive turret bank indices from the weapon slot being fired rather than the turret's bank cursor, so ammo and substitution state are tracked on the bank that actually fired.  Previously a single-selection turret could consume ammo from a bank it never fired, and non-ammo turrets (whose cursors stay at -1) would have skipped substitution entirely.

Use the Player_ship object flag rather than Player_obj in ship_secondary_bank_can_dual_fire() so the server and clients agree on dual fire for remote players, and guard ship_secondary_has_ammo() against a negative bank index.