### PR TITLE
refactor firing point patterns into a FirepointState class shared between primaries and secondaries

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6797,7 +6797,13 @@ bool check_los(int objnum, int target_objnum, float threshold, int primary_bank,
 		weapon_info *wip = &Weapon_info[is_primary ? swp->primary_bank_weapons[primary_bank] : swp->secondary_bank_weapons[secondary_bank]];
 		polymodel* pm = model_get(sip->model_num);
 
-		vec3d pnt = is_primary ? pm->gun_banks[primary_bank].pnt[swp->primary_next_slot[primary_bank]] : pm->missile_banks[secondary_bank].pnt[swp->secondary_next_slot[secondary_bank]];
+		// use the firing point that will fire next
+		FiringPattern firing_pattern = ship_get_firing_pattern(sip, swp, wip, is_primary ? primary_bank : secondary_bank);
+		auto ship_bank = is_primary ? &pm->gun_banks[primary_bank] : &pm->missile_banks[secondary_bank];
+		int slot = is_primary
+			? swp->primary_firepoint_state[primary_bank].peek(firing_pattern, 0, ship_bank->num_slots)
+			: swp->secondary_firepoint_state[secondary_bank].peek(firing_pattern, 0, ship_bank->num_slots);
+		vec3d pnt = ship_bank->pnt[slot];
 		vec3d firing_point;
 
 		// external model firing points only apply when the external models are actually drawn
@@ -6810,8 +6816,6 @@ bool check_los(int objnum, int target_objnum, float threshold, int primary_bank,
 
 		// use the same firing point the next shot will use
 		auto ext = is_primary ? &swp->primary_bank_external_weapon[primary_bank] : &swp->secondary_bank_external_weapon[secondary_bank];
-		auto ship_bank = is_primary ? &pm->gun_banks[primary_bank] : &pm->missile_banks[secondary_bank];
-		int slot = is_primary ? swp->primary_next_slot[primary_bank] : swp->secondary_next_slot[secondary_bank];
 		vec3d external_fp_offset = ship_get_external_model_fp_offset(ext, wip, weapon_model, ship_bank, slot, false);
 		vm_vec_add2(&pnt, &external_fp_offset);
 

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -447,10 +447,6 @@ void HudGaugeReticle::getFirepointStatus() {
 					// use this bank's pattern, not the current bank's (the old code got this wrong under dynamic linking)
 					FiringPattern firing_pattern = ship_get_firing_pattern(sip, swp, wip, i);
 
-					// fighter beams with +BeamShots predate firing patterns and always cycle forward through the points
-					if (!sip->flags[Ship::Info_Flags::Dyn_primary_linking] && wip->wi_flags[Weapon::Info_Flags::Beam] && wip->b_info.beam_shots)
-						firing_pattern = FiringPattern::CYCLE_FORWARD;
-
 					int shot_count = ship_get_firepoint_counts(sip, swp, wip, firing_pattern, i, num_points).shot_count;
 
 					for (int j = 0; j < num_points; j++) {

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -441,63 +441,27 @@ void HudGaugeReticle::getFirepointStatus() {
 						bankactive = 1;
 					}
 
-					int num_slots = pm->gun_banks[i].num_slots;
-					int point_count = 0;
-					FiringPattern firing_pattern;
-					if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
-						firing_pattern = sip->dyn_firing_patterns_allowed[shipp->weapons.current_primary_bank][swp->dynamic_firing_pattern[shipp->weapons.current_primary_bank]];
-					} else {
-						firing_pattern = Weapon_info[swp->primary_bank_weapons[i]].firing_pattern;
-					}
+					int num_points = pm->gun_banks[i].num_slots;
+					weapon_info *wip = &Weapon_info[swp->primary_bank_weapons[i]];
 
-					if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
-						point_count = MIN(num_slots, swp->primary_bank_slot_count[shipp->weapons.current_primary_bank] );
-					} else if (firing_pattern != FiringPattern::STANDARD) {
-						point_count = MIN(num_slots, Weapon_info[swp->primary_bank_weapons[i]].shots);
-					} else {
-						point_count = num_slots;
-					}
-					
-					for (int j = 0; j < num_slots; j++) {
+					// use this bank's pattern, not the current bank's (the old code got this wrong under dynamic linking)
+					FiringPattern firing_pattern = ship_get_firing_pattern(sip, swp, wip, i);
+
+					// fighter beams with +BeamShots predate firing patterns and always cycle forward through the points
+					if (!sip->flags[Ship::Info_Flags::Dyn_primary_linking] && wip->wi_flags[Weapon::Info_Flags::Beam] && wip->b_info.beam_shots)
+						firing_pattern = FiringPattern::CYCLE_FORWARD;
+
+					int shot_count = ship_get_firepoint_counts(sip, swp, wip, firing_pattern, i, num_points).shot_count;
+
+					for (int j = 0; j < num_points; j++) {
 						int fpactive = bankactive;
 
 						fpactive--;
 
-						for (int q = 0; q < point_count; q++) {
-							// If this firepoint is not among the next shot(s) to be fired, dim it one step
-							switch (firing_pattern) {
-								case FiringPattern::CYCLE_FORWARD: {
-								if (j == (swp->primary_firepoint_next_to_fire_index[i] + q) % num_slots) {
-										fpactive++;
-									}
-									break;
-								}
-								case FiringPattern::CYCLE_REVERSE: {
-									if (j == ((swp->primary_firepoint_next_to_fire_index[i] - (q + 1)) % num_slots + num_slots) % num_slots) {
-										fpactive++;
-									}
-									break;
-								}
-								case FiringPattern::RANDOM_EXHAUSTIVE: {
-									if (j == swp->primary_firepoint_indices[i][(swp->primary_firepoint_next_to_fire_index[i] + q) % num_slots]) {
-										fpactive++;
-									}
-									break;
-								}
-								case FiringPattern::RANDOM_NONREPEATING:
-								case FiringPattern::RANDOM_REPEATING: {
-									if (j == swp->primary_firepoint_indices[i][q]) {
-										fpactive++;
-									}
-									break;
-								}
-								default:
-								case FiringPattern::STANDARD: {
-									fpactive++;
-									break;
-								}
-							}
-							if (fpactive == bankactive) {
+						// If this firepoint is not among the next shot(s) to be fired, dim it one step
+						for (int q = 0; q < shot_count; q++) {
+							if (j == swp->primary_firepoint_state[i].peek(firing_pattern, q, num_points)) {
+								fpactive++;
 								break;
 							}
 						}

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7938,6 +7938,14 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 				auto weapon_pm = model_get(display_model_num);
 				num_secondaries_rendered = 0;
 
+				// figure out which points will fire next so they can be highlighted
+				int next_shot_count = 0;
+				FiringPattern firing_pattern = FiringPattern::ALL_AT_ONCE;
+				if (swp->current_secondary_bank == i) {
+					firing_pattern = ship_get_firing_pattern(sip, swp, wip, i);
+					next_shot_count = ship_get_secondary_firepoint_counts(sp, i, bank->num_slots).shot_count;
+				}
+
 				for(k = 0; k < bank->num_slots; k++)
 				{
 					if (num_secondaries_rendered >= sp->weapons.secondary_bank_ammo[i])
@@ -7949,7 +7957,15 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 
 					model_render_params weapon_render_info;
 
-					if ( swp->current_secondary_bank == i && ( swp->secondary_next_slot[i] == k || ( swp->secondary_next_slot[i]+1 == k && sp->flags[Ship::Ship_Flags::Secondary_dual_fire] && ship_secondary_bank_can_dual_fire(sp, i) ) ) ) {
+					bool fires_next = false;
+					for (int q = 0; q < next_shot_count; q++) {
+						if (swp->secondary_firepoint_state[i].peek(firing_pattern, q, bank->num_slots) == k) {
+							fires_next = true;
+							break;
+						}
+					}
+
+					if (fires_next) {
 						weapon_render_info.set_color(Color_bright_blue);
 					} else {
 						weapon_render_info.set_color(Color_bright_white);

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1840,7 +1840,7 @@ int button_function_critical(int n, net_player *p = NULL)
 					polymodel *pm = model_get( sip->model_num );
 					count = (int)ftables.getNext( pm->gun_banks[ swp->current_primary_bank ].num_slots, swp->primary_bank_slot_count[ swp->current_primary_bank ] );
 					swp->primary_bank_slot_count[ swp->current_primary_bank ] = count;
-					swp->primary_firepoint_next_to_fire_index[swp->current_primary_bank] = 0;
+					swp->primary_firepoint_state[swp->current_primary_bank].restart();
 				}
 			}
 			break;
@@ -1852,7 +1852,7 @@ int button_function_critical(int n, net_player *p = NULL)
 				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
 					int new_pattern = (swp->dynamic_firing_pattern[swp->current_primary_bank] + 1) % (sip->dyn_firing_patterns_allowed[swp->current_primary_bank].size());
 					swp->dynamic_firing_pattern[swp->current_primary_bank] = new_pattern;
-					swp->primary_firepoint_next_to_fire_index[swp->current_primary_bank] = 0;
+					swp->primary_firepoint_state[swp->current_primary_bank].restart();
 				}
 			} break;
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -740,7 +740,8 @@ ADE_VIRTVAR(SecondaryBanks, l_Ship, "weaponbanktype", "Array of secondary weapon
 		memcpy(dst->secondary_bank_rearm_time, src->secondary_bank_rearm_time, sizeof(dst->secondary_bank_rearm_time));
 		memcpy(dst->secondary_bank_start_ammo, src->secondary_bank_start_ammo, sizeof(dst->secondary_bank_start_ammo));
 		memcpy(dst->secondary_bank_weapons, src->secondary_bank_weapons, sizeof(dst->secondary_bank_weapons));
-		memcpy(dst->secondary_next_slot, src->secondary_next_slot, sizeof(dst->secondary_next_slot));
+		for (int bank_i = 0; bank_i < MAX_SHIP_SECONDARY_BANKS; bank_i++)
+			dst->secondary_firepoint_state[bank_i] = src->secondary_firepoint_state[bank_i];
 	}
 
 	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(objh->objp(), dst, SWH_SECONDARY)));

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -501,7 +501,8 @@ ADE_VIRTVAR(SecondaryBanks, l_Subsystem, "weaponbanktype", "Array of secondary w
 		memcpy(dst->secondary_bank_rearm_time, src->secondary_bank_rearm_time, sizeof(dst->secondary_bank_rearm_time));
 		memcpy(dst->secondary_bank_start_ammo, src->secondary_bank_start_ammo, sizeof(dst->secondary_bank_start_ammo));
 		memcpy(dst->secondary_bank_weapons, src->secondary_bank_weapons, sizeof(dst->secondary_bank_weapons));
-		memcpy(dst->secondary_next_slot, src->secondary_next_slot, sizeof(dst->secondary_next_slot));
+		for (int bank_i = 0; bank_i < MAX_SHIP_SECONDARY_BANKS; bank_i++)
+			dst->secondary_firepoint_state[bank_i] = src->secondary_firepoint_state[bank_i];
 	}
 
 	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(sso->objh.objp(), dst, SWH_SECONDARY)));

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -87,10 +87,10 @@
 #include "ship/shiphit.h"
 #include "ship/subsysdamage.h"
 #include "species_defs/species_defs.h"
+#include "parse/encrypt.h"
 #include "tracing/Monitor.h"
 #include "tracing/tracing.h"
 #include "utils/Random.h"
-#include "utils/RandomRange.h"
 #include "utils/string_utils.h"
 #include "weapon/beam.h"
 #include "weapon/corkscrew.h"
@@ -7157,13 +7157,25 @@ void FirepointState::clear()
 {
 	m_indices.clear();
 	m_cursor = 0;
+	m_seed = 0;
+	m_shuffle_count = 0;
 }
 
-// Shuffles a range of the firing point order.  All of the patterns go through here so that there is
-// one place to control how the order is randomized.
+void FirepointState::seed(unsigned int seed)
+{
+	m_seed = seed;
+	m_shuffle_count = 0;
+}
+
+// Shuffles a range of the firing point order.  Each shuffle draws from a fresh static_rand() sequence
+// derived from the seed and the shuffle count, so successive shuffles differ but every machine in a
+// multiplayer game reproduces them exactly.
 void FirepointState::shuffle(SCP_vector<int>::iterator first, SCP_vector<int>::iterator last)
 {
-	std::shuffle(first, last, util::seeder);
+	util::StaticRandGenerator rng(static_rand(static_cast<int>((m_seed + m_shuffle_count) & 0x7fffffffu)));
+	m_shuffle_count++;
+
+	util::deterministic_shuffle(first, last, rng);
 }
 
 void FirepointState::reset(int num_points)
@@ -7274,6 +7286,25 @@ void FirepointState::post_fire(FiringPattern pattern, int shot_count, int num_po
 			// the CYCLE_* patterns need no upkeep
 			break;
 	}
+}
+
+// Derives the seed for a bank's firing point state.  The ship name is used because it is unique
+// per ship and is available at this point on every machine in a multiplayer game, unlike the net
+// signature, which isn't assigned until after ship_create() returns.
+//
+// In multiplayer the seed must be identical on every machine, and static_rand() is already rebuilt
+// per mission from the netgame seed (see game_level_init).  In single player the Semirand table is
+// only built once per session (from ai_init), so a random salt is added to keep the firing orders
+// from repeating when a mission is replayed.
+static unsigned int ship_firepoint_seed(const ship *shipp, int bank, bool is_secondary)
+{
+	unsigned int seed = hash_fnv1a(shipp->ship_name, strlen(shipp->ship_name));
+	seed = hash_fnv1a(seed ^ static_cast<unsigned int>(bank + (is_secondary ? MAX_SHIP_PRIMARY_BANKS : 0)));
+
+	if (!(Game_mode & GM_MULTIPLAYER))
+		seed ^= static_cast<unsigned int>(Random::next());
+
+	return seed;
 }
 
 void ship_weapon::clear()
