### PR TITLE
Fix unused param warnings when compiling with openxr off

### DIFF
--- a/code/graphics/opengl/gropenglopenxr.cpp
+++ b/code/graphics/opengl/gropenglopenxr.cpp
@@ -483,7 +483,7 @@ bool gr_opengl_openxr_test_capabilities() { return false; }
 
 bool gr_opengl_openxr_create_session() { return false; }
 
-int64_t gr_opengl_openxr_get_swapchain_format(const SCP_vector<int64_t>& allowed) { return 0; }
+int64_t gr_opengl_openxr_get_swapchain_format(const SCP_vector<int64_t>& /*allowed*/) { return 0; }
 
 bool gr_opengl_openxr_acquire_swapchain_buffers() { return false; }
 

--- a/code/graphics/openxr.cpp
+++ b/code/graphics/openxr.cpp
@@ -525,9 +525,9 @@ void openxr_start_frame() {
 // Stubs for when building without OpenXR support.
 // NOTE: macOS has issues linking with OpenXR.
 
-void openxr_prepare(float hudscale) {}
+void openxr_prepare(float /*hudscale*/) {}
 
-float openxr_preinit(float req_ar, float scale) {
+float openxr_preinit(float /*req_ar*/, float /*scale*/) {
 	mprintf(("Cannot create OpenXR session. Not built with OpenXR support.\n"));
 	return 0.0f;
 }


### PR DESCRIPTION
Fix these warnings when compiling with OpenXR off.

```
[711/1325] Building CXX object code/CMakeFiles/code.dir/graphics/openxr.cpp.o
/work/fso_android/fs2open.github.com/code/graphics/openxr.cpp:528:27: warning: unused parameter 'hudscale' [-Wunused-parameter]
  528 | void openxr_prepare(float hudscale) {}
      |                           ^
/work/fso_android/fs2open.github.com/code/graphics/openxr.cpp:530:28: warning: unused parameter 'req_ar' [-Wunused-parameter]
  530 | float openxr_preinit(float req_ar, float scale) {
      |                            ^
/work/fso_android/fs2open.github.com/code/graphics/openxr.cpp:530:42: warning: unused parameter 'scale' [-Wunused-parameter]
  530 | float openxr_preinit(float req_ar, float scale) {
      |                                          ^
3 warnings generated.
[725/1325] Building CXX object code/CMakeFiles/code.dir/graphics/opengl/gropenglopenxr.cpp.o
/work/fso_android/fs2open.github.com/code/graphics/opengl/gropenglopenxr.cpp:486:74: warning: unused parameter 'allowed' [-Wunused-parameter]
  486 | int64_t gr_opengl_openxr_get_swapchain_format(const SCP_vector<int64_t>& allowed) { return 0; }
      |                                                                          ^
1 warning generated.
```