### PR TITLE
Replace the Cockpit_active global with computed predicates

### DIFF
--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -794,7 +794,7 @@ static void render_viewer_shadow(object* objp, const matrix* light_matrix,
 		viewer_list.render_all();
 	}
 
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && sip->cockpit_model_num >= 0 && !Disable_cockpits;
+	const bool renderCockpitModel = ship_render_player_cockpit(sip);
 
 	if (renderCockpitModel && !Shadow_disable_overrides.disable_cockpit) {
 		matrix4 dummy_view;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1413,11 +1413,10 @@ bool HudGauge::canRender() const
 	}
 	
 	if (render_for_cockpit_toggle > 0) {
-		if ((Viewer_mode & VM_CHASE) && (render_for_cockpit_toggle == 2)) {
-			return true;
-		} else if (Cockpit_active && (render_for_cockpit_toggle == 2)) {
+		bool cockpit_active = ship_render_player_cockpit_active();
+		if (cockpit_active && (render_for_cockpit_toggle == 2)) {
 			return false;
-		} else if (!Cockpit_active && (render_for_cockpit_toggle == 1)) {
+		} else if (!cockpit_active && (render_for_cockpit_toggle == 1)) {
 			return false;
 		}
 	}

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1347,9 +1347,10 @@ bool HudGaugeTalkingHead::canRender() const
 	}
 
 	if (render_for_cockpit_toggle > 0) {
-		if (!(Viewer_mode & VM_CHASE) && Cockpit_active && (render_for_cockpit_toggle == 2)) {
+		bool cockpit_active = ship_render_player_cockpit_active();
+		if (cockpit_active && (render_for_cockpit_toggle == 2)) {
 			return false;
-		} else if (!Cockpit_active && (render_for_cockpit_toggle == 1)) {
+		} else if (!cockpit_active && (render_for_cockpit_toggle == 1)) {
 			return false;
 		}
 	}

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2807,9 +2807,10 @@ bool HudGaugeSquadMessage::canRender() const
 	}
 
 	if (render_for_cockpit_toggle > 0) {
-		if (!(Viewer_mode & VM_CHASE) && Cockpit_active && (render_for_cockpit_toggle == 2)) {
+		bool cockpit_active = ship_render_player_cockpit_active();
+		if (cockpit_active && (render_for_cockpit_toggle == 2)) {
 			return false;
-		} else if (!Cockpit_active && (render_for_cockpit_toggle == 1)) {
+		} else if (!cockpit_active && (render_for_cockpit_toggle == 1)) {
 			return false;
 		}
 	}

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -219,9 +219,10 @@ bool HudGaugeDirectives::canRender() const
 	}
 
 	if (render_for_cockpit_toggle > 0) {
-		if (!(Viewer_mode & VM_CHASE) && Cockpit_active && (render_for_cockpit_toggle == 2)) {
+		bool cockpit_active = ship_render_player_cockpit_active();
+		if (cockpit_active && (render_for_cockpit_toggle == 2)) {
 			return false;
-		} else if (!Cockpit_active && (render_for_cockpit_toggle == 1)) {
+		} else if (!cockpit_active && (render_for_cockpit_toggle == 1)) {
 			return false;
 		}
 	}

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -267,7 +267,7 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 			&& (obj->type == OBJ_SHIP)
 			&& c_viewer
 			&& (Ship_info[Ships[obj->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model])
-			&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active) )
+			&& (!Show_ship_only_if_cockpits_enabled || ship_cockpit_enabled(&Ship_info[Ships[obj->instance].ship_info_index])) )
 		{
 			(*draw_viewer_last) = true;
 			continue;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -135,7 +135,6 @@ std::shared_ptr<model_texture_replace> Player_cockpit_textures;
 SCP_vector<cockpit_display> Player_displays;
 bool Disable_cockpits = false;
 bool Disable_cockpit_sway = false;
-bool Cockpit_active = false;
 
 wing	Wings[MAX_WINGS];
 bool	Ships_inited = false;
@@ -8158,9 +8157,27 @@ static void ship_find_warping_ship_helper(object *objp, dock_function_info *info
 	}
 }
 
+bool ship_cockpit_enabled(const ship_info* sip)
+{
+	return sip->cockpit_model_num >= 0 && !Disable_cockpits;
+}
+
+bool ship_render_player_cockpit(const ship_info* sip)
+{
+	return (Viewer_mode != VM_TOPDOWN) && ship_cockpit_enabled(sip);
+}
+
+bool ship_render_player_cockpit_active()
+{
+	if (Viewer_obj == nullptr || Viewer_obj->type != OBJ_SHIP || Viewer_obj->instance < 0)
+		return false;
+
+	return ship_render_player_cockpit(&Ship_info[Ships[Viewer_obj->instance].ship_info_index]);
+}
+
 static bool ship_render_player_renderShipModel(const ship_info* sip) {
 	return sip->flags[Ship::Info_Flags::Show_ship_model]
-		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active)
+		&& (!Show_ship_only_if_cockpits_enabled || ship_cockpit_enabled(sip))
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK) || !(Viewer_mode & VM_EXTERNAL));
 }
 
