### PR TITLE
ci: run the unit tests against SDL's dummy video driver

### DIFF
--- a/ci/linux/run_tests.sh
+++ b/ci/linux/run_tests.sh
@@ -5,6 +5,14 @@ HERE=$(dirname "$SCRIPT")
 
 export LD_LIBRARY_PATH=$(pwd)/bin/lib:$LD_LIBRARY_PATH
 
+# The unit tests never open a window, but a few of them reach code that brings SDL's video
+# subsystem up (os_init() and resolution_default(), the latter via gr_init()). Left to itself SDL
+# probes its real backends and dlopens libX11, which leaks a handful of blocks per init/quit cycle
+# that SDL_QuitSubSystem() does not reclaim -- those are the "definitely lost" contexts memcheck
+# fails the Debug legs on. Pinning the dummy driver skips the probing entirely, so the leaks never
+# happen, and it makes the tests behave the same way whether or not the runner has a display.
+export SDL_VIDEODRIVER=dummy
+
 # if on mac and building for architecture that doesn't match host
 # then unittests will fail so we just need to skip it (for now)
 if [ "$RUNNER_OS" = "macOS" ] && [ "$ARCH" != "$(uname -m)" ]; then

--- a/ci/linux/valgrind.supp
+++ b/ci/linux/valgrind.supp
@@ -120,6 +120,9 @@
    fun:_Z7os_initPKcS0_S0_
    fun:_ZN4test13FSTestFixture5SetUpEv
 }
+# Kept only as a backstop for running memcheck by hand. run_tests.sh pins SDL_VIDEODRIVER=dummy, so
+# the X11 backend is never created there; this block also cannot match the prebuilt libSDL3 anymore,
+# since that library is now stripped and X11_CreateDevice is a static symbol.
 {
    SDL3 X11 video backend internal allocations, not freed by SDL_VideoQuit
    Memcheck:Leak


### PR DESCRIPTION
The Linux Debug legs fail memcheck on six "definitely lost" contexts (480 bytes in 12 blocks), all allocated under the temporary SDL_InitSubSystem(SDL_INIT_VIDEO) in resolution_default(). SDL probes its real video backends, dlopens libX11, and keeps a few small blocks across the matching SDL_QuitSubSystem().

These are the same six contexts #7657 suppressed via fun:X11_CreateDevice. That suppression stopped matching when #7774 bumped the prebuilt libs: 62c89ef6 shipped libSDL3.so.0.2.14 with a full .symtab (433 distinct X11_* symbols), b57636e0 ships a stripped libSDL3.so.0.4.14 (none). X11_CreateDevice is a static function, so valgrind can no longer resolve it and every libSDL3 frame prints as ???. Every PR branch based on post-bump master fails this leg.

Rather than rewrite the suppression around object wildcards, stop allocating the memory in the first place. The unit tests never open a window and the runners are headless, so pin SDL_VIDEODRIVER=dummy: SDL skips backend probing entirely, libX11 is never loaded, and the leaks do not happen. It also makes the tests behave identically whether or not the runner has a display. No test depends on the real desktop mode; the only resolution test sets an explicit override.

The os_init suppression stays. That leak is from SDL_Init(SDL_INIT_EVENTS) and SDL_hid_init(), not from video, so the dummy driver does not affect it. The X11_CreateDevice block also stays, as a backstop for running memcheck by hand, now with a comment recording why it is inert in CI.