### PR TITLE
fix copying multiple glow point banks into a virtual POF

### DIFF
--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -482,6 +482,7 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 				for (const glow_point_bank* gpb : glowpointbanks) {
 					pm->glow_point_banks[insertFrom] = object_copy_including_array_member(*gpb, &glow_point_bank::num_points, &glow_point_bank::points);
 					change_submodel_numbers(pm->glow_point_banks[insertFrom], replaceSubobjNo);
+					insertFrom++;
 				}
 			}
 		}


### PR DESCRIPTION
Every copied bank was written to the same array slot, so all but the last were lost, and the slots left behind kept their zero-initialized contents. A zeroed bitmap handle is slot 0 rather than -1, so the paging code would then page out an unrelated bitmap.