@@ -8191,9 +8208,7 @@ bool ship_render_player_has_closeup_visuals() {
 	ship* shipp = &Ships[Viewer_obj->instance];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
-	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
-
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
+	const bool renderCockpitModel = ship_render_player_cockpit(sip);
 	const bool renderShipModel = ship_render_player_renderShipModel(sip);
 
 	return renderCockpitModel || renderShipModel;
@@ -8206,9 +8221,8 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 
 	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
 
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
+	const bool renderCockpitModel = ship_render_player_cockpit(sip);
 	const bool renderShipModel = ship_render_player_renderShipModel(sip);
-	Cockpit_active = renderCockpitModel;
 
 	//Nothing to do
 	if (!(renderCockpitModel || renderShipModel)) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -306,7 +306,6 @@ typedef struct cockpit_display {
 
 extern bool Disable_cockpits;
 extern bool Disable_cockpit_sway;
-extern bool Cockpit_active;
 
 extern SCP_vector<cockpit_display> Player_displays;
 
@@ -1795,6 +1794,12 @@ extern void change_ship_type(int n, int ship_type, int by_sexp = 0);
 extern void ship_process_pre( object * objp, float frametime );
 extern void ship_process_post( object * objp, float frametime );
 extern void ship_render( object * obj, model_draw_list * scene );
+// whether this ship class shows a cockpit at all: it has a cockpit model and the player hasn't turned cockpits off
+extern bool ship_cockpit_enabled(const ship_info* sip);
+// whether the cockpit model is rendered for this ship class when it is the viewer
+extern bool ship_render_player_cockpit(const ship_info* sip);
+// whether the viewer's cockpit is being rendered this frame
+extern bool ship_render_player_cockpit_active();
 extern bool ship_render_player_ship_casts_shadow_on_cockpit();
 extern bool ship_render_player_has_closeup_visuals();
 extern void ship_render_player_ship( object * objp, const vec3d* offset = nullptr, const matrix* rot_offset = nullptr, const fov_t* fov_override = nullptr);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -938,7 +938,7 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int light_n )
 			}
 
 			if ( sip->flags[Ship::Info_Flags::Show_ship_model] 
-				&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active) ) {
+				&& (!Show_ship_only_if_cockpits_enabled || ship_cockpit_enabled(sip)) ) {
 				vm_vec_scale_add( &rp1, &rp0, &light_dir, Viewer_obj->radius*10.0f );
 
 				mc_info mc;
@@ -1084,7 +1084,7 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 	bool player_show_ship_model = (
 		objp == Player_obj 
 		&& Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model]
-		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active));
+		&& (!Show_ship_only_if_cockpits_enabled || ship_cockpit_enabled(&Ship_info[Ships[objp->instance].ship_info_index])));
 
 	auto* wip = &Weapon_info[weapon_info_index];
 	

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1641,7 +1641,7 @@ void beam_render_muzzle_glow(beam *b)
 		b->objp != nullptr // Can validly be nullptr for floating beams!
 		&& b->objp == Player_obj  
 		&& Ship_info[Ships[b->objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model] 
-		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active));
+		&& (!Show_ship_only_if_cockpits_enabled || ship_cockpit_enabled(&Ship_info[Ships[b->objp->instance].ship_info_index])));
 	if ((b->flags & BF_IS_FIGHTER_BEAM) && (b->objp == Player_obj && !Render_player_mflash && in_cockpit_view && !player_show_ship_model)) {
 		return;
 	}


### PR DESCRIPTION
Cockpit_active was latched inside ship_render_player_ship(), which only runs when Viewer_obj is non-null.  External, chase, warp-chase, topdown, free-camera and dead views all null Viewer_obj, so the flag froze at its last cockpit-view value and cockpitinactive HUD gauges vanished.  It was also read before being written each frame (by the show-ship check and the shadow helpers), so those decisions lagged a frame on any transition.

Replace it with three functions computed on demand:
- ship_cockpit_enabled(sip): the ship has a cockpit model and cockpits aren't disabled; used by the Show_ship_only_if_cockpits_enabled checks
- ship_render_player_cockpit(sip): the above, outside topdown view; replaces three duplicated copies of that expression
- ship_render_player_cockpit_active(): whether the viewer's cockpit is being rendered this frame; used by the HUD cockpit-view-choice checks

With the predicate correct, the VM_CHASE special cases added for #4804 are no longer needed and are removed.  In chase view, cockpitinactive gauges now also respect pop-up state, No_ets, and setRenderOverride, which the early return in HudGauge::canRender() used to bypass.