@@ -11193,6 +11224,7 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 
 		swp->primary_bank_capacity[i] = sip->primary_bank_ammo_capacity[i];
 
+		swp->primary_firepoint_state[i].seed(ship_firepoint_seed(shipp, i, false));
 		swp->primary_firepoint_state[i].reset(pm->gun_banks[i].num_slots);
 	}
 
@@ -11216,6 +11248,7 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 
 		swp->secondary_bank_capacity[i] = sip->secondary_bank_ammo_capacity[i];
 
+		swp->secondary_firepoint_state[i].seed(ship_firepoint_seed(shipp, i, true));
 		swp->secondary_firepoint_state[i].reset(pm->missile_banks[i].num_slots);
 	}
 
@@ -11774,9 +11807,11 @@ static void ship_model_change(int n, int ship_type)
 	sp->base_texture_anim_timestamp = _timestamp();
 
 	for (int bank_i = 0; bank_i < pm->n_guns; bank_i++) {
+		sp->weapons.primary_firepoint_state[bank_i].seed(ship_firepoint_seed(sp, bank_i, false));
 		sp->weapons.primary_firepoint_state[bank_i].reset(pm->gun_banks[bank_i].num_slots);
 	}
 	for (int bank_i = 0; bank_i < pm->n_missiles; bank_i++) {
+		sp->weapons.secondary_firepoint_state[bank_i].seed(ship_firepoint_seed(sp, bank_i, true));
 		sp->weapons.secondary_firepoint_state[bank_i].reset(pm->missile_banks[bank_i].num_slots);
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7310,7 +7310,6 @@ void ship_weapon::clear()
         primary_bank_ammo[i] = 0;
         primary_bank_start_ammo[i] = 0;
         primary_bank_capacity[i] = 0;
-        primary_next_slot[i] = 0;
         primary_bank_fof_cooldown[i] = 0;
 
         primary_animation_position[i] = EModelAnimationPosition::MA_POS_NOT_SET;
@@ -7340,7 +7339,7 @@ void ship_weapon::clear()
         secondary_bank_ammo[i] = 0;
         secondary_bank_start_ammo[i] = 0;
         secondary_bank_capacity[i] = 0;
-        secondary_next_slot[i] = 0;
+        secondary_firepoint_state[i].clear();
 
 		secondary_animation_position[i] = EModelAnimationPosition::MA_POS_NOT_SET;
 
@@ -8151,15 +8150,12 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 			if (Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo])
 			{
 				ship_system->weapons.secondary_bank_ammo[k] = 0;
-				ship_system->weapons.secondary_next_slot[k] = 0;
 				continue;
 			}
 
 			float weapon_size = Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].cargo_size;
 			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].name );
 			ship_system->weapons.secondary_bank_ammo[k] = (Fred_running ? 100 : (int)std::lround(ship_system->weapons.secondary_bank_capacity[k] / weapon_size));
-
-			ship_system->weapons.secondary_next_slot[k] = 0;
 		}
 
 		// Goober5000
@@ -10851,17 +10847,19 @@ void update_reload_percent(ship *shipp, float frametime)
 
 			int points = pm->missile_banks[i].num_slots;
 			int missles_left = shipp->weapons.secondary_bank_ammo[i];
-			int next_point = shipp->weapons.secondary_next_slot[i];
-			float fire_wait = Weapon_info[shipp->weapons.secondary_bank_weapons[i]].fire_wait;
+			auto wip = &Weapon_info[shipp->weapons.secondary_bank_weapons[i]];
+			float fire_wait = wip->fire_wait;
 			float reload_time = (fire_wait == 0.0f) ? 1.0f : 1.0f / fire_wait;
 
 			//ok so...we want to move up missles but only if there is a missle there to be moved up
