### PR TITLE
Reorder HID deinit

### DIFF
--- a/code/io/spacemouse.cpp
+++ b/code/io/spacemouse.cpp
@@ -165,10 +165,19 @@ std::unique_ptr<SpaceMouse> SpaceMouse::searchSpaceMice(int pollingFrequency) {
 	return mouse;
 }
 
+static std::unique_ptr<SpaceMouse> sharedMouse = nullptr;
 SpaceMouse* SpaceMouse::getSharedSpaceMouse(int pollingFrequency)
 {
-	static std::unique_ptr<SpaceMouse> sharedMouse = SpaceMouse::searchSpaceMice(pollingFrequency);
+	if (!sharedMouse) {
+		sharedMouse = searchSpaceMice(pollingFrequency);
+	}
+
 	return sharedMouse.get();
+}
+
+void SpaceMouse::shutdownSharedSpaceMouse()
+{
+	sharedMouse = nullptr;
 }
 
 #define HANDLE_NONLINEARITY(field, idx) field = copysignf(powf(field, std::get<0>(spacemouse_nonlinearity[idx])) * std::get<1>(spacemouse_nonlinearity[idx]), field)

--- a/code/io/spacemouse.h
+++ b/code/io/spacemouse.h
@@ -63,6 +63,14 @@ namespace io
 			@returns A pointer to the shared SpaceMouse instance, or nullptr if no supported device is present.
 			*/
 			static SpaceMouse* getSharedSpaceMouse(int pollingFrequency = 10);
+
+			/*
+			@brief Closes the shared SpaceMouse instance, if one was opened.
+
+			Must be called before HIDAPI is shut down, since the device handle may not outlive it.
+			Safe to call repeatedly and when no device was ever opened.
+			*/
+			static void shutdownSharedSpaceMouse();
 		};
 	}
 }

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -21,6 +21,7 @@
 
 #include "imgui.h"
 #include "backends/imgui_impl_sdl3.h"
+#include "io/spacemouse.h"
 
 #ifdef SCP_UNIX
 #include <sys/stat.h>
@@ -634,10 +635,12 @@ void os_deinit()
 	// Free the view ports
 	os::closeAllViewports();
 
-	SDL_Quit();
+	//If we have an open space mouse, close it
+	io::spacemouse::SpaceMouse::shutdownSharedSpaceMouse();
 
-	// Balance the SDL_hid_init() from os_init().
 	SDL_hid_exit();
+
+	SDL_Quit();
 }
 
 void debug_int3(const char *file, int line)


### PR DESCRIPTION
This must happen in the order `Close spacemouse -> Close HID -> Close SDL`, otherwise this will crash on exit.