### PR TITLE
fix jump in chase view

### DIFF
--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1459,6 +1459,8 @@ void player_level_init()
 	memset(&(Player->ci), 0, sizeof(control_info) );		// set the controls to 0
 
 	Viewer_slew_angles.p = 0.0f;	Viewer_slew_angles.b = 0.0f;	Viewer_slew_angles.h = 0.0f;
+	reset_angles(&chase_slew_angles);
+	reset_angles(&Viewer_slew_angles_delta);
 	Viewer_external_info.angles.p = 0.0f;
 	Viewer_external_info.angles.b = 0.0f;
 	Viewer_external_info.angles.h = 0.0f;
@@ -1477,7 +1479,10 @@ void player_level_init()
 	{
 		Viewer_mode = 0;
 	}
- 
+
+	Perspective_locked = false;
+	Slew_locked = false;
+
 	Player_obj = NULL;
 	Player_ship = NULL;
 	Player_ai = NULL;


### PR DESCRIPTION
Chase view deltas are not reset on mission init, so ensure they are reset to prevent the viewing jumps that can be seen at the start of mission in chase view. Also ensure perspective and slew lock are properly resotred.