-			//there is a missle behind next_point, and how ever many missles there are left after that
+			//the missles are considered to be loaded in the points that will fire next
 
 			if (points > missles_left) {
 				//there are more slots than missles left, so not all of the slots will have missles drawn on them
-				for (int k = next_point; k < next_point+missles_left; k ++) {
-					float &s_pct = shipp->secondary_point_reload_pct.get(i, k % points);
+				auto firing_pattern = ship_get_firing_pattern(&Ship_info[shipp->ship_info_index], &shipp->weapons, wip, i);
+				for (int k = 0; k < missles_left; k++) {
+					int pt = shipp->weapons.secondary_firepoint_state[i].peek(firing_pattern, k, points);
+					float &s_pct = shipp->secondary_point_reload_pct.get(i, pt);
 					if (s_pct < 1.0)
 						s_pct += reload_time * frametime;
 					if (s_pct > 1.0)
@@ -11217,6 +11215,8 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 		}
 
 		swp->secondary_bank_capacity[i] = sip->secondary_bank_ammo_capacity[i];
+
+		swp->secondary_firepoint_state[i].reset(pm->missile_banks[i].num_slots);
 	}
 
 	for ( i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++ ){
@@ -11775,6 +11775,9 @@ static void ship_model_change(int n, int ship_type)
 
 	for (int bank_i = 0; bank_i < pm->n_guns; bank_i++) {
 		sp->weapons.primary_firepoint_state[bank_i].reset(pm->gun_banks[bank_i].num_slots);
+	}
+	for (int bank_i = 0; bank_i < pm->n_missiles; bank_i++) {
+		sp->weapons.secondary_firepoint_state[bank_i].reset(pm->missile_banks[bank_i].num_slots);
 	}
 
 	model_delete_instance(sp->model_instance_num);
@@ -12979,7 +12982,8 @@ vec3d ship_get_external_model_fp_offset(external_weapon_state *ext, const weapon
 
 FiringPattern ship_get_firing_pattern(const ship_info *sip, const ship_weapon *swp, const weapon_info *wip, int bank)
 {
-	if (sip->flags[Ship::Info_Flags::Dyn_primary_linking])
+	// dynamic linking is a primary-only feature
+	if (wip->is_primary() && sip->flags[Ship::Info_Flags::Dyn_primary_linking])
 		return sip->dyn_firing_patterns_allowed[bank][swp->dynamic_firing_pattern[bank]];
 
 	return wip->firing_pattern;
@@ -12992,7 +12996,7 @@ FirepointCounts ship_get_firepoint_counts(const ship_info *sip, const ship_weapo
 	// for cycling patterns, $Shots: is the number of points to fire from at a time and $Cycle Multishot: is
 	// the number of projectiles per point; for ALL_AT_ONCE, every point fires and $Shots: is the number of
 	// projectiles per point (used mostly for the 'shotgun' effect)
-	if (sip->flags[Ship::Info_Flags::Dyn_primary_linking])
+	if (wip->is_primary() && sip->flags[Ship::Info_Flags::Dyn_primary_linking])
 	{
 		counts.shot_count = MIN(num_points, swp->primary_bank_slot_count[bank]);
 		counts.multishot_count = fl2i(i2fl(wip->cycle_multishot) * multishot_curve_mult);
@@ -13012,6 +13016,22 @@ FirepointCounts ship_get_firepoint_counts(const ship_info *sip, const ship_weapo
 		counts.shot_count = num_points;
 		counts.multishot_count = fl2i(i2fl(wip->shots) * multishot_curve_mult);
 	}
+
+	return counts;
+}
+
+FirepointCounts ship_get_secondary_firepoint_counts(const ship *shipp, int bank, int num_points)
+{
+	auto sip = &Ship_info[shipp->ship_info_index];
+	auto swp = &shipp->weapons;
+	auto wip = &Weapon_info[swp->secondary_bank_weapons[bank]];
+
+	auto counts = ship_get_firepoint_counts(sip, swp, wip, ship_get_firing_pattern(sip, swp, wip, bank), bank, num_points);
+
+	// dual fire launches twice as many missiles per volley.  Since the flag is ignored rather than
+	// cleared for banks that can't use it, the capability check is essential here.
+	if (shipp->flags[Ship::Ship_Flags::Secondary_dual_fire] && ship_secondary_bank_can_dual_fire(shipp, bank))
+		counts.shot_count = MIN(num_points, counts.shot_count * 2);
 
 	return counts;
 }
@@ -14047,7 +14067,7 @@ bool ship_secondary_bank_can_dual_fire(const ship *shipp, int bank)
 //                need to avoid firing when normally called
 int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 {
-	int			n, weapon_idx, j, bank, bank_adjusted, num_fired;
+	int			n, weapon_idx, fired_weapon_idx, bank, bank_adjusted, num_fired;
 	ushort		starting_sig = 0;
 	ship			*shipp;
 	ship_weapon *swp;
@@ -14132,6 +14152,10 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 	}
 
 	weapon_idx = swp->secondary_bank_weapons[bank];
+
+	// this tracks the class of the weapon that was most recently created, which can differ from the bank's
+	// class if the weapon substitutes; it is used for the effects and sounds that follow the actual shot
+	fired_weapon_idx = weapon_idx;
 
 	// It's possible for banks to be empty without issue
 	// but indices outside the weapon_info range are a problem
@@ -14402,154 +14426,160 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 			goto done_secondary;
 		}
 
-		int start_slot, end_slot;
-		no_energy = shipp->weapon_energy < 2 * wip->energy_consumed; // whether there's enough energy for at least 1 shot was checked above
-
 		// Dual fire can be unavailable for this bank because it has only one firepoint, because
 		// the weapon disallows it, or because of an ai_profiles restriction.  In any of these
 		// cases the flag is ignored rather than cleared so the dual fire preference isn't lost
-		// when cycling through banks or weapons.
-		if ( shipp->flags[Ship_Flags::Secondary_dual_fire] && ship_secondary_bank_can_dual_fire(shipp, bank) ) {
-			start_slot = swp->secondary_next_slot[bank];
-			// AL 11-19-97: Ensure enough ammo remains when firing linked secondary weapons
-			if ( check_ammo && ((swp->secondary_bank_ammo[bank] < 2 && !no_ammo_needed) || no_energy) ) {
-				end_slot = start_slot;
+		// when cycling through banks or weapons.  The counts helper takes all of this into account.
+		FiringPattern firing_pattern = ship_get_firing_pattern(sip, swp, wip, bank);
+		auto [shot_count, multishot_count] = ship_get_secondary_firepoint_counts(shipp, bank, num_slots);
+
+		// Note: unlike primaries, secondaries do not scale their fire wait by the number of firing points
+		// when using a cycling pattern, because cycling is the retail behavior for secondaries.
+
+		// AL 11-19-97: Ensure enough ammo (and energy) remains when firing linked secondary weapons.
+		// Fire as many projectiles as we can afford, but at least one, since that much was checked above.
+		// (A shot or multishot count of zero fires nothing, so there is nothing to clamp in that case.)
+		if ( check_ammo && shot_count > 0 && multishot_count > 0 ) {
+			int affordable = INT_MAX;
+			if ( !no_ammo_needed )
+				affordable = MIN(affordable, swp->secondary_bank_ammo[bank]);
+			if ( wip->energy_consumed > 0.0f )
+				affordable = MIN(affordable, fl2i(shipp->weapon_energy / wip->energy_consumed));
+			affordable = MAX(affordable, 1);
+
+			// shot_count * multishot_count must not exceed what we can afford, so if a single
+			// shot's worth of projectiles is already too many, fire one shot with fewer projectiles
+			if ( multishot_count > affordable ) {
+				multishot_count = affordable;
+				shot_count = 1;
 			} else {
-				end_slot = start_slot+1;
+				shot_count = MIN(shot_count, affordable / multishot_count);
 			}
-		} else {
-			start_slot = swp->secondary_next_slot[bank];
-			end_slot = start_slot;
 		}
 
-		int pnt_index=start_slot;
-		//If this is a tertiary weapon, only subtract one piece of ammo
-		for ( j = start_slot; j <= end_slot; j++ ) {
-			int	weapon_num;
+		for ( int shot_index = 0; shot_index < shot_count; shot_index++ ) {
+			int pt = swp->secondary_firepoint_state[bank].next(firing_pattern, shot_index, num_slots);
 
-			swp->secondary_next_slot[bank]++;
-			if ( swp->secondary_next_slot[bank] > (num_slots-1) ){
-				swp->secondary_next_slot[bank] = 0;
-			}
+			shipp->secondary_point_reload_pct.set(bank, pt, 0.0f);
+			vec3d dir = pm->missile_banks[bank].norm[pt];
 
-			if ( pnt_index >= num_slots ){
-				pnt_index = 0;
-			}
-			shipp->secondary_point_reload_pct.set(bank, pnt_index, 0.0f);
-			pnt = pm->missile_banks[bank].pnt[pnt_index];
-			vec3d dir;
-			dir = pm->missile_banks[bank].norm[pnt_index];
+			for ( int multishot_index = 0; multishot_index < multishot_count; multishot_index++ ) {
+				int	weapon_num;
 
-			// external model firing points only apply when the external models are actually drawn
-			// (matching the primary bank behavior in ship_fire_primary)
-			polymodel *weapon_model = nullptr;
-			if(sip->draw_secondary_models[bank] && wip->external_model_num >= 0){
-				weapon_model = model_get(wip->external_model_num);
-			}
+				pnt = pm->missile_banks[bank].pnt[pt];
 
-			// chained weapons cycle through the external model's firing points; other weapons use the 0 index slot
-			vec3d external_fp_offset = ship_get_external_model_fp_offset(&swp->secondary_bank_external_weapon[bank], wip, weapon_model, &pm->missile_banks[bank], pnt_index, true);
-			vm_vec_add2(&pnt, &external_fp_offset);
-			pnt_index++;
-			vm_vec_unrotate(&missile_point, &pnt, &obj->orient);
-			vm_vec_add(&firing_pos, &missile_point, &obj->pos);
-
-			if ( Game_mode & GM_MULTIPLAYER ) {
-				Assert( Weapon_info[weapon_idx].subtype == WP_MISSILE );
-			}
-
-			matrix firing_orient;
-			if (obj == Player_obj && sip->aims_at_flight_cursor_secondary)
-			{
-				vm_angles_2_matrix(&firing_orient, &Player_flight_cursor);
-				firing_orient = firing_orient * obj->orient;
-			} 
-			else if(!(sip->flags[Ship::Info_Flags::Gun_convergence]))
-			{
-				firing_orient = obj->orient;
-			}
-			else
-			{
-				vec3d firing_vec;
-				vm_vec_unrotate(&firing_vec, &pm->missile_banks[bank].norm[pnt_index-1], &obj->orient);
-				vm_vector_2_matrix_norm(&firing_orient, &firing_vec, &obj->orient.vec.uvec, &obj->orient.vec.rvec);
-			}
-
-			// create the weapon -- for multiplayer, the net_signature is assigned inside
-			// of weapon_create
-			weapon_num = weapon_create( &firing_pos, &firing_orient, weapon_idx, OBJ_INDEX(obj), -1, tinfo.locked, false, swp, -1, bank, launch_curve_data);
-
-			if (weapon_num == -1) {
-				// Weapon most likely failed to fire
-				if (obj == Player_obj) {
-					ship_maybe_do_secondary_fail_sound_hud(wip, false);
-				}
-				continue;
-			}
-
-			if (weapon_num >= 0) {
-				weapon_idx = Weapons[Objects[weapon_num].instance].weapon_info_index;
-				weapon_set_tracking_info(weapon_num, OBJ_INDEX(obj), tinfo);
-				has_fired = true;
-
-				// create the muzzle flash effect
-				shipfx_flash_create(obj, sip->model_num, &pnt, &dir, 0, weapon_idx, weapon_num);
-
-				if((wip->wi_flags[Weapon::Info_Flags::Shudder]) && (obj == Player_obj) && !(Game_mode & GM_STANDALONE_SERVER)){
-					// calculate some arbitrary value between 100
-					// (mass * velocity) / 10
-					game_shudder_apply(500, (wip->mass * wip->max_speed) * 0.1f * sip->ship_shudder_modifier * wip->shudder_modifier);
+				// external model firing points only apply when the external models are actually drawn
+				// (matching the primary bank behavior in ship_fire_primary)
+				polymodel *weapon_model = nullptr;
+				if(sip->draw_secondary_models[bank] && wip->external_model_num >= 0){
+					weapon_model = model_get(wip->external_model_num);
 				}
 
-				num_fired++;
-				swp->detonate_weapon_time = timestamp((int)(DEFAULT_REMOTE_DETONATE_TRIGGER_WAIT * 1000));;		//	Can detonate 1/2 second later.
-				if (Weapon_info[weapon_idx].wi_flags[Weapon::Info_Flags::Remote])
-					swp->remote_detonaters_active++;
+				// chained weapons cycle through the external model's firing points; other weapons use the 0 index slot
+				vec3d external_fp_offset = ship_get_external_model_fp_offset(&swp->secondary_bank_external_weapon[bank], wip, weapon_model, &pm->missile_banks[bank], pt, true);
+				vm_vec_add2(&pnt, &external_fp_offset);
+				vm_vec_unrotate(&missile_point, &pnt, &obj->orient);
+				vm_vec_add(&firing_pos, &missile_point, &obj->pos);
 
-				// possibly add this to the rollback vector
-				if ((Game_mode & (GM_MULTIPLAYER | GM_STANDALONE_SERVER)) && rollback_shot){
-					multi_ship_record_add_rollback_wep(weapon_num);
+				if ( Game_mode & GM_MULTIPLAYER ) {
+					Assert( Weapon_info[weapon_idx].subtype == WP_MISSILE );
 				}
 
-				// subtract the number of missiles fired
-				if ( !Weapon_energy_cheat ){
-					if(!Weapon_info[swp->secondary_bank_weapons[bank]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo])
-						swp->secondary_bank_ammo[bank]--;
-
-					shipp->weapon_energy -= wip->energy_consumed;
+				matrix firing_orient;
+				if (obj == Player_obj && sip->aims_at_flight_cursor_secondary)
+				{
+					vm_angles_2_matrix(&firing_orient, &Player_flight_cursor);
+					firing_orient = firing_orient * obj->orient;
+				} 
+				else if(!(sip->flags[Ship::Info_Flags::Gun_convergence]))
+				{
+					firing_orient = obj->orient;
+				}
+				else
+				{
+					vec3d firing_vec;
+					vm_vec_unrotate(&firing_vec, &dir, &obj->orient);
+					vm_vector_2_matrix_norm(&firing_orient, &firing_vec, &obj->orient.vec.uvec, &obj->orient.vec.rvec);
 				}
 
-				if (wip->wi_flags[Weapon::Info_Flags::Apply_Recoil]) {
-					float recoil_force = (wip->mass * wip->max_speed * wip->recoil_modifier * sip->ship_recoil_modifier);
+				// create the weapon -- for multiplayer, the net_signature is assigned inside
+				// of weapon_create
+				weapon_num = weapon_create( &firing_pos, &firing_orient, weapon_idx, OBJ_INDEX(obj), -1, tinfo.locked, false, swp, -1, bank, launch_curve_data);
 
-					vec3d impulse = firing_orient.vec.fvec * -recoil_force;
+				if (weapon_num == -1) {
+					// Weapon most likely failed to fire
+					if (obj == Player_obj) {
+						ship_maybe_do_secondary_fail_sound_hud(wip, false);
+					}
+					continue;
+				}
 
-					ship_apply_whack(&impulse, &firing_pos, obj);
+				if (weapon_num >= 0) {
+					// note that this is the class that was actually created, which can differ from the bank's
+					// class via $Substitute:; weapon_idx itself must not change, or the next shot in this volley
+					// would have its substitution resolved from the substituted class rather than the bank's
+					fired_weapon_idx = Weapons[Objects[weapon_num].instance].weapon_info_index;
+					weapon_set_tracking_info(weapon_num, OBJ_INDEX(obj), tinfo);
+					has_fired = true;
+
+					// create the muzzle flash effect
+					shipfx_flash_create(obj, sip->model_num, &pnt, &dir, 0, fired_weapon_idx, weapon_num);
+
+					if((wip->wi_flags[Weapon::Info_Flags::Shudder]) && (obj == Player_obj) && !(Game_mode & GM_STANDALONE_SERVER)){
+						// calculate some arbitrary value between 100
+						// (mass * velocity) / 10
+						game_shudder_apply(500, (wip->mass * wip->max_speed) * 0.1f * sip->ship_shudder_modifier * wip->shudder_modifier);
+					}
+
+					num_fired++;
+					swp->detonate_weapon_time = timestamp((int)(DEFAULT_REMOTE_DETONATE_TRIGGER_WAIT * 1000));;		//	Can detonate 1/2 second later.
+					if (Weapon_info[fired_weapon_idx].wi_flags[Weapon::Info_Flags::Remote])
+						swp->remote_detonaters_active++;
+
+					// possibly add this to the rollback vector
+					if ((Game_mode & (GM_MULTIPLAYER | GM_STANDALONE_SERVER)) && rollback_shot){
+						multi_ship_record_add_rollback_wep(weapon_num);
+					}
+
+					// subtract the number of missiles fired
+					if ( !Weapon_energy_cheat ){
+						if(!Weapon_info[swp->secondary_bank_weapons[bank]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo])
+							swp->secondary_bank_ammo[bank]--;
+
+						shipp->weapon_energy -= wip->energy_consumed;
+					}
+
+					if (wip->wi_flags[Weapon::Info_Flags::Apply_Recoil]) {
+						float recoil_force = (wip->mass * wip->max_speed * wip->recoil_modifier * sip->ship_recoil_modifier);
+
+						vec3d impulse = firing_orient.vec.fvec * -recoil_force;
+
+						ship_apply_whack(&impulse, &firing_pos, obj);
+					}
 				}
 			}
 		}
+
+		swp->secondary_firepoint_state[bank].post_fire(firing_pattern, shot_count, num_slots);
 	}
 
 	if ( obj == Player_obj ) {
-		if ( Weapon_info[weapon_idx].cockpit_launch_snd.isValid() ) {
-			snd_play( gamesnd_get_game_sound(Weapon_info[weapon_idx].cockpit_launch_snd), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY );
-		} else if (Weapon_info[weapon_idx].launch_snd.isValid()) {
-			snd_play(gamesnd_get_game_sound(Weapon_info[weapon_idx].launch_snd), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
+		if ( Weapon_info[fired_weapon_idx].cockpit_launch_snd.isValid() ) {
+			snd_play( gamesnd_get_game_sound(Weapon_info[fired_weapon_idx].cockpit_launch_snd), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY );
+		} else if (Weapon_info[fired_weapon_idx].launch_snd.isValid()) {
+			snd_play(gamesnd_get_game_sound(Weapon_info[fired_weapon_idx].launch_snd), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
 		}
 
 		swp = &Player_ship->weapons;
 		if (bank >= 0) {
 			wip = &Weapon_info[swp->secondary_bank_weapons[bank]];
-			if (Player_ship->flags[Ship_Flags::Secondary_dual_fire] && ship_secondary_bank_can_dual_fire(Player_ship, bank)){
-				joy_ff_play_secondary_shoot((int) (wip->cargo_size * 2.0f));
-			} else {
-				joy_ff_play_secondary_shoot((int) wip->cargo_size);
-			}
+			// scale the force feedback by the number of missiles actually launched
+			joy_ff_play_secondary_shoot((int) (wip->cargo_size * MAX(num_fired, 1)));
 		}
 
 	} else {
-		if ( Weapon_info[weapon_idx].launch_snd.isValid() ) {
-			snd_play_3d( gamesnd_get_game_sound(Weapon_info[weapon_idx].launch_snd), &obj->pos, &View_position );
+		if ( Weapon_info[fired_weapon_idx].launch_snd.isValid() ) {
+			snd_play_3d( gamesnd_get_game_sound(Weapon_info[fired_weapon_idx].launch_snd), &obj->pos, &View_position );
 		}
 	}
 
@@ -14587,7 +14617,7 @@ done_secondary:
 		}
 	
 		// maybe announce a shockwave weapon
-		ai_maybe_announce_shockwave_weapon(obj, weapon_idx);
+		ai_maybe_announce_shockwave_weapon(obj, fired_weapon_idx);
 	}
 
 	// if we are out of ammo in this bank then don't carry over firing swarm/corkscrew
@@ -14625,7 +14655,7 @@ done_secondary:
 				scripting::hook_param("User", 'o', objp),
 				scripting::hook_param("Target", 'o', target)
 			);
-			auto conditions = scripting::hooks::WeaponUsedConditions{ shipp, target, SCP_vector<int>{ weapon_idx }, false };
+			auto conditions = scripting::hooks::WeaponUsedConditions{ shipp, target, SCP_vector<int>{ fired_weapon_idx }, false };
 			scripting::hooks::OnWeaponFired->run(conditions, param_list);
 			scripting::hooks::OnSecondaryFired->run(std::move(conditions), std::move(param_list));
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10,6 +10,7 @@
 
 #include <csetjmp>
 #include <algorithm>
+#include <memory>
 
 #include "ai/aibig.h"
 #include "ai/aigoals.h"
@@ -13623,32 +13624,33 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				// Mark all these weapons as in the same group
 				int new_group_id = weapon_create_group_id();
 
-				vec3d total_impulse;
-				vec3d *firepoint_list;
-				size_t current_firepoint = 0;
-
-				if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){
-					firepoint_list = new vec3d[shot_count * multishot_count];
-					vm_vec_zero(&total_impulse);
-				} else {
-					firepoint_list = nullptr;
-				}
-
 				// external model firing points only apply when the external models are actually drawn
 				polymodel *weapon_model = nullptr;
 				if (sip->draw_primary_models[bank_to_fire] && (winfo_p->external_model_num >= 0))
 					weapon_model = model_get(winfo_p->external_model_num);
 
+				// weapons that don't chain their external model firing points fire from all of them at once
+				// (note that external model firing points always come from the model's first gun bank)
+				int sub_shots = 1;
+				if (weapon_model && weapon_model->n_guns && !(winfo_p->wi_flags[Weapon::Info_Flags::External_weapon_fp]))
+					sub_shots = weapon_model->gun_banks[0].num_slots;
+
+				// whether the bank applies recoil is a property of the bank's own weapon, so check that here before we do any substitution
+				bool apply_recoil = winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil];
+
+				vec3d total_impulse;
+				std::unique_ptr<vec3d[]> firepoint_list;
+				size_t current_firepoint = 0;
+
+				if (apply_recoil){
+					firepoint_list = std::make_unique<vec3d[]>(shot_count * multishot_count * sub_shots);
+					vm_vec_zero(&total_impulse);
+				}
+
 				for (int shot_index = 0; shot_index < shot_count; shot_index++) {
 					int pt = swp->primary_firepoint_state[bank_to_fire].next(firing_pattern, shot_index, num_slots);
 
 					for (int j = 0; j < multishot_count; j++) {
-						int sub_shots = 1;
-						// weapons that don't chain their external model firing points fire from all of them at once
-						// (note that external model firing points always come from the model's first gun bank)
-						if (weapon_model && weapon_model->n_guns && !(winfo_p->wi_flags[Weapon::Info_Flags::External_weapon_fp]))
-							sub_shots = weapon_model->gun_banks[0].num_slots;
-
 						for(int s = 0; s<sub_shots; s++){
 							pnt = pm->gun_banks[bank_to_fire].pnt[pt];
 							vec3d dir;
@@ -13715,7 +13717,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, &obj->orient.vec.uvec, &obj->orient.vec.rvec);
 							}
 
-							if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){	// Function to add recoil functionality - DahBlount
+							if (apply_recoil){	// Function to add recoil functionality - DahBlount
 								vec3d local_impulse = firing_orient.vec.fvec;
 
 								float recoil_force = (winfo_p->mass * winfo_p->max_speed * winfo_p->recoil_modifier * sip->ship_recoil_modifier);
@@ -13796,13 +13798,13 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 				swp->primary_firepoint_state[bank_to_fire].post_fire(firing_pattern, shot_count, num_slots);
 
-				if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){
-					vec3d avg_firepoint;
-
-					vm_vec_avg_n(&avg_firepoint, (int)current_firepoint, firepoint_list);
-
-					ship_apply_whack(&total_impulse, &avg_firepoint, obj);
-					delete[] firepoint_list;
+				if (apply_recoil){
+					// a bank that fired nothing has no firepoints to average
+					if (current_firepoint > 0) {
+						vec3d avg_firepoint;
+						vm_vec_avg_n(&avg_firepoint, sz2i(current_firepoint), firepoint_list.get());
+						ship_apply_whack(&total_impulse, &avg_firepoint, obj);
+					}
 				}
 			}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13021,6 +13021,10 @@ FiringPattern ship_get_firing_pattern(const ship_info *sip, const ship_weapon *s
 	if (wip->is_primary() && sip->flags[Ship::Info_Flags::Dyn_primary_linking])
 		return sip->dyn_firing_patterns_allowed[bank][swp->dynamic_firing_pattern[bank]];
 
+	// fighter beams without a tabled pattern always cycle forward, as they did before firing patterns existed
+	if (wip->uses_legacy_fighter_beam_firing())
+		return FiringPattern::CYCLE_FORWARD;
+
 	return wip->firing_pattern;
 }
 
@@ -13030,16 +13034,24 @@ FirepointCounts ship_get_firepoint_counts(const ship_info *sip, const ship_weapo
 
 	// for cycling patterns, $Shots: is the number of points to fire from at a time and $Cycle Multishot: is
 	// the number of projectiles per point; for ALL_AT_ONCE, every point fires and $Shots: is the number of
-	// projectiles per point (used mostly for the 'shotgun' effect)
+	// projectiles per point (used mostly for the 'shotgun' effect).  Fighter beams without a tabled pattern
+	// use their own legacy mapping: the beam's +Shots: is the number of points and $Shots: is the number of
+	// beams per point.  Secondaries without a tabled pattern keep their retail behavior of one missile from
+	// one point, since $Shots: already governs how many missiles the same weapon fires from a turret.
 	if (wip->is_primary() && sip->flags[Ship::Info_Flags::Dyn_primary_linking])
 	{
 		counts.shot_count = MIN(num_points, swp->primary_bank_slot_count[bank]);
 		counts.multishot_count = fl2i(i2fl(wip->cycle_multishot) * multishot_curve_mult);
 	}
-	else if (wip->wi_flags[Weapon::Info_Flags::Beam] && wip->b_info.beam_shots)
+	else if (wip->uses_legacy_fighter_beam_firing())
 	{
 		counts.shot_count = MIN(wip->b_info.beam_shots, num_points);
 		counts.multishot_count = fl2i(i2fl(wip->shots) * multishot_curve_mult);
+	}
+	else if (wip->uses_legacy_secondary_firing())
+	{
+		counts.shot_count = 1;
+		counts.multishot_count = 1;
 	}
 	else if (pattern != FiringPattern::ALL_AT_ONCE)
 	{
@@ -13463,10 +13475,6 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			if(winfo_p->wi_flags[Weapon::Info_Flags::Beam]){		// the big change I made for fighter beams, if there beams fill out the Fire_Info for a targeting laser then fire it, for each point in the weapon bank -Bobboau				
 
 				FiringPattern firing_pattern = ship_get_firing_pattern(sip, swp, winfo_p, bank_to_fire);
-
-				// fighter beams with +BeamShots predate firing patterns and always cycle forward through the points
-				if (!sip->flags[Ship::Info_Flags::Dyn_primary_linking] && winfo_p->b_info.beam_shots)
-					firing_pattern = FiringPattern::CYCLE_FORWARD;
 
 				float multishot_curve_mult = winfo_p->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::SHOTS_MULT, launch_curve_data);
 				auto [shot_count, multishot_count] = ship_get_firepoint_counts(sip, swp, winfo_p, firing_pattern, bank_to_fire, num_slots, multishot_curve_mult);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -90,6 +90,7 @@
 #include "tracing/Monitor.h"
 #include "tracing/tracing.h"
 #include "utils/Random.h"
+#include "utils/RandomRange.h"
 #include "utils/string_utils.h"
 #include "weapon/beam.h"
 #include "weapon/corkscrew.h"
@@ -3786,23 +3787,13 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		}
 		stuff_string_list(temp_string_list);
 		sip->dyn_firing_patterns_allowed[pattern_index].clear();
-		FiringPattern pattern;
 		for (auto &entry : temp_string_list) {
-			if (entry == "CYCLE FORWARD") {
-				pattern = FiringPattern::CYCLE_FORWARD;
-			} else if (entry == "CYCLE REVERSE") {
-				pattern = FiringPattern::CYCLE_REVERSE;
-			} else if (entry == "RANDOM EXHAUSTIVE") {
-				pattern = FiringPattern::RANDOM_EXHAUSTIVE;
-			} else if (entry == "RANDOM NONREPEATING") {
-				pattern = FiringPattern::RANDOM_NONREPEATING;
-			} else if (entry == "RANDOM REPEATING") {
-				pattern = FiringPattern::RANDOM_REPEATING;
-			} else {
+			auto pattern = firing_pattern_from_string(entry.c_str());
+			if (!pattern.has_value()) {
 				Warning(LOCATION, "%s is not a valid firing pattern!", entry.c_str());
 				continue;
 			}
-			sip->dyn_firing_patterns_allowed[pattern_index].push_back(pattern);
+			sip->dyn_firing_patterns_allowed[pattern_index].push_back(*pattern);
 		}
 		if (sip->dyn_firing_patterns_allowed[pattern_index].empty()) {
 			sip->dyn_firing_patterns_allowed[pattern_index].push_back(FiringPattern::CYCLE_FORWARD);
@@ -7162,7 +7153,130 @@ void ship::apply_replacement_textures(const SCP_vector<texture_replace> &replace
 	}
 }
 
-void ship_weapon::clear() 
+void FirepointState::clear()
+{
+	m_indices.clear();
+	m_cursor = 0;
+}
+
+// Shuffles a range of the firing point order.  All of the patterns go through here so that there is
+// one place to control how the order is randomized.
+void FirepointState::shuffle(SCP_vector<int>::iterator first, SCP_vector<int>::iterator last)
+{
+	std::shuffle(first, last, util::seeder);
+}
+
+void FirepointState::reset(int num_points)
+{
+	m_indices.clear();
+	for (int fp = 0; fp < num_points; fp++)
+		m_indices.push_back(fp);
+	shuffle(m_indices.begin(), m_indices.end());
+	m_cursor = 0;
+}
+
+// self-repair for banks whose point count changed (or was never initialized) since the last reset
+void FirepointState::ensure(int num_points)
+{
+	if (sz2i(m_indices.size()) != num_points)
+		reset(num_points);
+	if (m_cursor < 0 || m_cursor >= num_points)
+		m_cursor = 0;
+}
+
+int FirepointState::next(FiringPattern pattern, int shot_index, int num_points)
+{
+	ensure(num_points);
+
+	int pt;
+	switch (pattern)
+	{
+		case FiringPattern::CYCLE_FORWARD:
+			pt = m_cursor++;
+			if (m_cursor >= num_points)
+				m_cursor = 0;
+			break;
+		case FiringPattern::CYCLE_REVERSE:
+			pt = m_cursor--;
+			if (m_cursor < 0)
+				m_cursor = num_points - 1;
+			break;
+		case FiringPattern::RANDOM_EXHAUSTIVE:
+			pt = m_indices[m_cursor++];
+			if (m_cursor >= num_points)
+				m_cursor = 0;
+			break;
+		case FiringPattern::RANDOM_NONREPEATING:
+		case FiringPattern::RANDOM_REPEATING:
+			pt = m_indices[shot_index % num_points];
+			break;
+		case FiringPattern::ALL_AT_ONCE:
+		default:
+			pt = shot_index % num_points;
+			break;
+	}
+	return pt;
+}
+
+int FirepointState::peek(FiringPattern pattern, int shot_index, int num_points) const
+{
+	switch (pattern)
+	{
+		case FiringPattern::CYCLE_FORWARD:
+			return (m_cursor + shot_index) % num_points;
+		case FiringPattern::CYCLE_REVERSE:
+		{
+			int pt = (m_cursor - shot_index) % num_points;
+			return (pt < 0) ? pt + num_points : pt;
+		}
+		case FiringPattern::RANDOM_EXHAUSTIVE:
+		case FiringPattern::RANDOM_NONREPEATING:
+		case FiringPattern::RANDOM_REPEATING:
+		{
+			int idx = (pattern == FiringPattern::RANDOM_EXHAUSTIVE) ? (m_cursor + shot_index) % num_points : shot_index % num_points;
+			// being const, peek can't lazy-initialize, so fall back to the identity order if the state isn't ready
+			if (m_indices.in_bounds(idx))
+				return m_indices[idx];
+			return idx;
+		}
+		case FiringPattern::ALL_AT_ONCE:
+		default:
+			return shot_index % num_points;
+	}
+}
+
+void FirepointState::post_fire(FiringPattern pattern, int shot_count, int num_points)
+{
+	ensure(num_points);
+
+	switch (pattern)
+	{
+		case FiringPattern::RANDOM_NONREPEATING:
+		{
+			// move the just-fired points to the back and shuffle the points that will rotate to the
+			// front, so consecutive volleys avoid repeating a point (as far as the point count allows)
+			int shuffle_start = MIN(shot_count, num_points - shot_count);
+			auto middle = m_indices.begin() + shuffle_start;
+			shuffle(middle, m_indices.end());
+			std::rotate(m_indices.begin(), middle, m_indices.end());
+			break;
+		}
+		case FiringPattern::RANDOM_EXHAUSTIVE:
+			// if this volley wrapped past the end of the pass, reshuffle the points that have not fired yet
+			// in the new pass; the ones that just fired keep their places so that they can't repeat early
+			if (m_cursor < shot_count)
+				shuffle(m_indices.begin() + m_cursor, m_indices.end());
+			break;
+		case FiringPattern::RANDOM_REPEATING:
+			shuffle(m_indices.begin(), m_indices.end());
+			break;
+		default:
+			// the CYCLE_* patterns need no upkeep
+			break;
+	}
+}
+
+void ship_weapon::clear()
 {
     flags.reset();
 
@@ -7206,8 +7320,7 @@ void ship_weapon::clear()
         burst_counter[i] = 0;
 		burst_seed[i] = Random::next();
 
-		primary_firepoint_indices[i].clear();
-		primary_firepoint_next_to_fire_index[i] = 0;
+		primary_firepoint_state[i].clear();
 
 		firing_loop_sounds[i] = -1;
     }
@@ -11082,14 +11195,7 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 
 		swp->primary_bank_capacity[i] = sip->primary_bank_ammo_capacity[i];
 
-		swp->primary_firepoint_next_to_fire_index[i] = 0;
-		auto &fpi = swp->primary_firepoint_indices[i];
-		fpi.clear();
-		for (int fp = 0; fp < pm->gun_banks[i].num_slots; fp++) {
-			fpi.push_back(fp);
-		}
-		std::random_device rd;
-		std::shuffle(fpi.begin(), fpi.end(), std::mt19937(rd()));
+		swp->primary_firepoint_state[i].reset(pm->gun_banks[i].num_slots);
 	}
 
 	swp->num_secondary_banks = sip->num_secondary_banks;
@@ -11455,10 +11561,6 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 	ship_set_default_weapons(shipp, sip);	//	Moved up here because ship_set requires that weapon info be valid.  MK, 4/28/98
 	ship_set(shipnum, objnum, ship_type);
 
-	for (auto& fpu : shipp->weapons.primary_firepoint_next_to_fire_index) {
-		fpu = 0;
-	}
-
 	init_ai_object(objnum);
 	ai_clear_ship_goals( &Ai_info[shipp->ai_index] );		// only do this one here.  Can't do it in init_ai because it might wipe out goals in mission file
 
@@ -11672,14 +11774,7 @@ static void ship_model_change(int n, int ship_type)
 	sp->base_texture_anim_timestamp = _timestamp();
 
 	for (int bank_i = 0; bank_i < pm->n_guns; bank_i++) {
-		sp->weapons.primary_firepoint_next_to_fire_index[bank_i] = 0;
-		auto &fpi = sp->weapons.primary_firepoint_indices[bank_i];
-		fpi.clear();
-		for (int fp = 0; fp < pm->gun_banks[bank_i].num_slots; fp++) {
-			fpi.push_back(fp);
-		}
-		std::random_device rd;
-		std::shuffle(fpi.begin(), fpi.end(), std::mt19937(rd()));
+		sp->weapons.primary_firepoint_state[bank_i].reset(pm->gun_banks[bank_i].num_slots);
 	}
 
 	model_delete_instance(sp->model_instance_num);
@@ -12882,6 +12977,45 @@ vec3d ship_get_external_model_fp_offset(external_weapon_state *ext, const weapon
 	return offset;
 }
 
+FiringPattern ship_get_firing_pattern(const ship_info *sip, const ship_weapon *swp, const weapon_info *wip, int bank)
+{
+	if (sip->flags[Ship::Info_Flags::Dyn_primary_linking])
+		return sip->dyn_firing_patterns_allowed[bank][swp->dynamic_firing_pattern[bank]];
+
+	return wip->firing_pattern;
+}
+
+FirepointCounts ship_get_firepoint_counts(const ship_info *sip, const ship_weapon *swp, const weapon_info *wip, FiringPattern pattern, int bank, int num_points, float multishot_curve_mult)
+{
+	FirepointCounts counts;
+
+	// for cycling patterns, $Shots: is the number of points to fire from at a time and $Cycle Multishot: is
+	// the number of projectiles per point; for ALL_AT_ONCE, every point fires and $Shots: is the number of
+	// projectiles per point (used mostly for the 'shotgun' effect)
+	if (sip->flags[Ship::Info_Flags::Dyn_primary_linking])
+	{
+		counts.shot_count = MIN(num_points, swp->primary_bank_slot_count[bank]);
+		counts.multishot_count = fl2i(i2fl(wip->cycle_multishot) * multishot_curve_mult);
+	}
+	else if (wip->wi_flags[Weapon::Info_Flags::Beam] && wip->b_info.beam_shots)
+	{
+		counts.shot_count = MIN(wip->b_info.beam_shots, num_points);
+		counts.multishot_count = fl2i(i2fl(wip->shots) * multishot_curve_mult);
+	}
+	else if (pattern != FiringPattern::ALL_AT_ONCE)
+	{
+		counts.shot_count = MIN(num_points, wip->shots);
+		counts.multishot_count = fl2i(i2fl(wip->cycle_multishot) * multishot_curve_mult);
+	}
+	else
+	{
+		counts.shot_count = num_points;
+		counts.multishot_count = fl2i(i2fl(wip->shots) * multishot_curve_mult);
+	}
+
+	return counts;
+}
+
 // fires a primary weapon for the given object.  It also handles multiplayer cases.
 // in multiplayer, the starting network signature, and number of banks fired are sent
 // to all the clients in the game. All the info is passed to send_primary at the end of
@@ -13188,7 +13322,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			Assert(pm->gun_banks[bank_to_fire].num_slots != 0);
 			swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay * ( swp->primary_bank_slot_count[ bank_to_fire ] ) / pm->gun_banks[bank_to_fire].num_slots ) );
 			swp->last_primary_fire_stamp[bank_to_fire] = timestamp();
-		} else if (winfo_p->firing_pattern != FiringPattern::STANDARD) {
+		} else if (winfo_p->firing_pattern != FiringPattern::ALL_AT_ONCE) {
 			Assert(pm->gun_banks[bank_to_fire].num_slots != 0);
 			swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay / pm->gun_banks[bank_to_fire].num_slots));
 			swp->last_primary_fire_stamp[bank_to_fire] = timestamp();
@@ -13273,31 +13407,16 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			
 			if(winfo_p->wi_flags[Weapon::Info_Flags::Beam]){		// the big change I made for fighter beams, if there beams fill out the Fire_Info for a targeting laser then fire it, for each point in the weapon bank -Bobboau				
 
-				int point_count = 0, shot_count = 1;
-				FiringPattern firing_pattern;
-				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
-					firing_pattern = sip->dyn_firing_patterns_allowed[bank_to_fire][swp->dynamic_firing_pattern[bank_to_fire]];
-				} else {
-					firing_pattern = winfo_p->firing_pattern;
-				}
+				FiringPattern firing_pattern = ship_get_firing_pattern(sip, swp, winfo_p, bank_to_fire);
 
-				// ok if this is a cycling weapon use shots as the number of points to fire from at a time
-				// otherwise shots is the number of times all points will be fired (used mostly for the 'shotgun' effect)
-				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
-					shot_count = fl2i(i2fl(winfo_p->cycle_multishot) * winfo_p->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::SHOTS_MULT, launch_curve_data));
-					point_count = MIN(num_slots, swp->primary_bank_slot_count[bank_to_fire] );
-				} else if (winfo_p->b_info.beam_shots) {
-					shot_count = fl2i(i2fl(winfo_p->shots) * winfo_p->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::SHOTS_MULT, launch_curve_data));
-					point_count = MIN(winfo_p->b_info.beam_shots, num_slots);
-				} else if (firing_pattern != FiringPattern::STANDARD) {
-					shot_count = fl2i(i2fl(winfo_p->cycle_multishot) * winfo_p->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::SHOTS_MULT, launch_curve_data));
-					point_count = MIN(num_slots, winfo_p->shots);
-				} else {
-					shot_count = fl2i(i2fl(winfo_p->shots) * winfo_p->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::SHOTS_MULT, launch_curve_data));
-					point_count = num_slots;
-				}
+				// fighter beams with +BeamShots predate firing patterns and always cycle forward through the points
+				if (!sip->flags[Ship::Info_Flags::Dyn_primary_linking] && winfo_p->b_info.beam_shots)
+					firing_pattern = FiringPattern::CYCLE_FORWARD;
 
-				bool no_energy = shipp->weapon_energy < point_count * shot_count * winfo_p->energy_consumed * flFrametime;
+				float multishot_curve_mult = winfo_p->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::SHOTS_MULT, launch_curve_data);
+				auto [shot_count, multishot_count] = ship_get_firepoint_counts(sip, swp, winfo_p, firing_pattern, bank_to_fire, num_slots, multishot_curve_mult);
+
+				bool no_energy = shipp->weapon_energy < shot_count * multishot_count * winfo_p->energy_consumed * flFrametime;
 				if (no_energy || (winfo_p->wi_flags[Weapon::Info_Flags::Ballistic] && shipp->weapons.primary_bank_ammo[bank_to_fire] <= 0))
 				{
 					swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay));
@@ -13309,50 +13428,10 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					continue;
 				}			
 
-				for (int pt_count = 0; pt_count < point_count; pt_count++) {
-					int pt;
-					if (!sip->flags[Ship::Info_Flags::Dyn_primary_linking] && winfo_p->b_info.beam_shots) {
-						pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]++;
-						if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
-							swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
-						}
-					} else {
-						switch (firing_pattern) {
-							case FiringPattern::CYCLE_FORWARD: {
-								pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]++;
-								if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
-									swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
-								}
-								break;
-							}
-							case FiringPattern::CYCLE_REVERSE: {
-								pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]--;
-								if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] < 0) {
-									swp->primary_firepoint_next_to_fire_index[bank_to_fire] = num_slots - 1;
-								}
-								break;
-							}
-							case FiringPattern::RANDOM_EXHAUSTIVE: {
-								pt = swp->primary_firepoint_indices[bank_to_fire][swp->primary_firepoint_next_to_fire_index[bank_to_fire]++];
-								if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
-									swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
-								}
-								break;
-							}
-							case FiringPattern::RANDOM_NONREPEATING: // behaves the same as random repeating here
-							case FiringPattern::RANDOM_REPEATING: {
-								pt = swp->primary_firepoint_indices[bank_to_fire][pt_count];
-								break;
-							}
-							default:
-							case FiringPattern::STANDARD: {
-								pt = pt_count;
-								break;
-							}
-						}
-					}
+				for (int shot_index = 0; shot_index < shot_count; shot_index++) {
+					int pt = swp->primary_firepoint_state[bank_to_fire].next(firing_pattern, shot_index, num_slots);
 
-					for (int w = 0; w < shot_count; w++) {
+					for (int w = 0; w < multishot_count; w++) {
 						beam_fire_info fbfire_info;
 						shipp->beam_sys_info.turret_norm.xyz.x = 0.0f;
 				    	shipp->beam_sys_info.turret_norm.xyz.y = 0.0f;
@@ -13394,39 +13473,16 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 						num_fired++;
 					}
 				}
+
+				// note: the original firing pattern code did not reshuffle the RANDOM_* patterns for fighter beams; that is now fixed
+				swp->primary_firepoint_state[bank_to_fire].post_fire(firing_pattern, shot_count, num_slots);
 			}
 			else	//if this isn't a fighter beam, do it normally -Bobboau
 			{
-				int point_count = 0, shot_count = 1;
-				FiringPattern firing_pattern;
-				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
-					firing_pattern = sip->dyn_firing_patterns_allowed[bank_to_fire][swp->dynamic_firing_pattern[bank_to_fire]];
-				} else {
-					firing_pattern = winfo_p->firing_pattern;
-				}
+				FiringPattern firing_pattern = ship_get_firing_pattern(sip, swp, winfo_p, bank_to_fire);
 
-				// ok if this is a cycling weapon use shots as the number of points to fire from at a time
-				// otherwise shots is the number of times all points will be fired (used mostly for the 'shotgun' effect)
-				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
-					shot_count = winfo_p->cycle_multishot;
-					point_count = MIN(num_slots, swp->primary_bank_slot_count[ bank_to_fire ] );
-				} else if (firing_pattern != FiringPattern::STANDARD) {
-					shot_count = winfo_p->cycle_multishot;
-					point_count = MIN(num_slots, winfo_p->shots);
-				} else {
-					shot_count = winfo_p->shots;
-					point_count = num_slots;
-				}
-
-				if (swp->primary_firepoint_indices[bank_to_fire].empty()) {
-					auto &fpi = swp->primary_firepoint_indices[bank_to_fire];
-					fpi.clear();
-					for (int fp = 0; fp < num_slots; fp++) {
-						fpi.push_back(fp);
-					}
-					std::random_device rd;
-					std::shuffle(fpi.begin(), fpi.end(), std::mt19937(rd()));
-				}
+				// note: unlike the fighter beam branch, this branch has never applied the SHOTS_MULT launch curve
+				auto [shot_count, multishot_count] = ship_get_firepoint_counts(sip, swp, winfo_p, firing_pattern, bank_to_fire, num_slots);
 
 				// The energy-consumption code executes even for ballistic primaries, because
 				// there may be a reason why you want to have ballistics consume energy.  Perhaps
@@ -13434,7 +13490,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				// the weapon's energy_consumed to 0 and it'll work just fine. - Goober5000
 
 				// fail unless we're forcing (energy based primaries)
-				bool no_energy = shipp->weapon_energy < point_count * shot_count * winfo_p->energy_consumed; //was num_slots
+				bool no_energy = shipp->weapon_energy < shot_count * multishot_count * winfo_p->energy_consumed; //was num_slots
 				if ( no_energy && !force ) {
 
 					swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay));
@@ -13484,7 +13540,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					// deplete ammo
 					if ( !Weapon_energy_cheat )
 					{
-						swp->primary_bank_ammo[bank_to_fire] -= point_count*shot_count;
+						swp->primary_bank_ammo[bank_to_fire] -= shot_count * multishot_count;
 
 						// make sure we don't go below zero; any such error is excusable
 						// because it only happens when the bank is depleted in one shot
@@ -13498,7 +13554,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				// now handle the energy as usual
 				// deplete the weapon reserve energy by the amount of energy used to fire the weapon	
 				// Only subtract the energy amount required for equipment operation once
-				shipp->weapon_energy -= point_count*shot_count * winfo_p->energy_consumed;
+				shipp->weapon_energy -= shot_count * multishot_count * winfo_p->energy_consumed;
 				// note for later: option for fuel!
 				
 				// Mark all these weapons as in the same group
@@ -13509,7 +13565,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				size_t current_firepoint = 0;
 
 				if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){
-					firepoint_list = new vec3d[shot_count * point_count];
+					firepoint_list = new vec3d[shot_count * multishot_count];
 					vm_vec_zero(&total_impulse);
 				} else {
 					firepoint_list = nullptr;
@@ -13520,43 +13576,10 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				if (sip->draw_primary_models[bank_to_fire] && (winfo_p->external_model_num >= 0))
 					weapon_model = model_get(winfo_p->external_model_num);
 
-				for (int pt_count = 0; pt_count < point_count; pt_count++) {
-					int pt;
-					switch (firing_pattern) {
-						case FiringPattern::CYCLE_FORWARD: {
-							pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]++;
-							if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
-								swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
-							}
-							break;
-						}
-						case FiringPattern::CYCLE_REVERSE: {
-							pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]--;
-							if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] < 0) {
-								swp->primary_firepoint_next_to_fire_index[bank_to_fire] = num_slots - 1;
-							}
-							break;
-						}
-						case FiringPattern::RANDOM_EXHAUSTIVE: {
-							pt = swp->primary_firepoint_indices[bank_to_fire][swp->primary_firepoint_next_to_fire_index[bank_to_fire]++];
-							if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
-								swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
-							}
-							break;
-						}
-						case FiringPattern::RANDOM_NONREPEATING: // behaves the same as random repeating here
-						case FiringPattern::RANDOM_REPEATING: {
-							pt = swp->primary_firepoint_indices[bank_to_fire][pt_count];
-							break;
-						}
-						default:
-						case FiringPattern::STANDARD: {
-							pt = pt_count;
-							break;
-						}
-					}
+				for (int shot_index = 0; shot_index < shot_count; shot_index++) {
+					int pt = swp->primary_firepoint_state[bank_to_fire].next(firing_pattern, shot_index, num_slots);
 
-					for (int j = 0; j < shot_count; j++) {
+					for (int j = 0; j < multishot_count; j++) {
 						int sub_shots = 1;
 						// weapons that don't chain their external model firing points fire from all of them at once
 						// (note that external model firing points always come from the model's first gun bank)
@@ -13708,35 +13731,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					}
 				}
 
-				switch (firing_pattern) {
-					case FiringPattern::RANDOM_EXHAUSTIVE: {
-						if (num_slots < (swp->primary_firepoint_next_to_fire_index[bank_to_fire] + point_count)) {
-							std::random_device rd;
-							std::shuffle(&swp->primary_firepoint_indices[bank_to_fire][0], &swp->primary_firepoint_indices[bank_to_fire][swp->primary_firepoint_next_to_fire_index[bank_to_fire]-1], std::mt19937(rd())); //NOLINT
-						} else if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] < point_count) {
-							std::random_device rd;
-							std::shuffle(swp->primary_firepoint_indices[bank_to_fire].begin(), swp->primary_firepoint_indices[bank_to_fire].end(), std::mt19937(rd()));
-						}
-						break;
-					}
-					case FiringPattern::RANDOM_NONREPEATING: {
-						int shuffle_start = MIN(point_count, num_slots - point_count);
-						std::random_device rd;
-						auto middle_iterator = swp->primary_firepoint_indices[bank_to_fire].begin();
-						std::advance(middle_iterator, shuffle_start);
-						std::shuffle(middle_iterator, swp->primary_firepoint_indices[bank_to_fire].end(), std::mt19937(rd()));
-						std::rotate(swp->primary_firepoint_indices[bank_to_fire].begin(), middle_iterator, swp->primary_firepoint_indices[bank_to_fire].end());
-						break;
-					}
-					case FiringPattern::RANDOM_REPEATING: {
-						std::random_device rd;
-						std::shuffle(swp->primary_firepoint_indices[bank_to_fire].begin(), swp->primary_firepoint_indices[bank_to_fire].end(), std::mt19937(rd()));
-						break;
-					}
-					default: {
-						break;
-					}
-				}
+				swp->primary_firepoint_state[bank_to_fire].post_fire(firing_pattern, shot_count, num_slots);
 
 				if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){
 					vec3d avg_firepoint;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -169,7 +169,6 @@ public:
 	int primary_bank_ammo[MAX_SHIP_PRIMARY_BANKS];			// Number of missiles left in primary bank
 	int primary_bank_start_ammo[MAX_SHIP_PRIMARY_BANKS];	// Number of missiles starting in primary bank
 	int primary_bank_capacity[MAX_SHIP_PRIMARY_BANKS];		// Max number of projectiles in bank
-	int primary_next_slot[MAX_SHIP_PRIMARY_BANKS];			// Next slot to fire in the bank
 	int primary_bank_rearm_time[MAX_SHIP_PRIMARY_BANKS];	// timestamp which indicates when bank can get new projectile
 	// end ballistic primary support
 
@@ -183,7 +182,6 @@ public:
 	int secondary_bank_ammo[MAX_SHIP_SECONDARY_BANKS];			// Number of missiles left in secondary bank
 	int secondary_bank_start_ammo[MAX_SHIP_SECONDARY_BANKS];	// Number of missiles starting in secondary bank -- Every time the secondary bank changes, this must change too!
 	int secondary_bank_capacity[MAX_SHIP_SECONDARY_BANKS];		// Max number of missiles in bank
-	int secondary_next_slot[MAX_SHIP_SECONDARY_BANKS];			// Next slot to fire in the bank
 	int secondary_bank_rearm_time[MAX_SHIP_SECONDARY_BANKS];	// timestamp which indicates when bank can get new missile
 
 	int tertiary_bank_ammo;			// Number of shots left tertiary bank
@@ -210,6 +208,7 @@ public:
 	int	burst_seed[MAX_SHIP_PRIMARY_BANKS + MAX_SHIP_SECONDARY_BANKS];    // A random seed, recalculated only when the weapon's burst resets
 
 	FirepointState primary_firepoint_state[MAX_SHIP_PRIMARY_BANKS];		// per-bank firing point cycling state for the FiringPattern feature
+	FirepointState secondary_firepoint_state[MAX_SHIP_SECONDARY_BANKS];
 
 	size_t primary_bank_substitution_pattern_index[MAX_SHIP_PRIMARY_BANKS];
 	size_t secondary_bank_substitution_pattern_index[MAX_SHIP_SECONDARY_BANKS];
@@ -1872,6 +1871,10 @@ FiringPattern ship_get_firing_pattern(const ship_info *sip, const ship_weapon *s
 
 // how many firing points fire per volley (shot_count) and how many projectiles each fires (multishot_count)
 FirepointCounts ship_get_firepoint_counts(const ship_info *sip, const ship_weapon *swp, const weapon_info *wip, FiringPattern pattern, int bank, int num_points, float multishot_curve_mult = 1.0f);
+
+// the same for a secondary bank, including the dual fire doubling if it applies to this bank
+FirepointCounts ship_get_secondary_firepoint_counts(const ship *shipp, int bank, int num_points);
+
 extern vec3d ship_get_external_model_fp_offset(external_weapon_state *ext, const weapon_info *wip, const polymodel *weapon_model, const w_bank *ship_bank, int slot, bool advance_counter, int sub_shot = 0);
 extern void ship_get_weapon_model_slot_transform(const w_bank *bank, int slot, float reload_slide_back, vec3d *outpnt, matrix *outorient);
 extern int ship_get_external_weapon_model_instance(ship_weapon *swp, int bank, int display_model_num);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -104,6 +104,41 @@ struct external_weapon_state
 	bool spin_up_requested = false;	// set each frame the bank tries to fire; consumed by update_external_weapon_spin()
 };
 
+// Per-bank firing point state for the FiringPattern feature: which point fires next, and in what
+// order.  next() consumes points at fire time; peek() lets the HUD preview upcoming points without
+// disturbing the state.  shot_index is the position within the current volley (0 to shot_count-1).
+class FirepointState
+{
+	SCP_vector<int> m_indices;	// firing point order, shuffled; used by the RANDOM_* patterns
+	int m_cursor = 0;			// next-to-fire position; used by the CYCLE_* and RANDOM_EXHAUSTIVE patterns
+
+	void ensure(int num_points);
+	void shuffle(SCP_vector<int>::iterator first, SCP_vector<int>::iterator last);
+
+public:
+	void clear();
+	void reset(int num_points);
+
+	// return to the start of the cycle without changing the firing point order
+	void restart() { m_cursor = 0; }
+
+	// returns the model firing point index for this shot and advances the state
+	int next(FiringPattern pattern, int shot_index, int num_points);
+
+	// returns the model firing point index that next(pattern, shot_index, ...) would return, without advancing
+	int peek(FiringPattern pattern, int shot_index, int num_points) const;
+
+	// per-volley upkeep (reshuffling for the RANDOM_* patterns); call once after a volley is fired
+	void post_fire(FiringPattern pattern, int shot_count, int num_points);
+};
+
+// How many firing points fire in a volley, and how many projectiles each of those points fires
+struct FirepointCounts
+{
+	int shot_count;
+	int multishot_count;
+};
+
 class ship_weapon {
 public:
 	int num_primary_banks;					// Number of primary banks (same as model)
@@ -174,9 +209,7 @@ public:
 	int	burst_counter[MAX_SHIP_PRIMARY_BANKS + MAX_SHIP_SECONDARY_BANKS];
 	int	burst_seed[MAX_SHIP_PRIMARY_BANKS + MAX_SHIP_SECONDARY_BANKS];    // A random seed, recalculated only when the weapon's burst resets
 
-	SCP_vector<int> primary_firepoint_indices[MAX_SHIP_PRIMARY_BANKS];	// A list of firepoint indices which is shuffled for random fire ordering
-	int primary_firepoint_next_to_fire_index[MAX_SHIP_PRIMARY_BANKS];	// For cycle firing modes, keeps track of which firepoint we're on
-																		// For randomized ones, keeps track of where we are in primary_firepoint_indices
+	FirepointState primary_firepoint_state[MAX_SHIP_PRIMARY_BANKS];		// per-bank firing point cycling state for the FiringPattern feature
 
 	size_t primary_bank_substitution_pattern_index[MAX_SHIP_PRIMARY_BANKS];
 	size_t secondary_bank_substitution_pattern_index[MAX_SHIP_SECONDARY_BANKS];
@@ -1832,6 +1865,13 @@ extern void ship_actually_depart(int shipnum, int method = SHIP_DEPARTED_WARP);
 extern bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj);
 extern int ship_stop_fire_primary(object * obj);
 extern int ship_fire_primary(object * objp, int force = 0, bool rollback_shot = false);
+
+// the firing pattern currently in effect for this bank: the ship's dynamic pattern if dynamic
+// linking is active, otherwise the weapon's pattern
+FiringPattern ship_get_firing_pattern(const ship_info *sip, const ship_weapon *swp, const weapon_info *wip, int bank);
+
+// how many firing points fire per volley (shot_count) and how many projectiles each fires (multishot_count)
+FirepointCounts ship_get_firepoint_counts(const ship_info *sip, const ship_weapon *swp, const weapon_info *wip, FiringPattern pattern, int bank, int num_points, float multishot_curve_mult = 1.0f);
 extern vec3d ship_get_external_model_fp_offset(external_weapon_state *ext, const weapon_info *wip, const polymodel *weapon_model, const w_bank *ship_bank, int slot, bool advance_counter, int sub_shot = 0);
 extern void ship_get_weapon_model_slot_transform(const w_bank *bank, int slot, float reload_slide_back, vec3d *outpnt, matrix *outorient);
 extern int ship_get_external_weapon_model_instance(ship_weapon *swp, int bank, int display_model_num);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -107,16 +107,27 @@ struct external_weapon_state
 // Per-bank firing point state for the FiringPattern feature: which point fires next, and in what
 // order.  next() consumes points at fire time; peek() lets the HUD preview upcoming points without
 // disturbing the state.  shot_index is the position within the current volley (0 to shot_count-1).
+//
+// The shuffling is deterministic: it is driven by static_rand(), which is seeded identically on every
+// machine in a multiplayer game, so given the same seed and the same sequence of calls every machine
+// and platform produces the same firing point order.  (The state stays in sync only as long as every
+// machine sees every volley; a dropped fire packet desyncs the bank until its next reset.)
 class FirepointState
 {
-	SCP_vector<int> m_indices;	// firing point order, shuffled; used by the RANDOM_* patterns
-	int m_cursor = 0;			// next-to-fire position; used by the CYCLE_* and RANDOM_EXHAUSTIVE patterns
+	SCP_vector<int> m_indices;			// firing point order, shuffled; used by the RANDOM_* patterns
+	int m_cursor = 0;					// next-to-fire position; used by the CYCLE_* and RANDOM_EXHAUSTIVE patterns
+	unsigned int m_seed = 0;			// see seed()
+	unsigned int m_shuffle_count = 0;	// combined with the seed so that each successive shuffle is different
 
 	void ensure(int num_points);
 	void shuffle(SCP_vector<int>::iterator first, SCP_vector<int>::iterator last);
 
 public:
 	void clear();
+
+	// sets the seed for all subsequent shuffles; call before reset()
+	void seed(unsigned int seed);
+
 	void reset(int num_points);
 
 	// return to the start of the cycle without changing the firing point order

--- a/code/utils/Random.cpp
+++ b/code/utils/Random.cpp
@@ -1,6 +1,8 @@
 #include "Random.h"
 #include "RandomRange.h"
 
+#include "math/staticrand.h"
+
 #include <limits>
 #include <random>
 
@@ -83,5 +85,13 @@ bool Random::flip_coin()
 void Random::advance(unsigned long long distance)
 {
 	SCP_rng.advance(distance);
+}
+
+static_assert(StaticRandGenerator::max() == static_cast<unsigned int>(STATIC_RAND_MAX), "StaticRandGenerator::max() must match STATIC_RAND_MAX");
+
+StaticRandGenerator::result_type StaticRandGenerator::operator()()
+{
+	// mask before the cast: static_rand() negates a negative input, which would overflow for INT_MIN
+	return static_cast<result_type>(static_rand(static_cast<int>((m_seed + m_count++) & 0x7fffffffu)));
 }
 } // namespace util

--- a/code/utils/Random.h
+++ b/code/utils/Random.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+
 namespace util {
 
 class Random {
@@ -28,4 +33,47 @@ public:
 private:
 	Random();
 };
+
+// A UniformRandomBitGenerator over static_rand(), so that it can be passed to std::shuffle, the standard
+// distributions, or deterministic_shuffle().  Successive calls return static_rand(seed), static_rand(seed + 1),
+// and so on.  Because static_rand() is initialized from the netgame seed in multiplayer (see game_level_init),
+// a generator constructed with the same seed produces the same sequence on every machine.  Note that
+// std::shuffle and the standard distributions are implementation-defined, so for results that must match
+// across platforms as well, use deterministic_shuffle().
+//
+// Be aware that static_rand() only looks at the low 13 bits of its input (see SEMIRAND_MAX_LOG), so there
+// are only 8192 distinct sequences no matter how the seed is derived.  That is fine for shuffling a handful
+// of items, where two seeds occasionally sharing a sequence is harmless, but it is not a source of real
+// seed entropy.
+class StaticRandGenerator {
+	unsigned int m_seed;
+	unsigned int m_count = 0;
+public:
+	using result_type = unsigned int;
+
+	explicit StaticRandGenerator(unsigned int seed) : m_seed(seed) {}
+
+	static constexpr result_type min() { return 0; }
+	static constexpr result_type max() { return 0x3fffffff; }	// STATIC_RAND_MAX; checked in Random.cpp
+
+	result_type operator()();
+};
+
+// Fisher-Yates shuffle with a fully specified algorithm.  Unlike std::shuffle, whose algorithm (and its use of
+// uniform_int_distribution) is left to the implementation, this produces the same permutation on every platform
+// given the same generator sequence, which is what multiplayer needs.  Accepts any UniformRandomBitGenerator.
+// The modulo introduces a bias that is negligible for ranges far smaller than the generator's range.
+template <typename RandomIt, typename URBG>
+void deterministic_shuffle(RandomIt first, RandomIt last, URBG &&g)
+{
+	using diff_t = typename std::iterator_traits<RandomIt>::difference_type;
+	using gen_t = std::remove_reference_t<URBG>;
+
+	for (diff_t i = (last - first) - 1; i > 0; --i)
+	{
+		auto r = static_cast<uint64_t>(g() - gen_t::min());
+		auto j = static_cast<diff_t>(r % static_cast<uint64_t>(i + 1));
+		std::iter_swap(first + i, first + j);
+	}
+}
 } // namespace util

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -352,13 +352,16 @@ struct ConditionalImpact {
 };
 
 enum class FiringPattern {
-	STANDARD,
-	CYCLE_FORWARD,
+	ALL_AT_ONCE,			// every firing point fires each volley (the default for primaries, per retail)
+	CYCLE_FORWARD,			// firing points take turns (the default for secondaries, per retail)
 	CYCLE_REVERSE,
-	RANDOM_EXHAUSTIVE,
-	RANDOM_NONREPEATING,
-	RANDOM_REPEATING,
+	RANDOM_EXHAUSTIVE,		// random order, but each point fires once before any point repeats
+	RANDOM_NONREPEATING,	// random order; consecutive volleys avoid repeating points where possible
+	RANDOM_REPEATING,		// fully random order every volley
 };
+
+// maps a tables string (e.g. "CYCLE FORWARD") to a firing pattern; case-insensitive
+std::optional<FiringPattern> firing_pattern_from_string(const char *name);
 
 float weapon_get_lifetime_pct(const weapon& wp);
 float weapon_get_age(const weapon& wp);

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -619,8 +619,8 @@ struct weapon_info
 	float fof_spread_rate;			//How quickly the FOF will spread for each shot (primary weapons only, this doesn't really make sense for turrets)
 	float fof_reset_rate;			//How quickly the FOF spread will reset over time (primary weapons only, this doesn't really make sense for turrets)
 	float max_fof_spread;			//The maximum fof increase that the shots can spread to
-	FiringPattern firing_pattern;
-	int	  shots;					//the number of shots that will be fired at a time, 
+	FiringPattern firing_pattern;	// see also Info_Flags::Firing_pattern_specified
+	int	  shots;					//the number of shots that will be fired at a time,
 									//only realy usefull when used with FOF to make a shot gun effect
 									//now also used for weapon point cycleing
 	int   cycle_multishot;			//ugly hack -- used to control multishot if the weapon uses any non-standard firing pattern, since $shots is used for fire point number
@@ -953,6 +953,17 @@ struct weapon_info
     inline bool is_secondary()          const { return subtype == WP_MISSILE; }
     inline bool is_beam()               const { return subtype == WP_BEAM || wi_flags[Weapon::Info_Flags::Beam]; }
     inline bool is_non_beam_primary()   const { return subtype == WP_LASER && !wi_flags[Weapon::Info_Flags::Beam]; }
+
+    // Fighter beams predate firing patterns, and originally cycled forward through +Shots: firing points per
+    // trigger pull, firing $Shots: beams from each.  That behavior is kept for compatibility unless the weapon
+    // tables a $Firing Pattern:, in which case the beam fires exactly like a gun would with that pattern.
+    inline bool uses_legacy_fighter_beam_firing() const { return is_beam() && b_info.beam_shots > 0 && !wi_flags[Weapon::Info_Flags::Firing_pattern_specified]; }
+
+    // Secondaries have always launched one missile from one firing point per trigger pull, and $Shots: already
+    // means something for the same weapon when it is fired from a turret.  Honoring $Shots: and $Cycle Multishot:
+    // on a secondary bank would therefore silently rebalance existing tables, so it only happens for a secondary
+    // that opts in by tabling a $Firing Pattern:.
+    inline bool uses_legacy_secondary_firing() const { return is_secondary() && !wi_flags[Weapon::Info_Flags::Firing_pattern_specified]; }
 
     inline bool is_homing() const { return wi_flags.any_of(Weapon::Info_Flags::Homing_heat,Weapon::Info_Flags::Homing_aspect,Weapon::Info_Flags::Homing_javelin); }
 	inline bool is_locked_homing() const { return wi_flags.any_of(Weapon::Info_Flags::Homing_aspect,Weapon::Info_Flags::Homing_javelin); }

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -98,6 +98,7 @@ namespace Weapon {
 		Freespace_1_missile_behavior,		// Bundles several observed behaviors missiles had in the freespace 1 release
 		Dogfight_weapon,                    // Dogfight weapons are intended as balanced variants for multiplayer. This flag can be used to filter them out when necessary.
 		Mine,								// weapon is a stationary proximity mine (subset of secondary): zero velocity, infinite lifetime
+		Firing_pattern_specified,			// $Firing Pattern: was tabled rather than defaulted
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -914,11 +914,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		wip->subtype = subtype;
 	}
 
-	// assign subtype-specific flags
+	// assign subtype-specific flags and defaults
 	if (first_time)
 	{
 		if (wip->subtype == WP_MISSILE)
 			wip->wi_flags.set(Weapon::Info_Flags::Detonate_on_expiration);
+
+		// retail primaries fire all points at once while retail secondaries cycle
+		wip->firing_pattern = wip->is_primary() ? FiringPattern::ALL_AT_ONCE : FiringPattern::CYCLE_FORWARD;
 	}
 
 	if (optional_string("+Title:")) {
@@ -4054,25 +4057,30 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 	if(optional_string("$Firing Pattern:")) {
 		stuff_string(fname, F_NAME, NAME_LENGTH);
-		if (!stricmp(fname, "CYCLE FORWARD")) {
-			wip->firing_pattern = FiringPattern::CYCLE_FORWARD;
-		} else if (!stricmp(fname, "CYCLE REVERSE")) {
-			wip->firing_pattern = FiringPattern::CYCLE_REVERSE;
-		} else if (!stricmp(fname, "RANDOM EXHAUSTIVE")) {
-			wip->firing_pattern = FiringPattern::RANDOM_EXHAUSTIVE;
-		} else if (!stricmp(fname, "RANDOM NONREPEATING")) {
-			wip->firing_pattern = FiringPattern::RANDOM_NONREPEATING;
-		} else if (!stricmp(fname, "RANDOM REPEATING")) {
-			wip->firing_pattern = FiringPattern::RANDOM_REPEATING;
+		auto pattern = firing_pattern_from_string(fname);
+		if (pattern.has_value()) {
+			wip->firing_pattern = *pattern;
+		} else {
+			error_display(0, "\"%s\" is not a valid $Firing Pattern: for weapon %s", fname, wip->name);
 		}
 	}
 
+	// note that zero is allowed for this, and means the weapon fires nothing
 	if( optional_string("$Shots:")){
 		stuff_int(&wip->shots);
+		if (wip->shots < 0) {
+			error_display(0, "$Shots: for weapon %s cannot be negative; setting to 0", wip->name);
+			wip->shots = 0;
+		}
 	}
 
+	// note that zero is allowed for this, and means the weapon fires nothing
 	if( optional_string("$Cycle Multishot:")){
 		stuff_int(&wip->cycle_multishot);
+		if (wip->cycle_multishot < 0) {
+			error_display(0, "$Cycle Multishot: for weapon %s cannot be negative; setting to 0", wip->name);
+			wip->cycle_multishot = 0;
+		}
 	}
 
 	//Left in for compatibility
@@ -7046,6 +7054,26 @@ void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, int target_o
 	}
 }
 
+std::optional<FiringPattern> firing_pattern_from_string(const char *name)
+{
+	static const std::pair<const char *, FiringPattern> pattern_names[] =
+	{
+		{ "ALL AT ONCE",         FiringPattern::ALL_AT_ONCE },
+		{ "CYCLE FORWARD",       FiringPattern::CYCLE_FORWARD },
+		{ "CYCLE REVERSE",       FiringPattern::CYCLE_REVERSE },
+		{ "RANDOM EXHAUSTIVE",   FiringPattern::RANDOM_EXHAUSTIVE },
+		{ "RANDOM NONREPEATING", FiringPattern::RANDOM_NONREPEATING },
+		{ "RANDOM REPEATING",    FiringPattern::RANDOM_REPEATING },
+	};
+
+	for (const auto &entry : pattern_names)
+	{
+		if (!stricmp(entry.first, name))
+			return entry.second;
+	}
+	return std::nullopt;
+}
+
 static size_t *get_pointer_to_weapon_fire_pattern_index(ship_weapon *ship_weapon_p, int swp_pbank, int swp_sbank)
 {
 	if (ship_weapon_p)
@@ -10005,7 +10033,7 @@ void weapon_info::reset()
 	this->fof_spread_rate = 0.0f;
 	this->fof_reset_rate = 0.0f;
 	this->max_fof_spread = 0.0f;
-	this->firing_pattern = FiringPattern::STANDARD;
+	this->firing_pattern = FiringPattern::CYCLE_FORWARD;
 	this->shots = 1;
 	this->cycle_multishot = 1;
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -415,7 +415,8 @@ void parse_wi_flags(weapon_info *weaponp)
 			Weapon::Info_Flags::Apply_Recoil,
 			Weapon::Info_Flags::Has_display_name,
 			Weapon::Info_Flags::Vampiric,
-			Weapon::Info_Flags::Detonate_on_expiration
+			Weapon::Info_Flags::Detonate_on_expiration,
+			Weapon::Info_Flags::Firing_pattern_specified
 		};
 
 		// clear all flags except for the ones that are preset by other fields in the weapon
@@ -3257,7 +3258,8 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			wip->beam_curves.add_curve("Beam Lifetime", weapon_info::BeamCurveOutputs::BEAM_ALPHA_MULT, modular_curves_entry{curve_parse(" Beam Lifetime will not be modified.")});
 		}
 
-		// # of shots (only used for type D beams)
+		// # of shots: the number of aim vectors for antifighter (type D) turret beams, and for fighter beams
+		// without a $Firing Pattern:, the number of firing points per trigger pull (see uses_legacy_fighter_beam_firing)
 		if(optional_string("+Shots:")) {
 			stuff_int(&wip->b_info.beam_shots);
 		}
@@ -4060,6 +4062,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		auto pattern = firing_pattern_from_string(fname);
 		if (pattern.has_value()) {
 			wip->firing_pattern = *pattern;
+			wip->wi_flags.set(Weapon::Info_Flags::Firing_pattern_specified);
 		} else {
 			error_display(0, "\"%s\" is not a valid $Firing Pattern: for weapon %s", fname, wip->name);
 		}


### PR DESCRIPTION
This standardizes firing point management, allows both primary and secondary weapons to select from the same available patterns, and adds the ability for fighter-beams to use firing patterns.  Along the way, several design flaws and inconsistencies are fixed.  Changes are implemented in four stages corresponding to four commits: refactor for primaries, unify with secondaries, make consistent for multiplayer, and fighter beam support.

Follow-up to #7635.  Also a prerequisite for extending the same capability to turrets.  In draft pending testing.